### PR TITLE
feat(cli): buttons update self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ brew install autonoco/tap/buttons
 
 ## Updating
 
-Buttons does not ship a `buttons update` command — each install channel has its own upgrade path:
+```bash
+buttons update           # download and install the latest version
+buttons update --check   # just check, don't install
+buttons update --json    # structured output
+```
+
+The update command downloads the latest release from GitHub, verifies the SHA256 checksum, and atomically replaces the running binary. If the binary was installed via Homebrew, it tells you to use `brew upgrade` instead.
+
+For containerized and CI environments where `buttons update` isn't practical:
 
 | Installed via | Update with |
 |---|---|

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -276,17 +276,18 @@ func atomicReplace(path string, newData []byte) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(newData); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
+	// #nosec G302 -- the replacement binary needs exec bit to run.
 	if err := tmp.Chmod(0755); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 
@@ -294,7 +295,7 @@ func atomicReplace(path string, newData []byte) error {
 	oldPath := path + ".old"
 	_ = os.Remove(oldPath) // clean up any leftover from a previous update
 	if err := os.Rename(path, oldPath); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("cannot move current binary: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,331 @@
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/spf13/cobra"
+)
+
+const (
+	releasesAPI = "https://api.github.com/repos/autonoco/buttons/releases/latest"
+	repoOwner   = "autonoco"
+	repoName    = "buttons"
+)
+
+var updateCheck bool
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update buttons to the latest version",
+	Long: `Check for and install the latest version of buttons from GitHub Releases.
+
+Downloads the correct archive for your OS and architecture, verifies
+the SHA256 checksum, and atomically replaces the running binary.
+
+Examples:
+  buttons update              # download and install the latest version
+  buttons update --check      # just check, don't install
+  buttons update --json       # structured output`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		current := normalizeVersion(version)
+
+		latest, err := fetchLatestRelease()
+		if err != nil {
+			if jsonOutput {
+				_ = config.WriteJSONError("INTERNAL_ERROR", fmt.Sprintf("failed to check for updates: %v", err))
+				return errSilent
+			}
+			return fmt.Errorf("failed to check for updates: %w", err)
+		}
+
+		latestVersion := normalizeVersion(latest.TagName)
+		upToDate := current == latestVersion
+
+		if upToDate {
+			if jsonOutput {
+				return config.WriteJSON(map[string]any{
+					"current":    current,
+					"latest":     latestVersion,
+					"up_to_date": true,
+				})
+			}
+			fmt.Fprintf(os.Stderr, "Already up to date (%s)\n", current)
+			return nil
+		}
+
+		if updateCheck {
+			if jsonOutput {
+				return config.WriteJSON(map[string]any{
+					"current":    current,
+					"latest":     latestVersion,
+					"up_to_date": false,
+				})
+			}
+			fmt.Fprintf(os.Stderr, "Update available: %s → %s\n", current, latestVersion)
+			fmt.Fprintf(os.Stderr, "Run 'buttons update' to install.\n")
+			return nil
+		}
+
+		// Resolve the path to the currently running binary.
+		execPath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("cannot determine executable path: %w", err)
+		}
+		execPath, err = filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return fmt.Errorf("cannot resolve executable path: %w", err)
+		}
+
+		if isHomebrewManaged(execPath) {
+			if jsonOutput {
+				_ = config.WriteJSONError("VALIDATION_ERROR", "this binary is managed by Homebrew — run 'brew upgrade buttons' instead")
+				return errSilent
+			}
+			return fmt.Errorf("this binary is managed by Homebrew — run 'brew upgrade buttons' instead")
+		}
+
+		// Find the right archive for this platform.
+		archiveName := archiveNameForPlatform(latestVersion)
+		archiveAsset := latest.findAsset(archiveName)
+		if archiveAsset == nil {
+			return fmt.Errorf("no release asset found for %s (looked for %s)", runtime.GOOS+"/"+runtime.GOARCH, archiveName)
+		}
+		checksumsAsset := latest.findAsset("checksums.txt")
+		if checksumsAsset == nil {
+			return fmt.Errorf("checksums.txt not found in release %s", latest.TagName)
+		}
+
+		fmt.Fprintf(os.Stderr, "Updating %s → %s\n", current, latestVersion)
+
+		// Download the archive.
+		fmt.Fprintf(os.Stderr, "  downloading %s\n", archiveName)
+		archiveData, err := downloadAsset(archiveAsset.URL)
+		if err != nil {
+			return fmt.Errorf("failed to download archive: %w", err)
+		}
+
+		// Download and verify checksum.
+		fmt.Fprintf(os.Stderr, "  verifying checksum\n")
+		checksumsData, err := downloadAsset(checksumsAsset.URL)
+		if err != nil {
+			return fmt.Errorf("failed to download checksums: %w", err)
+		}
+		if err := verifyChecksum(archiveData, archiveName, checksumsData); err != nil {
+			return fmt.Errorf("checksum verification failed: %w", err)
+		}
+
+		// Extract the binary from the tarball.
+		fmt.Fprintf(os.Stderr, "  extracting binary\n")
+		binaryData, err := extractBinaryFromTarGz(archiveData, "buttons")
+		if err != nil {
+			return fmt.Errorf("failed to extract binary: %w", err)
+		}
+
+		// Atomically swap the binary.
+		fmt.Fprintf(os.Stderr, "  replacing %s\n", execPath)
+		if err := atomicReplace(execPath, binaryData); err != nil {
+			return fmt.Errorf("failed to replace binary: %w", err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{
+				"current":    current,
+				"latest":     latestVersion,
+				"up_to_date": true,
+				"updated":    true,
+				"path":       execPath,
+			})
+		}
+		fmt.Fprintf(os.Stderr, "Updated to %s\n", latestVersion)
+		return nil
+	},
+}
+
+// ghRelease is a minimal representation of a GitHub API release.
+type ghRelease struct {
+	TagName string    `json:"tag_name"`
+	Assets  []ghAsset `json:"assets"`
+}
+
+type ghAsset struct {
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+func (r *ghRelease) findAsset(name string) *ghAsset {
+	for i := range r.Assets {
+		if r.Assets[i].Name == name {
+			return &r.Assets[i]
+		}
+	}
+	return nil
+}
+
+func fetchLatestRelease() (*ghRelease, error) {
+	req, err := http.NewRequest("GET", releasesAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var release ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release: %w", err)
+	}
+	return &release, nil
+}
+
+func downloadAsset(url string) ([]byte, error) {
+	resp, err := http.Get(url) // #nosec G107 -- URL comes from GitHub API response, not user input
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("download returned %d", resp.StatusCode)
+	}
+
+	// Cap at 50 MB to prevent abuse.
+	return io.ReadAll(io.LimitReader(resp.Body, 50<<20))
+}
+
+func verifyChecksum(data []byte, name string, checksums []byte) error {
+	// Parse checksums.txt: each line is "<hash>  <filename>"
+	lines := strings.Split(string(checksums), "\n")
+	var expected string
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == name {
+			expected = parts[0]
+			break
+		}
+	}
+	if expected == "" {
+		return fmt.Errorf("no checksum entry for %s", name)
+	}
+
+	h := sha256.Sum256(data)
+	actual := hex.EncodeToString(h[:])
+	if actual != expected {
+		return fmt.Errorf("expected %s, got %s", expected, actual)
+	}
+	return nil
+}
+
+func extractBinaryFromTarGz(data []byte, binaryName string) ([]byte, error) {
+	gz, err := gzip.NewReader(strings.NewReader(string(data)))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("binary %q not found in archive", binaryName)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(hdr.Name) == binaryName && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(tr)
+		}
+	}
+}
+
+// atomicReplace writes newData to the path of the current binary
+// using a temp-file + rename pattern. On most filesystems rename
+// is atomic, so there's no window where the binary is missing.
+func atomicReplace(path string, newData []byte) error {
+	dir := filepath.Dir(path)
+
+	// Write to a temp file in the same directory (same filesystem
+	// required for atomic rename).
+	tmp, err := os.CreateTemp(dir, ".buttons-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp file in %s (is the directory writable?): %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(newData); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(0755); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	// Rename current → .old, temp → current, remove .old.
+	oldPath := path + ".old"
+	_ = os.Remove(oldPath) // clean up any leftover from a previous update
+	if err := os.Rename(path, oldPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("cannot move current binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		// Try to restore the old binary.
+		_ = os.Rename(oldPath, path)
+		return fmt.Errorf("cannot install new binary: %w", err)
+	}
+	_ = os.Remove(oldPath)
+	return nil
+}
+
+func archiveNameForPlatform(version string) string {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		arch = "x86_64"
+	}
+	return fmt.Sprintf("buttons_%s_%s_%s.tar.gz", version, os, arch)
+}
+
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSuffix(v, "-dirty"), "v")
+}
+
+func isHomebrewManaged(path string) bool {
+	return strings.Contains(path, "/Cellar/") ||
+		strings.Contains(path, "/opt/homebrew/") ||
+		strings.Contains(path, "/usr/local/Cellar/")
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&updateCheck, "check", false, "check for updates without installing")
+	rootCmd.AddCommand(updateCmd)
+}

--- a/internal/button/name.go
+++ b/internal/button/name.go
@@ -25,7 +25,7 @@ var reservedNames = map[string]bool{
 	"create": true, "press": true, "list": true, "rm": true,
 	"board": true, "drawer": true, "batteries": true, "smash": true,
 	"store": true, "history": true, "help": true, "version": true,
-	"mcp": true, "serve": true,
+	"mcp": true, "serve": true, "update": true, "delete": true,
 }
 
 func IsReservedName(name string) bool {

--- a/internal/tools/docgen/main.go
+++ b/internal/tools/docgen/main.go
@@ -31,6 +31,7 @@ func main() {
 	front := flag.Bool("frontmatter", true, "prepend Mintlify-compatible YAML front matter to markdown")
 	flag.Parse()
 
+	// #nosec G301 -- docs output directory needs to be world-readable for Mintlify and CI.
 	if err := os.MkdirAll(*out, 0o755); err != nil {
 		log.Fatal(err)
 	}
@@ -121,6 +122,8 @@ func postProcessMDX(dir string) error {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
+		// #nosec G304 -- path is constructed from the output directory we own
+		// + a DirEntry name from os.ReadDir, not user input.
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
@@ -130,6 +133,7 @@ func postProcessMDX(dir string) error {
 		content = fenceExamples(content)
 		content = escapeAngleBrackets(content)
 
+		// #nosec G306 -- generated docs must be world-readable.
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			return err
 		}

--- a/internal/tools/skillgen/main.go
+++ b/internal/tools/skillgen/main.go
@@ -35,6 +35,7 @@ func main() {
 	var b strings.Builder
 	writeSkill(&b, root)
 
+	// #nosec G306 -- generated skill file must be world-readable.
 	if err := os.WriteFile(*out, []byte(b.String()), 0o644); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Adds `buttons update` — downloads the latest release from GitHub Releases, verifies the SHA256 checksum, and atomically replaces the running binary. Zero external dependencies.

```bash
buttons update              # download and install latest
buttons update --check      # just check, don't install
buttons update --check --json
```

### How it works

1. Queries `https://api.github.com/repos/autonoco/buttons/releases/latest`
2. Compares the running version against the latest tag
3. If `--check`, reports and exits
4. Otherwise: finds the correct archive for OS/arch, downloads it + checksums.txt
5. Verifies SHA256
6. Extracts the `buttons` binary from the tarball
7. Atomically swaps: temp file → rename current to .old → rename temp to current → delete .old
8. If the rename fails mid-swap, restores the old binary

### Safety

- **Homebrew detection** — if the binary lives under `/opt/homebrew/` or `/Cellar/`, refuses and says `brew upgrade buttons`
- **Checksum verification** — SHA256 must match the release's checksums.txt
- **Atomic swap** — temp file + rename in the same directory, rollback on failure
- **Download cap** — 50 MB limit prevents abuse
- **No auth required** — the repo is public, anonymous GH API works. Respects `GITHUB_TOKEN` if set (for rate limits).

### Also in this PR

- `"update"` and `"delete"` added to reserved button names in `internal/button/name.go`
- README "Updating" section rewritten to show `buttons update` as the primary path

## Smoke test

```
$ go run . update --check
{
  "ok": true,
  "data": {
    "current": "dev",
    "latest": "0.1.0",
    "up_to_date": false
  }
}
```

Correctly identifies the dev build as behind v0.1.0.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./...` — all tests pass
- [x] `buttons update --check` returns correct current/latest comparison
- [x] `buttons update --check --json` returns structured output
- [ ] Full update flow against v0.1.0 release (requires a make-built binary, not `go run`)
- [ ] Homebrew path detection (manual check on a Homebrew-installed binary)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)