### PR TITLE
fix: AgentSkills spec frontmatter + commit all agent skills

### DIFF
--- a/.agents/skills/bubble-tea/SKILL.md
+++ b/.agents/skills/bubble-tea/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: bubble-tea
+description: >
+    Build terminal UIs in Go with Bubble Tea v2 (Elm Architecture). Covers Model/Update/View lifecycle,
+    commands (Batch, Sequence, Tick), key/mouse handling, Program options, and Charm ecosystem (Bubbles, Lip Gloss, Huh).
+
+    Use when: building Go TUI apps, creating terminal interfaces, handling keyboard/mouse input in TUI,
+    using Bubble Tea or Charm libraries, or troubleshooting "tea.Model" or "tea.Cmd" issues.
+---
+
+Apply these patterns when building terminal UIs with Bubble Tea v2. For full API reference, see [references/](references/).
+
+**Important**: This covers Bubble Tea **v2** (`github.com/charmbracelet/bubbletea/v2`). Key v2 changes from v1:
+- `View()` returns `tea.View` (not `string`) — use `tea.NewView(s)`
+- Key events are `tea.KeyPressMsg` (not `tea.KeyMsg`)
+- `tea.Quit` is now `tea.Quit()` (function call, returns `Msg`)
+- `Init()` returns `tea.Cmd` (not `(tea.Model, tea.Cmd)` in basic form)
+
+## Core Architecture (Elm Architecture)
+
+Every Bubble Tea program has three parts:
+
+```go
+type Model interface {
+    Init() tea.Cmd             // initial command (or nil)
+    Update(tea.Msg) (tea.Model, tea.Cmd)  // handle events, return new state + command
+    View() tea.View            // render UI from state
+}
+```
+
+1. **Init** — runs once at startup, returns an initial command (or `nil`)
+2. **Update** — receives messages (events), returns updated model + next command
+3. **View** — pure function: model in, string out (wrapped in `tea.NewView`)
+
+## Minimal Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    tea "github.com/charmbracelet/bubbletea/v2"
+)
+
+type model struct {
+    cursor   int
+    choices  []string
+    selected map[int]struct{}
+}
+
+func initialModel() model {
+    return model{
+        choices:  []string{"Buy carrots", "Buy celery", "Buy kohlrabi"},
+        selected: make(map[int]struct{}),
+    }
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        switch msg.String() {
+        case "ctrl+c", "q":
+            return m, tea.Quit
+        case "up", "k":
+            if m.cursor > 0 { m.cursor-- }
+        case "down", "j":
+            if m.cursor < len(m.choices)-1 { m.cursor++ }
+        case "enter", " ":
+            if _, ok := m.selected[m.cursor]; ok {
+                delete(m.selected, m.cursor)
+            } else {
+                m.selected[m.cursor] = struct{}{}
+            }
+        }
+    }
+    return m, nil
+}
+
+func (m model) View() tea.View {
+    s := "What should we buy?\n\n"
+    for i, choice := range m.choices {
+        cursor, checked := " ", " "
+        if m.cursor == i { cursor = ">" }
+        if _, ok := m.selected[i]; ok { checked = "x" }
+        s += fmt.Sprintf("%s [%s] %s\n", cursor, checked, choice)
+    }
+    s += "\nPress q to quit.\n"
+    return tea.NewView(s)
+}
+
+func main() {
+    if _, err := tea.NewProgram(initialModel()).Run(); err != nil {
+        fmt.Fprintf(os.Stderr, "error: %v\n", err)
+        os.Exit(1)
+    }
+}
+```
+
+## Commands (Cmd)
+
+Commands perform I/O and return messages. **Never do I/O in Update or View** — return a `Cmd` instead.
+
+```go
+// nil = no command
+return m, nil
+
+// Single command
+return m, fetchData
+
+// Run commands concurrently (no ordering guarantee)
+return m, tea.Batch(cmd1, cmd2, cmd3)
+
+// Run commands sequentially (one at a time, in order)
+return m, tea.Sequence(cmd1, cmd2, cmd3)
+```
+
+### Custom Command Pattern
+
+```go
+type DataMsg struct{ Items []Item }
+type ErrMsg struct{ Err error }
+
+func fetchData() tea.Msg {
+    items, err := api.GetItems()
+    if err != nil {
+        return ErrMsg{err}
+    }
+    return DataMsg{items}
+}
+
+// In Update:
+case tea.KeyPressMsg:
+    if msg.String() == "r" {
+        return m, fetchData  // pass function as Cmd
+    }
+case DataMsg:
+    m.items = msg.Items
+case ErrMsg:
+    m.err = msg.Err
+```
+
+### Tick / Timer
+
+```go
+type TickMsg time.Time
+
+func doTick() tea.Cmd {
+    return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+        return TickMsg(t)
+    })
+}
+
+func (m model) Init() tea.Cmd { return doTick() }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg.(type) {
+    case TickMsg:
+        m.elapsed++
+        return m, doTick()  // loop: return another tick
+    }
+    return m, nil
+}
+```
+
+`tea.Every` is similar but syncs to system clock (fires at exact intervals).
+
+### Conditional Batching
+
+```go
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmds []tea.Cmd
+    if m.needsRefresh {
+        cmds = append(cmds, refreshCmd)
+    }
+    cmds = append(cmds, saveCmd)
+    return m, tea.Batch(cmds...)
+}
+```
+
+## Key Handling (v2)
+
+```go
+case tea.KeyPressMsg:
+    // By string representation
+    switch msg.String() {
+    case "q", "ctrl+c":
+        return m, tea.Quit
+    case "enter":
+        // handle enter
+    case "up", "k":
+        // handle up
+    }
+
+    // By key code
+    switch msg.Key().Code {
+    case tea.KeyEnter:
+    case tea.KeyTab:
+    case tea.KeyEscape:
+    }
+
+    // By keystroke (includes modifiers)
+    switch msg.Keystroke() {
+    case "ctrl+c":
+    case "shift+alt+a":
+    }
+
+    // Printable characters
+    if msg.Key().Text != "" {
+        m.input += msg.Key().Text
+    }
+```
+
+### Common Key Constants
+
+```go
+tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight
+tea.KeyEnter, tea.KeyReturn, tea.KeyTab, tea.KeyEscape
+tea.KeyBackspace, tea.KeyDelete, tea.KeySpace
+tea.KeyHome, tea.KeyEnd, tea.KeyPgUp, tea.KeyPgDown
+tea.KeyF1 ... tea.KeyF63
+```
+
+### Modifier Keys
+
+```go
+tea.ModCtrl, tea.ModAlt, tea.ModShift
+tea.ModMeta, tea.ModHyper, tea.ModSuper
+```
+
+## Mouse Handling
+
+```go
+case tea.MouseClickMsg:
+    x, y := msg.Mouse().X, msg.Mouse().Y
+    button := msg.Mouse().Button  // tea.MouseLeft, tea.MouseRight, etc.
+
+case tea.MouseWheelMsg:
+    // scroll events
+
+case tea.MouseMotionMsg:
+    // hover/drag events
+```
+
+Mouse buttons: `MouseLeft`, `MouseMiddle`, `MouseRight`, `MouseWheelUp`, `MouseWheelDown`, `MouseBackward`, `MouseForward`.
+
+## Window Size
+
+```go
+case tea.WindowSizeMsg:
+    m.width = msg.Width
+    m.height = msg.Height
+```
+
+Request explicitly: `tea.RequestWindowSize()`
+
+## Built-in Messages
+
+```go
+tea.Quit()                    // quit the program
+tea.ClearScreen()             // clear terminal
+tea.Suspend()                 // suspend (like Ctrl+Z)
+tea.SetClipboard("text")      // set clipboard
+tea.ReadClipboard()           // read clipboard
+tea.RequestWindowSize()       // request window dimensions
+tea.RequestCursorPosition()   // request cursor position
+```
+
+## Program Setup
+
+```go
+p := tea.NewProgram(
+    initialModel(),
+    // Options:
+    tea.WithOutput(os.Stderr),          // custom output writer
+    tea.WithInput(customReader),        // custom input reader
+    tea.WithFPS(60),                    // framerate (default: 60)
+    tea.WithContext(ctx),               // context for cancellation
+    tea.WithWindowSize(80, 24),         // initial window size
+    tea.WithoutSignalHandler(),         // disable signal handling
+    tea.WithoutCatchPanics(),           // let panics propagate
+    tea.WithFilter(filterFunc),         // message filter
+)
+
+model, err := p.Run()  // blocking
+```
+
+### Sending Messages from Outside
+
+```go
+p := tea.NewProgram(m)
+go func() {
+    p.Send(MyCustomMsg{data: "hello"})
+}()
+p.Run()
+```
+
+### Printing Outside the TUI
+
+```go
+// From within Update (as Cmd):
+return m, tea.Println("Status: done")
+return m, tea.Printf("Processed %d items", count)
+
+// From outside:
+p.Println("External message")
+```
+
+## Focus and Blur
+
+```go
+case tea.FocusMsg:
+    m.focused = true
+case tea.BlurMsg:
+    m.focused = false
+```
+
+## Debugging
+
+```go
+// Log to file (since TUI owns stdout)
+if os.Getenv("DEBUG") != "" {
+    f, err := tea.LogToFile("debug.log", "debug")
+    if err != nil {
+        fmt.Println("fatal:", err)
+        os.Exit(1)
+    }
+    defer f.Close()
+}
+// Then use log.Println() throughout your code
+// Monitor: tail -f debug.log
+```
+
+## Charm Ecosystem
+
+| Library | Purpose | Import |
+|---------|---------|--------|
+| **Bubbles** | Reusable components (text input, viewport, spinner, list, table, paginator, progress bar) | `github.com/charmbracelet/bubbles` |
+| **Lip Gloss** | Styling and layout (colors, borders, padding, alignment) | `github.com/charmbracelet/lipgloss` |
+| **Huh** | Interactive forms and prompts | `github.com/charmbracelet/huh` |
+| **Harmonica** | Spring animations | `github.com/charmbracelet/harmonica` |
+| **BubbleZone** | Mouse event zone tracking | `github.com/lrstanley/bubblezone` |
+
+### Bubbles Components Pattern
+
+```go
+import "github.com/charmbracelet/bubbles/textinput"
+
+type model struct {
+    textInput textinput.Model
+}
+
+func initialModel() model {
+    ti := textinput.New()
+    ti.Placeholder = "Search..."
+    ti.Focus()
+    return model{textInput: ti}
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmd tea.Cmd
+    m.textInput, cmd = m.textInput.Update(msg)  // delegate to component
+    return m, cmd
+}
+
+func (m model) View() tea.View {
+    return tea.NewView(m.textInput.View())
+}
+```
+
+## Common Patterns
+
+### Multiple Components
+
+```go
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmds []tea.Cmd
+
+    // Update each component, collect commands
+    var cmd tea.Cmd
+    m.input, cmd = m.input.Update(msg)
+    cmds = append(cmds, cmd)
+
+    m.list, cmd = m.list.Update(msg)
+    cmds = append(cmds, cmd)
+
+    return m, tea.Batch(cmds...)
+}
+```
+
+### State Machine (Screens/Views)
+
+```go
+type state int
+const (
+    stateMenu state = iota
+    stateInput
+    stateConfirm
+)
+
+type model struct {
+    state state
+    // ...
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch m.state {
+    case stateMenu:
+        return m.updateMenu(msg)
+    case stateInput:
+        return m.updateInput(msg)
+    case stateConfirm:
+        return m.updateConfirm(msg)
+    }
+    return m, nil
+}
+
+func (m model) View() tea.View {
+    switch m.state {
+    case stateMenu:
+        return tea.NewView(m.menuView())
+    case stateInput:
+        return tea.NewView(m.inputView())
+    case stateConfirm:
+        return tea.NewView(m.confirmView())
+    }
+    return tea.NewView("")
+}
+```
+
+### Running External Processes
+
+```go
+cmd := exec.Command("vim", "file.txt")
+return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+    return editorFinishedMsg{err}
+})
+```
+
+This pauses the TUI, runs the process with full terminal access, then resumes.
+
+## Common Mistakes
+
+- **Doing I/O in Update**: Never. Return a `Cmd` instead.
+- **Forgetting to return a Cmd from Init**: Return `nil` if no initial I/O needed.
+- **Not delegating Update to sub-components**: Bubbles components need their `Update` called.
+- **Using `string` return from View (v1 style)**: v2 requires `tea.View` — use `tea.NewView(s)`.
+- **Using `tea.KeyMsg` (v1)**: v2 uses `tea.KeyPressMsg` and `tea.KeyReleaseMsg`.
+- **Using `tea.Quit` as a value (v1)**: v2 requires `tea.Quit()` (function call).
+- **Printing to stdout**: TUI owns stdout. Use `tea.LogToFile` for debugging.
+- **Not collecting Cmds from sub-components**: Use `tea.Batch(cmds...)` to combine.

--- a/.agents/skills/bubble-tea/references/full-guide.md
+++ b/.agents/skills/bubble-tea/references/full-guide.md
@@ -1,0 +1,490 @@
+# Bubble Tea v2 — Full API Reference
+
+Source: [pkg.go.dev/github.com/charmbracelet/bubbletea/v2](https://pkg.go.dev/github.com/charmbracelet/bubbletea/v2)
+
+Package `tea` — A Go framework for building rich terminal user interfaces based on The Elm Architecture.
+
+**Version**: v2 (beta, production-ready)
+**License**: MIT
+**Import**: `tea "github.com/charmbracelet/bubbletea/v2"`
+
+---
+
+## Core Interface: Model
+
+```go
+type Model interface {
+    Init() Cmd
+    Update(Msg) (Model, Cmd)
+    View() View
+}
+```
+
+### The Elm Architecture Lifecycle
+
+1. **Init()** — Perform initial setup, return optional initial command
+2. **Update(Msg)** — React to messages, update state, return new model + command
+3. **View()** — Render current state as UI (pure function, no side effects)
+
+---
+
+## Type: Program
+
+```go
+type Program struct { }
+
+func NewProgram(model Model, opts ...ProgramOption) *Program
+
+func (p *Program) Run() (returnModel Model, returnErr error)
+func (p *Program) Send(msg Msg)
+func (p *Program) Quit()
+func (p *Program) Kill()
+func (p *Program) Wait()
+
+func (p *Program) Printf(template string, args ...any)
+func (p *Program) Println(args ...any)
+
+func (p *Program) ReleaseTerminal() error
+func (p *Program) RestoreTerminal() error
+```
+
+### Program Options
+
+```go
+// Window and rendering
+WithWindowSize(width, height int) ProgramOption
+WithOutput(output io.Writer) ProgramOption
+WithInput(input io.Reader) ProgramOption
+WithFPS(fps int) ProgramOption
+
+// Color and environment
+WithColorProfile(profile colorprofile.Profile) ProgramOption
+WithEnvironment(env []string) ProgramOption
+
+// Behavior
+WithContext(ctx context.Context) ProgramOption
+WithFilter(filter func(Model, Msg) Msg) ProgramOption
+
+// Signal handling
+WithoutSignalHandler() ProgramOption
+WithoutSignals() ProgramOption
+WithoutCatchPanics() ProgramOption
+
+// Rendering control
+WithoutRenderer() ProgramOption
+```
+
+---
+
+## Type: Cmd
+
+Commands perform I/O and return messages.
+
+```go
+type Cmd func() Msg
+
+func Batch(cmds ...Cmd) Cmd         // run concurrently, no ordering
+func Sequence(cmds ...Cmd) Cmd      // run one at a time, in order
+func Tick(d time.Duration, fn func(time.Time) Msg) Cmd  // timer
+func Every(duration time.Duration, fn func(time.Time) Msg) Cmd  // system clock sync
+func ExecProcess(c *exec.Cmd, fn ExecCallback) Cmd  // run external process
+func Exec(c ExecCommand, fn ExecCallback) Cmd
+
+// Print outside the managed UI
+func Println(args ...any) Cmd
+func Printf(template string, args ...any) Cmd
+
+// Clipboard
+func SetClipboard(s string) Cmd
+func SetPrimaryClipboard(s string) Cmd
+
+// Terminal capabilities
+func RequestCapability(s string) Cmd
+func Raw(r any) Cmd
+```
+
+---
+
+## Type: Msg
+
+Messages represent events. All built-in messages:
+
+```go
+type Msg interface{}
+
+// Quit/control
+func Quit() Msg
+func Interrupt() Msg
+func ClearScreen() Msg
+func Suspend() Msg
+
+// Terminal state requests
+func RequestWindowSize() Msg
+func RequestCursorPosition() Msg
+func RequestTerminalVersion() Msg
+func RequestForegroundColor() Msg
+func RequestBackgroundColor() Msg
+func RequestCursorColor() Msg
+
+// Clipboard
+func ReadClipboard() Msg
+func ReadPrimaryClipboard() Msg
+```
+
+### Built-in Message Types
+
+```go
+// Keyboard
+type KeyPressMsg Key       // Key press event (v2 — replaces KeyMsg from v1)
+type KeyReleaseMsg Key     // Key release event
+
+// Window
+type WindowSizeMsg struct { Width, Height int }
+
+// Mouse
+type MouseClickMsg struct { }
+type MouseMotionMsg struct { }
+type MouseReleaseMsg struct { }
+type MouseWheelMsg struct { }
+
+// Focus
+type FocusMsg struct{}
+type BlurMsg struct{}
+
+// Paste
+type PasteStartMsg struct{}
+type PasteMsg string
+type PasteEndMsg struct{}
+
+// Lifecycle
+type InterruptMsg struct{}
+type SuspendMsg struct{}
+type ResumeMsg struct{}
+type QuitMsg struct{}
+
+// Terminal info
+type ColorProfileMsg struct { colorprofile.Profile }
+type BackgroundColorMsg struct { color.Color }
+type ForegroundColorMsg struct { color.Color }
+type CursorColorMsg struct { color.Color }
+type CursorPositionMsg Position
+type TerminalVersionMsg string
+type CapabilityMsg string
+type KeyboardEnhancementsMsg uint8
+
+// Environment
+type EnvMsg uv.Environ
+func (msg EnvMsg) Getenv(key string) string
+func (msg EnvMsg) LookupEnv(key string) (string, bool)
+
+// Clipboard
+type ClipboardMsg struct {
+    Content   string
+    Selection byte  // 'c' = system, 'p' = primary
+}
+
+// Internal
+type BatchMsg []Cmd
+type RawMsg any
+```
+
+---
+
+## Type: Key
+
+```go
+type Key struct {
+    Text        string      // Printable characters
+    Code        rune        // The key code
+    ShiftedCode rune        // Shifted version (Kitty/Windows)
+    BaseCode    rune        // PC-101 layout code (Kitty/Windows)
+    Mod         KeyMod      // Modifier keys
+    IsRepeat    bool        // Key being held down
+}
+
+func (k Key) String() string      // Text representation
+func (k Key) Keystroke() string   // Full keystroke like "ctrl+a"
+
+type KeyMsg interface {
+    Key() Key
+    fmt.Stringer
+}
+
+type KeyPressMsg Key
+type KeyReleaseMsg Key
+```
+
+### Special Key Constants
+
+```go
+// Arrow keys
+KeyUp, KeyDown, KeyLeft, KeyRight
+
+// Navigation
+KeyHome, KeyEnd, KeyPgUp, KeyPgDown
+KeyInsert, KeyDelete
+
+// Function keys
+KeyF1 ... KeyF63
+
+// Special
+KeyEnter, KeyReturn, KeyTab
+KeyEscape, KeyEsc
+KeyBackspace, KeySpace
+
+// Modifiers
+ModCtrl, ModAlt, ModShift
+ModMeta, ModHyper, ModSuper
+ModCapsLock, ModNumLock, ModScrollLock
+```
+
+### Key Matching Patterns
+
+```go
+// By string
+switch msg.String() {
+case "enter": ...
+case "a": ...
+case "ctrl+c": ...
+}
+
+// By key code
+switch msg.Key().Code {
+case KeyEnter: ...
+case KeyTab: ...
+}
+
+// By keystroke (with modifiers)
+switch msg.Keystroke() {
+case "ctrl+c": ...
+case "shift+alt+a": ...
+}
+
+// Printable characters
+if msg.Key().Text != "" {
+    // handle typed text
+}
+```
+
+---
+
+## Type: Mouse
+
+```go
+type Mouse struct {
+    X, Y   int
+    Button MouseButton
+    Mod    KeyMod
+}
+
+const (
+    MouseNone MouseButton = iota
+    MouseLeft
+    MouseMiddle
+    MouseRight
+    MouseWheelUp
+    MouseWheelDown
+    MouseWheelLeft
+    MouseWheelRight
+    MouseBackward
+    MouseForward
+    MouseButton10
+    MouseButton11
+)
+```
+
+---
+
+## Type: View and Rendering
+
+```go
+type View struct{}
+func NewView(s any) View
+func (v *View) SetContent(s any)
+
+type Layer interface {
+    Draw(s Screen, r Rectangle)
+}
+
+type Cursor struct {
+    Position Position
+    Color    color.Color
+    Shape    CursorShape
+    Blink    bool
+}
+
+func NewCursor(x, y int) *Cursor
+
+type CursorShape int
+const (
+    CursorBlock CursorShape = iota
+    CursorUnderline
+    CursorBar
+)
+
+type Position struct { X, Y int }
+
+type Hittable interface {
+    Hit(x, y int) string
+}
+
+type LayerHitMsg struct {
+    ID    string
+    Mouse MouseMsg
+}
+```
+
+---
+
+## Logging
+
+```go
+func LogToFile(path string, prefix string) (*os.File, error)
+func LogToFileWith(path string, prefix string, log LogOptionsSetter) (*os.File, error)
+
+type LogOptionsSetter interface {
+    SetOutput(io.Writer)
+    SetPrefix(string)
+}
+```
+
+Usage:
+```go
+if os.Getenv("DEBUG") != "" {
+    f, err := tea.LogToFile("debug.log", "debug")
+    if err != nil {
+        fmt.Println("fatal:", err)
+        os.Exit(1)
+    }
+    defer f.Close()
+}
+// Then use log.Println() throughout
+// Monitor: tail -f debug.log
+```
+
+---
+
+## Error Variables
+
+```go
+var ErrProgramPanic = errors.New("program experienced a panic")
+var ErrProgramKilled = errors.New("program was killed")
+var ErrInterrupted = errors.New("program was interrupted")
+```
+
+---
+
+## TTY Operations
+
+```go
+func OpenTTY() (*os.File, *os.File, error)
+```
+
+---
+
+## Complete Example: Shopping List
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    tea "github.com/charmbracelet/bubbletea/v2"
+)
+
+type model struct {
+    choices  []string
+    cursor   int
+    selected map[int]struct{}
+}
+
+func initialModel() model {
+    return model{
+        choices:  []string{"Buy carrots", "Buy celery", "Buy kohlrabi"},
+        selected: make(map[int]struct{}),
+    }
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        switch msg.String() {
+        case "ctrl+c", "q":
+            return m, tea.Quit
+        case "up", "k":
+            if m.cursor > 0 { m.cursor-- }
+        case "down", "j":
+            if m.cursor < len(m.choices)-1 { m.cursor++ }
+        case "enter", " ":
+            if _, ok := m.selected[m.cursor]; ok {
+                delete(m.selected, m.cursor)
+            } else {
+                m.selected[m.cursor] = struct{}{}
+            }
+        }
+    }
+    return m, nil
+}
+
+func (m model) View() tea.View {
+    s := "What should we buy at the market?\n\n"
+    for i, choice := range m.choices {
+        cursor, checked := " ", " "
+        if m.cursor == i { cursor = ">" }
+        if _, ok := m.selected[i]; ok { checked = "x" }
+        s += fmt.Sprintf("%s [%s] %s\n", cursor, checked, choice)
+    }
+    s += "\nPress q to quit.\n"
+    return tea.NewView(s)
+}
+
+func main() {
+    if _, err := tea.NewProgram(initialModel()).Run(); err != nil {
+        fmt.Fprintf(os.Stderr, "error: %v\n", err)
+        os.Exit(1)
+    }
+}
+```
+
+---
+
+## v2 Breaking Changes from v1
+
+| v1 | v2 |
+|----|-----|
+| `View() string` | `View() tea.View` (use `tea.NewView(s)`) |
+| `tea.KeyMsg` | `tea.KeyPressMsg` / `tea.KeyReleaseMsg` |
+| `tea.Quit` (value) | `tea.Quit()` (function call) |
+| `tea.WithAltScreen()` | Removed — alt screen is now default |
+| `tea.WithMouseCellMotion()` | Mouse enabled by default |
+
+---
+
+## Charm Ecosystem
+
+| Library | Purpose | Import |
+|---------|---------|--------|
+| **Bubbles** | Reusable components (text input, viewport, spinner, list, table, paginator, progress) | `github.com/charmbracelet/bubbles` |
+| **Lip Gloss** | Styling (colors, borders, padding, alignment, layout) | `github.com/charmbracelet/lipgloss` |
+| **Huh** | Interactive forms and prompts | `github.com/charmbracelet/huh` |
+| **Harmonica** | Spring animations | `github.com/charmbracelet/harmonica` |
+| **BubbleZone** | Mouse event zone tracking | `github.com/lrstanley/bubblezone` |
+
+---
+
+## Notable Users
+
+- **Microsoft** (Aztify), **CockroachDB**, **Truffle Security** (Trufflehog), **NVIDIA** (container-canary), **AWS** (eks-node-viewer), **MinIO** (mc), **Ubuntu** (Authd)
+- **Charm projects**: Glow (markdown), Huh (forms), Mods (AI CLI), Wishlist (SSH)
+- **Community**: chezmoi, circumflex, gh-dash, Tetrigo, Superfile
+
+---
+
+## Debugging Tips
+
+1. **Don't print to stdout** — TUI owns it. Use `tea.LogToFile("debug.log", "debug")`.
+2. **Headless Delve**: `dlv debug --headless --api-version=2 --listen=127.0.0.1:43000 .` then `dlv connect` from another terminal.
+3. **Monitor logs**: `tail -f debug.log` in a separate terminal.

--- a/.agents/skills/buttons/SKILL.md
+++ b/.agents/skills/buttons/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: buttons
+description: |
+  Deterministic workflow engine for AI agents. Create and press
+  reusable buttons (shell scripts, HTTP APIs, agent instructions)
+  with typed inputs and structured JSON output. Use when wrapping
+  repeatable actions, calling HTTP endpoints, or building multi-step
+  workflows where each step is a named, typed, pressable button.
+license: Apache-2.0
+compatibility: Requires the buttons CLI binary installed (go install github.com/autonoco/buttons@latest or curl installer).
+metadata:
+  author: autonoco
+  repository: https://github.com/autonoco/buttons
+---
+
 # Buttons CLI
 
 Deterministic workflow engine for AI agents. Create reusable, composable actions with typed inputs and structured JSON output.

--- a/.agents/skills/cli-design-guidelines/SKILL.md
+++ b/.agents/skills/cli-design-guidelines/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: cli-design-guidelines
+description: >
+    Design human-first CLI tools following clig.dev best practices. Covers help text, output formatting,
+    error handling, flags/args, subcommands, interactivity, configuration, signals, naming, and distribution.
+
+    Use when: building CLI tools, designing command interfaces, adding flags or subcommands,
+    writing help text, formatting CLI output, handling CLI errors, or reviewing CLI UX.
+---
+
+Apply these rules when building or reviewing CLI tools. For full rationale and examples, see [full-guide.md](references/full-guide.md).
+
+## Core Philosophy
+
+- **Human-first**: Design for humans by default, machines via flags (`--json`, `--plain`).
+- **Composable**: stdout for data, stderr for messaging. Support pipes. Use exit codes correctly.
+- **Consistent**: Follow established conventions. Users guess based on other CLIs.
+- **Discoverable**: Suggest next commands, show examples in help, guide on errors.
+- **Empathetic**: Keep users informed, explain errors helpfully, confirm dangerous actions.
+
+---
+
+## Help Text
+
+- Show concise help when run with no args: description, 1-2 examples, common flags, pointer to `--help`.
+- Show full help on `-h` and `--help`. Both must work. Don't overload `-h`.
+- For subcommand CLIs, also support `myapp help <subcmd>` and `myapp <subcmd> --help`.
+- Lead with examples. Build a narrative from simple to complex.
+- Show the most common flags and commands first, group by purpose.
+- Use formatting (bold headings, whitespace) for scannability.
+- Link to web docs from help text. Provide a support/issues URL.
+- If the user made a typo, suggest the correct command. Ask for confirmation before executing it.
+- If expecting piped stdin but running in a TTY, show help and quit (don't hang).
+
+## Output
+
+- **stdout** = program output (data). **stderr** = messages, logs, errors.
+- Detect TTY: human-friendly output for terminals, machine-friendly for pipes.
+- Support `--json` for structured JSON output. Support `--plain` for grep-friendly tabular output.
+- Support `-q`/`--quiet` to suppress non-essential output.
+- Print something on success, but keep it brief. Don't print nothing.
+- When changing state, tell the user what changed.
+- Suggest commands the user should run next (like `git status` does).
+- Use a pager for long output. Good `less` flags: `-FIRX`.
+- Don't print log-level labels (ERR, WARN) or developer-facing info by default. Reserve for `-v`/`--verbose`.
+- Disable animations when not in a TTY (CI logs).
+
+### Color
+
+- Use color with intention: highlight important info, red for errors. Don't rainbow everything.
+- Disable color when: stdout/stderr is not a TTY, `NO_COLOR` is set, `TERM=dumb`, or `--no-color` is passed.
+- Check stdout and stderr independently (piping one shouldn't disable color on the other).
+
+### Symbols and Density
+
+- Use ASCII art, symbols, and emoji where they genuinely clarify. Don't overdo it.
+- Increase information density when it aids scanning (like `ls -l` permission columns).
+
+## Errors
+
+- Catch expected errors and rewrite them for humans. Include what went wrong AND how to fix it.
+- Keep signal-to-noise ratio high. Group similar errors under one header.
+- Put the most important information last (where the eye lands).
+- Use red sparingly and intentionally.
+- For unexpected errors: provide debug info and a bug-report URL (pre-populated if possible).
+- Write debug/traceback to a file rather than flooding the terminal.
+
+## Arguments and Flags
+
+- **Prefer flags to args.** More typing, much clearer. Easier to extend later.
+- Every flag gets a `--long-form`. One-letter shortcuts only for the most common flags.
+- Standard flag names (use these, don't reinvent):
+  - `-a`/`--all`, `-d`/`--debug`, `-f`/`--force`, `-h`/`--help`
+  - `-n`/`--dry-run`, `-o`/`--output`, `-p`/`--port`, `-q`/`--quiet`
+  - `-u`/`--user`, `-v`/`--version`, `--json`, `--no-input`
+- Multiple args are fine for the same kind of thing (`rm file1 file2`). Two args for *different* things is usually wrong (exception: `cp src dest`).
+- Make flag/arg/subcommand order independent when possible.
+- Support `-` for stdin/stdout (e.g., `tar xvf -`).
+- **Never read secrets from flags.** They leak into `ps` and shell history. Use `--password-file` or stdin.
+- Make the default the right thing for most users.
+
+## Subcommands
+
+- Be consistent across subcommands: same flag names, same output formatting.
+- Use consistent naming for multi-level commands: `noun verb` or `verb noun` (pick one).
+- Don't have ambiguous names ("update" vs "upgrade").
+- Don't have a catch-all subcommand (prevents adding new commands later).
+- Don't allow arbitrary abbreviations of subcommand names (locks you in).
+
+## Interactivity
+
+- Only prompt if stdin is a TTY. In non-TTY contexts, fail with instructions on which flags to pass.
+- Support `--no-input` to explicitly disable all prompts.
+- Don't echo passwords. Use terminal echo-disable helpers.
+- Let users escape: Ctrl-C must always work. Clarify exit methods in wrappers.
+
+### Confirming Dangerous Actions
+
+- **Mild risk** (delete a file): Optional confirmation or just do it if the command is explicitly destructive.
+- **Moderate risk** (delete a directory, remote resource): Prompt for confirmation. Consider `--dry-run`.
+- **Severe risk** (delete an entire deployment): Require typing the resource name. Support `--confirm="name"` for scripts.
+- Watch for non-obvious destruction (changing a count from 10 to 1 implicitly deletes 9 items).
+
+## Configuration
+
+Precedence (highest to lowest): flags > env vars > project config (`.env`) > user config > system config.
+
+- **Per-invocation** (debug level, dry-run): flags + env vars.
+- **Per-machine** (paths, proxy, color): flags + env vars. Maybe config file if complex.
+- **Per-project, all users** (build config): version-controlled config files.
+- Follow XDG Base Directory spec (`~/.config/myapp/`). Don't litter `$HOME` with dotfiles.
+- Don't auto-modify other programs' config without consent.
+
+## Environment Variables
+
+- Uppercase letters, numbers, underscores only. Don't start with a number.
+- Single-line values preferred.
+- Check standard vars: `NO_COLOR`, `DEBUG`, `EDITOR`, `HTTP_PROXY`, `SHELL`, `TERM`, `TMPDIR`, `HOME`, `PAGER`, `LINES`, `COLUMNS`.
+- Read `.env` files for project-specific config, but don't use `.env` as a substitute for proper config files.
+- **Never read secrets from env vars.** They leak into child processes, logs, `docker inspect`, `systemctl show`. Use credential files, pipes, or secret managers.
+
+## Signals
+
+- On Ctrl-C (SIGINT): print a message immediately, then exit as fast as possible. Timeout any cleanup.
+- On second Ctrl-C during cleanup: skip cleanup and exit immediately. Warn about consequences.
+- Design for crash-only: avoid post-op cleanup, defer to next run. Makes programs robust and responsive.
+
+## Robustness
+
+- Validate input early, fail with clear errors before doing anything.
+- Print something within 100ms. For network requests, print before the request.
+- Show progress for long operations. Use animated indicators so users know it's not hung.
+- Make timeouts configurable with sensible defaults.
+- Make operations resumable after transient failures (up-arrow + enter should work).
+- Make operations idempotent where possible.
+- Anticipate misuse: script wrapping, bad connections, concurrent instances, weird filesystems.
+
+## Naming
+
+- Simple, memorable, lowercase word. Dashes if needed, no capitals.
+- Keep it short but not cryptic. Easy to type (consider hand ergonomics).
+- Don't conflict with existing common commands.
+
+## Distribution
+
+- Distribute as a single binary when possible. Use PyInstaller etc. for interpreted languages.
+- Make uninstallation easy and documented.
+
+## Analytics
+
+- Never phone home without explicit consent.
+- Prefer alternatives: instrument web docs, track downloads, talk to users directly.
+
+## Exit Codes
+
+- `0` = success. Non-zero = failure.
+- Map distinct non-zero codes to important failure modes.
+
+## Future-proofing
+
+- Keep changes additive (new flags, not changed flag behavior).
+- Warn users in-program before making breaking changes. Detect when they've migrated and stop warning.
+- Human-readable output can change freely. Machine-readable output (`--json`, `--plain`) is a contract.

--- a/.agents/skills/cli-design-guidelines/references/full-guide.md
+++ b/.agents/skills/cli-design-guidelines/references/full-guide.md
@@ -1,0 +1,430 @@
+# CLI Design Guidelines — Full Reference
+
+Source: [clig.dev](https://clig.dev/) — An open-source guide to help you write better command-line programs, following traditional UNIX principles while updating them for the modern day.
+
+---
+
+## Philosophy
+
+### Human-first design
+Traditional UNIX commands were created assuming primary use by other programs. Today, even when CLIs are used primarily by humans, interaction design often carries baggage from this past. Modern CLIs designed for human use should prioritize human needs over machine-readability as the default behavior.
+
+### Simple parts that work together
+Core UNIX philosophy emphasizes small, simple programs with clean interfaces that combine to build larger systems. Rather than stuffing features into single programs, create modular programs for recombination as needed. Pipes, shell scripts, and modern automation (CI/CD, orchestration) still rely on this composability. Standard mechanisms like stdin/stdout/stderr, signals, exit codes, and plain text ensure different programs integrate smoothly. JSON provides additional structure for complex data when needed.
+
+Designing for composability need not conflict with human-first design—both can coexist.
+
+### Consistency across programs
+Terminal conventions are deeply learned. Following existing patterns makes CLIs intuitive and guessable, enabling user efficiency. However, consistency sometimes conflicts with usability. When following convention would compromise usability, breaking with it may be appropriate—but this decision requires careful consideration.
+
+### Saying (just) enough
+The terminal presents pure information. Output can be too little (program hangs for minutes, users wonder if it's broken) or too much (pages of debugging output drowning important information). Balance is crucial for clarity and user empowerment.
+
+### Ease of discovery
+GUIs display everything on screen; CLIs are assumed to require memorization. Yet these needn't be mutually exclusive. Discoverable CLIs offer comprehensive help texts, examples, suggestions for next commands, and error guidance—borrowing GUI principles while maintaining CLI efficiency.
+
+### Conversation as the norm
+CLI interaction embodies an accidental metaphor: conversation. Beyond simple commands, programs typically involve multiple invocations. Learning through repeated trial-and-error resembles dialogue with the program. Other conversational patterns include: multi-step setup then learning what to run; sequential commands building toward a final action; exploring systems; dry-running complex operations before execution. Good CLI design acknowledges this conversational nature, allowing you to suggest corrections, clarify intermediate state, and confirm dangerous actions.
+
+### Robustness
+Robustness has objective and subjective dimensions. Programs must handle unexpected input gracefully, perform idempotent operations where possible, etc. They should also *feel* robust—appearing solid and responsive rather than fragile. Subjective robustness requires attention to detail: keeping users informed, explaining common errors, avoiding scary stack traces. Simplicity contributes to robustness by reducing special cases and fragile code.
+
+### Empathy
+Command-line tools are programmers' creative toolkits and should be enjoyable to use. This means giving users the feeling you're on their side, wanting them to succeed, having carefully considered their problems. Empathy means exceeding expectations at every turn—it's not about emoji or gamification, though these aren't inherently wrong.
+
+### Chaos
+The terminal environment contains inconsistencies everywhere. Yet this chaos enables power—the terminal places few constraints on what you can build, fostering invention. This document advises following existing patterns while acknowledging that rule-breaking sometimes becomes necessary. As Jef Raskin wrote: "Abandon a standard when it is demonstrably harmful to productivity or user satisfaction."
+
+---
+
+## The Basics
+
+**Use a command-line argument parsing library.** Either your language's built-in library or a good third-party option. These handle arguments, flag parsing, help text, and spelling suggestions sensibly.
+
+Recommended libraries by language:
+- Multi-platform: docopt
+- Bash: argbash
+- Go: Cobra, cli
+- Haskell: optparse-applicative
+- Java: picocli
+- Julia: ArgParse.jl, Comonicon.jl
+- Kotlin: clikt
+- Node: oclif
+- Deno: parseArgs
+- Perl: Getopt::Long
+- PHP: console, CLImate
+- Python: Argparse, Click, Typer
+- Ruby: TTY
+- Rust: clap
+- Swift: swift-argument-parser
+
+**Return zero exit code on success, non-zero on failure.** Scripts determine program success/failure via exit codes. Report this correctly and map non-zero codes to important failure modes.
+
+**Send output to stdout.** Primary command output goes to stdout. Machine-readable output also goes to stdout (piping's default destination).
+
+**Send messaging to stderr.** Log messages, errors, and related messaging go to stderr. This prevents these messages from being fed into piped commands while displaying them to users.
+
+---
+
+## Help
+
+**Display extensive help text when asked.** Show help when passed `-h` or `--help` flags, including for subcommands with their own help.
+
+**Display concise help text by default.** When a program requires arguments but is run without them, display concise help (excluding programs interactive by default like `npm init`).
+
+Concise help should include only:
+- Description of what the program does
+- One or two example invocations
+- Flag descriptions (unless there are many)
+- Instruction to pass `--help` for full information
+
+Example from `jq`:
+```
+$ jq
+jq - commandline JSON processor [version 1.6]
+
+Usage:    jq [options] <jq filter> [file...]
+    jq [options] --args <jq filter> [strings...]
+    jq [options] --jsonargs <jq filter> [JSON_TEXTS...]
+
+jq is a tool for processing JSON inputs, applying the given filter to
+its JSON text inputs and producing the filter's results as JSON on
+standard output.
+
+The simplest filter is ., which copies jq's input to its output
+unmodified (except for formatting, but note that IEEE754 is used
+for number representation internally, with all that that implies).
+
+For more advanced filters see the jq(1) manpage ("man jq")
+and/or https://stedolan.github.io/jq
+
+Example:
+
+    $ echo '{"foo": 0}' | jq .
+    {
+        "foo": 0
+    }
+
+For a listing of options, use jq --help.
+```
+
+**Show full help when `-h` and `--help` are passed.** All of these should show help:
+```
+$ myapp
+$ myapp --help
+$ myapp -h
+```
+
+Ignore other flags and arguments—users should be able to add `-h` to anything. Don't overload `-h`.
+
+For `git`-like programs, also support:
+```
+$ myapp help
+$ myapp help subcommand
+$ myapp subcommand --help
+$ myapp subcommand -h
+```
+
+**Provide a support path for feedback and issues.** Include website or GitHub link in top-level help text.
+
+**In help text, link to the web version of documentation.** Link directly to specific pages or anchors for subcommands. This proves especially useful when documentation provides more detail or additional reading.
+
+**Lead with examples.** Users typically prefer examples over other documentation forms. Show them first, particularly for common complex uses. Include actual output if it clarifies behavior without excessive length. Build a narrative with series of examples advancing toward complex uses.
+
+**If you've got loads of examples, put them somewhere else.** Use cheat sheet commands or web pages for exhaustive, advanced examples to avoid overwhelming help text. Consider full tutorials for complex integration use cases.
+
+**Display the most common flags and commands at the start of help text.** Many flags are fine, but highlight really common ones first.
+
+Example from `git`:
+```
+$ git
+usage: git [--version] [--help] [-C <path>] [-c <name>=<value>]
+           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
+           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
+           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
+           <command> [<args>]
+
+These are common Git commands used in various situations:
+
+start a working area (see also: git help tutorial)
+   clone      Clone a repository into a new directory
+   init       Create an empty Git repository or reinitialize an existing one
+
+work on the current change (see also: git help everyday)
+   add        Add file contents to the index
+   mv         Move or rename a file, a directory, or a symlink
+   reset      Reset current HEAD to the specified state
+   rm         Remove files from the working tree and from the index
+
+examine the history and state (see also: git help revisions)
+   bisect     Use binary search to find the commit that introduced a bug
+   grep       Print lines matching a pattern
+   log        Show commit logs
+   show       Show various types of objects
+   status     Show the working tree status
+…
+```
+
+**Use formatting in your help text.** Bold headings improve scannability, using terminal-independent methods to avoid escape character walls.
+
+**If the user did something wrong and you can guess what they meant, suggest it.** For example, `brew update jq` suggests running `brew upgrade jq`. You can ask for confirmation, but don't auto-correct silently—invalid input doesn't necessarily indicate simple typos, and auto-correcting risks dangerous state changes while preventing users from learning proper syntax.
+
+**If your command expects piped input but stdin is an interactive terminal, display help immediately and quit.** This prevents hanging like `cat` does. Alternatively, print a log message to stderr.
+
+---
+
+## Documentation
+
+Help text provides brief immediate understanding; documentation offers full detail covering what the tool is, what it isn't, how it works, and everything users might need.
+
+**Provide web-based documentation.** Users must be able to search online for your tool's documentation and link others to specific sections.
+
+**Provide terminal-based documentation.** Terminal documentation offers advantages: fast access, version-specific synchronization, offline availability.
+
+**Consider providing man pages.** Many users reflexively check `man mycmd` first. Tools like [ronn](http://rtomayko.github.io/ronn/) generate both man pages and web docs. Since not everyone knows about `man` and it doesn't run on all platforms, ensure terminal docs are accessible through your tool itself (e.g., `git help` and `npm help ls`).
+
+---
+
+## Output
+
+**Human-readable output is paramount.** Humans first, machines second. The most reliable heuristic for human reading is checking whether output streams (stdout/stderr) connect to a TTY.
+
+**Have machine-readable output where it does not impact usability.** Text streams form UNIX's universal interface. Programs output text lines; programs expect text input. This composition enables scripting and improves human usability—users can pipe output to `grep` and expect correct behavior.
+
+**If human-readable output breaks machine-readable output, use `--plain`.** Display plain, tabular text format for integration with tools like `grep` or `awk`. When human-readable formatting breaks record-per-line expectations, provide `--plain` for scripts.
+
+**Display output as formatted JSON if `--json` is passed.** JSON provides more structure than plain text. `jq` is the standard for command-line JSON work with a whole ecosystem of tools. JSON's web prevalence enables piping directly to/from web services using `curl`.
+
+**Display output on success, but keep it brief.** Traditionally, UNIX commands display nothing when nothing's wrong. Printing nothing is rarely ideal for default human interaction. Err toward less output. For no-output preferences in shell scripts, provide `-q` option to suppress non-essential output.
+
+**If you change state, tell the user.** State changes deserve explanation so users model the system's new state—especially when results don't directly map to requests. Example: `git push` shows detailed transfer information.
+
+**Make it easy to see the current state of the system.** When your program performs complex state changes not immediately visible in the filesystem, make state viewing easy. Example: `git status` shows branch, changes, and suggests commands.
+
+**Suggest commands the user should run.** When commands form workflows, suggesting next commands helps learning and feature discovery.
+
+**Actions crossing the program's internal world boundary should usually be explicit.** This includes reading/writing files not explicitly passed as arguments and talking to remote servers.
+
+**Increase information density—with ASCII art!** For example, `ls` displays permissions in scannable ways.
+
+**Use color with intention.** Highlight text for user notice or indicate errors (red). Don't overuse—if everything's different colors, color becomes meaningless.
+
+**Disable color if your program is not in a terminal or the user requested it.** Disable when:
+- stdout or stderr is not a TTY (check individually)
+- `NO_COLOR` environment variable is set and non-empty
+- `TERM` environment variable equals `dumb`
+- User passes `--no-color` option
+- Consider adding `MYAPP_NO_COLOR` for program-specific disabling
+
+**If stdout is not an interactive terminal, don't display animations.** This prevents progress bars from becoming visual noise in CI logs.
+
+**Use symbols and emoji where it makes things clearer.** Careful application prevents cluttering or appearing toy-like.
+
+**By default, don't output information understandable only by software creators.** Developer-facing info should only display in verbose mode.
+
+**Don't treat stderr like a log file, at least not by default.** Don't print log level labels unless in verbose mode.
+
+**Use a pager (e.g. `less`) if outputting lots of text.** Use pagers only when stdin or stdout is an interactive terminal. Good `less` options: `less -FIRX`.
+
+---
+
+## Errors
+
+**Catch errors and rewrite them for humans.** When expecting errors, catch and rewrite messages usefully. Treat it as conversation guiding the user rightward. Example: "Can't write to file.txt. You might need to make it writable by running 'chmod +w file.txt'."
+
+**Signal-to-noise ratio is crucial.** More irrelevant output lengthens error diagnosis time. Consider grouping multiple same-type errors under single explanatory header.
+
+**Consider where the user will look first.** Place most important information at output end. Red text draws eye attention—use intentionally and sparingly.
+
+**If there is an unexpected or unexplainable error, provide debug and traceback information with bug submission instructions.** Consider writing debug logs to files rather than terminal printing.
+
+**Make it effortless to submit bug reports.** Provide a URL pre-populating as much information as possible.
+
+---
+
+## Arguments and Flags
+
+Terminology:
+- **Arguments** (args): Positional parameters. Order often matters.
+- **Flags**: Named parameters using hyphens. May include user-specified values. Order generally doesn't matter.
+
+**Prefer flags to args.** More typing, but far clearer. Easier to extend later.
+
+**Have full-length versions of all flags.** Include both `-h` and `--help`. Full versions are useful in scripts.
+
+**Only use one-letter flags for commonly used flags.** Especially at top-level. Avoids polluting short flag namespace.
+
+**Multiple arguments are fine for simple multiple-file actions.** Example: `rm file1.txt file2.txt file3.txt`. Works with globbing.
+
+**If you've got two or more arguments for different things, you're probably doing something wrong.** Exception: Common primary actions where brevity merits memorization (`cp <src> <dest>`).
+
+**Use standard names for flags, if standards exist.** Common flags:
+- `-a`/`--all`: All items
+- `-d`/`--debug`: Show debugging output
+- `-f`/`--force`: Force action (skip confirmation)
+- `--json`: Display JSON output
+- `-h`/`--help`: Help (should mean help only)
+- `-n`/`--dry-run`: Don't run; describe changes
+- `--no-input`: Disable prompts
+- `-o`/`--output`: Output file
+- `-p`/`--port`: Port
+- `-q`/`--quiet`: Less output
+- `-u`/`--user`: User
+- `--version`: Version
+- `-v`: Often means verbose or version (consider `-d` for verbose)
+
+**Make the default the right thing for most users.** Most users won't find and remember correct flags.
+
+**Prompt for user input.** If users don't pass arguments/flags, prompt them.
+
+**Never require a prompt.** Always provide flag/argument alternatives. Skip prompting when stdin isn't interactive terminal.
+
+**Confirm before doing anything dangerous.** Prompt for `y`/`yes` when interactive, or require `-f`/`--force` otherwise. Risk levels:
+- **Mild**: Small local change. May or may not need prompting.
+- **Moderate**: Larger local or remote changes. Usually warrant confirmation. Consider dry run.
+- **Severe**: Deleting complex items. Require typing the item's name. Support `--confirm="name"` for scripts.
+
+**If input or output is a file, support `-` for stdin/stdout.** Enables piping without temporary files.
+
+**If a flag accepts optional values, allow a special word like "none".** Example: `ssh -F none` runs with no config.
+
+**If possible, make arguments, flags, and subcommands order-independent.** Users add flags at the end after up-arrow recall.
+
+**Do not read secrets directly from flags.** Flag values leak into `ps` output and shell history. Accept secrets only via files (`--password-file`) or stdin.
+
+---
+
+## Interactivity
+
+**Only use prompts or interactive elements if stdin is an interactive terminal (TTY).** Throw errors specifying flag passage when required.
+
+**If `--no-input` is passed, don't prompt or do anything interactive.** Fail telling users how to pass information as flags.
+
+**If you're prompting for a password, don't print it as users type.** Disable terminal echo.
+
+**Let the user escape.** Make exit methods clear. Ensure Ctrl-C still works during network I/O hangs.
+
+---
+
+## Subcommands
+
+**Be consistent across subcommands.** Same flag names for same things; similar output formatting.
+
+**Use consistent names for multiple subcommand levels.** Two-level commands: one noun, one verb. Either `noun verb` or `verb noun`; `noun verb` is more common. Example: `docker container create`.
+
+**Don't have ambiguous or similarly-named commands.** "Update" and "upgrade" confuse users.
+
+**Don't have a catch-all subcommand.** You can never add a subcommand with a name that was previously used as an argument to the catch-all. Scripts break silently.
+
+**Don't allow arbitrary subcommand abbreviations.** Explicit aliases are fine, but implicit prefix-matching prevents future additions.
+
+---
+
+## Robustness
+
+**Validate user input.** Check early and bail before anything breaks, making errors understandable.
+
+**Responsive is more important than fast.** Print something within 100ms. For network requests, print before executing.
+
+**Show progress if something takes a long time.** Good libraries: tqdm (Python), schollz/progressbar (Go), node-progress (Node.js).
+
+**Do stuff in parallel where you can, but be thoughtful about it.** Ensure robustness and non-confusing output interleaving. Use libraries. If progress bars are hidden during normal operation, still print logs when errors occur.
+
+**Make things time out.** Allow network timeout configuration with sensible defaults.
+
+**Make it recoverable.** Transient failures should allow resuming from where it left off.
+
+**Make it crash-only.** Avoid post-operation cleanup or defer cleanup to next run.
+
+**People are going to misuse your program.** Prepare for script wrapping, poor connections, multiple simultaneous instances, unexpected environments.
+
+---
+
+## Future-proofing
+
+**Keep changes additive where you can.** Add new flags rather than changing existing behavior.
+
+**Warn before making non-additive changes.** When users pass deprecated flags, tell them. Detect migration and stop warning.
+
+**Changing output for humans is usually OK.** Encourage script users to use `--plain` or `--json` for stability.
+
+**Don't have a catch-all subcommand.** Prevents adding new commands forever.
+
+**Don't allow arbitrary subcommand abbreviations.** Locks you into never adding conflicting commands.
+
+**Don't create a "time bomb."** Will your command work identically in twenty years?
+
+---
+
+## Signals and Control Characters
+
+**If a user hits Ctrl-C (INT signal), exit as soon as possible.** Say something immediately before cleanup. Add cleanup timeouts.
+
+**If a user hits Ctrl-C during long cleanup operations, skip them.** Tell users what happens when pressing Ctrl-C again.
+
+---
+
+## Configuration
+
+Configuration precedence (highest to lowest):
+1. Flags
+2. Running shell's environment variables
+3. Project-level configuration (e.g., `.env`)
+4. User-level configuration
+5. System-wide configuration
+
+**Follow the XDG spec.** Use `~/.config/myapp/` instead of littering home directory with dotfiles.
+
+**If you automatically modify non-your-program configuration, ask user consent.**
+
+---
+
+## Environment Variables
+
+**For portability, names must contain only uppercase letters, numbers, underscores.** Don't start with numbers.
+
+**Aim for single-line values.** Multi-line values create usability issues.
+
+**Check general-purpose environment variables:**
+- `NO_COLOR` / `FORCE_COLOR`: Color control
+- `DEBUG`: Enable verbose output
+- `EDITOR`: For file editing prompts
+- `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`: Network operations
+- `SHELL`: User's preferred shell
+- `TERM`, `TERMINFO`, `TERMCAP`: Terminal capabilities
+- `TMPDIR`: Temporary files
+- `HOME`: Configuration files
+- `PAGER`: Auto-paging output
+- `LINES`, `COLUMNS`: Screen-size-dependent output
+
+**Read `.env` where appropriate.** But don't use it as a substitute for proper config files.
+
+**Do not read secrets from environment variables.** They leak into child processes, logs, docker inspect, and systemctl show.
+
+---
+
+## Naming
+
+**Make it a simple, memorable word.** Not too generic (avoid conflicts).
+
+**Use only lowercase letters, dashes if really needed.**
+
+**Keep it short.** Users type it constantly.
+
+**Make it easy to type.** Consider hand ergonomics.
+
+---
+
+## Distribution
+
+**If possible, distribute as a single binary.** Use PyInstaller etc. for interpreted languages.
+
+**Make it easy to uninstall.** Document uninstallation at the bottom of install instructions.
+
+---
+
+## Analytics
+
+**Do not phone home usage or crash data without consent.** Explain data collection, reasons, anonymity, and retention.
+
+**Consider analytics alternatives:** Instrument web docs, track downloads, talk to users directly.

--- a/.agents/skills/cobra/SKILL.md
+++ b/.agents/skills/cobra/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: cobra
+description: >
+    Build Go CLI applications with Cobra framework. Covers command structure, flags (local/persistent/required),
+    hooks (PreRun/PostRun), shell completions, Viper config integration, error handling, and doc generation.
+
+    Use when: building Go CLIs, adding Cobra commands or subcommands, working with flags,
+    generating shell completions, or troubleshooting "unknown command" or flag parsing errors.
+---
+
+Apply these patterns when building CLI applications with Cobra. For full examples and rationale, see [references/](references/).
+
+## Setup
+
+```bash
+go get -u github.com/spf13/cobra@latest
+go install github.com/spf13/cobra-cli@latest
+cobra-cli init          # scaffold project
+cobra-cli add serve     # add subcommand
+```
+
+## Command Structure
+
+```go
+var serveCmd = &cobra.Command{
+    Use:     "serve [flags]",
+    Short:   "Start the HTTP server",
+    Long:    "Start the HTTP server with sensible defaults.\nUseful in development and production.",
+    Example: `  myapp serve
+  myapp serve --port 9090`,
+    Aliases: []string{"s", "start"},
+    GroupID: "server",                    // for grouped help output
+    Args:    cobra.ExactArgs(0),          // argument validation
+    RunE: func(cmd *cobra.Command, args []string) error {
+        cmd.SilenceUsage = true           // don't show usage on runtime errors
+        // ...
+        return nil
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(serveCmd)
+}
+```
+
+### Critical Fields
+
+| Field | Purpose |
+|-------|---------|
+| `Use` | Command name + usage pattern. First word is the command name. |
+| `Short` | One-line description shown in parent's help |
+| `Long` | Full description shown in command's own help |
+| `Example` | Code examples (indent with 2 spaces) |
+| `RunE` | Main execution (prefer over `Run` — returns errors) |
+| `Args` | Argument validation function |
+| `Aliases` | Alternative names |
+| `GroupID` | Group in parent's help (set with `rootCmd.AddGroup()`) |
+
+### Argument Validators
+
+```go
+cobra.NoArgs              // error if any args
+cobra.ExactArgs(n)        // exactly n args
+cobra.MinimumNArgs(n)     // at least n args
+cobra.MaximumNArgs(n)     // at most n args
+cobra.RangeArgs(min, max) // between min and max
+cobra.ArbitraryArgs       // any args (default)
+cobra.OnlyValidArgs       // only args listed in ValidArgs
+```
+
+Custom validator:
+```go
+Args: func(cmd *cobra.Command, args []string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires a name argument")
+    }
+    return nil
+},
+```
+
+## Flags
+
+### Local vs Persistent
+
+```go
+// Local: only on this command
+serveCmd.Flags().IntP("port", "p", 8080, "port to listen on")
+
+// Persistent: inherited by all child commands
+rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+```
+
+**Rule**: Use local flags by default. Only use persistent for truly global concerns (verbose, config path, output format).
+
+### Flag Types
+
+```go
+// Variable binding (access via variable)
+var port int
+serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "port to listen on")
+
+// On-demand reading (access in RunE)
+port, _ := cmd.Flags().GetInt("port")
+
+// Common types
+cmd.Flags().String("name", "", "description")
+cmd.Flags().StringP("name", "n", "", "description")     // with shorthand
+cmd.Flags().Bool("force", false, "description")
+cmd.Flags().Duration("timeout", 30*time.Second, "timeout")
+cmd.Flags().StringSlice("tags", nil, "repeatable tags")  // --tags a --tags b
+cmd.Flags().StringArray("env", nil, "env vars")           // no CSV splitting
+```
+
+### Required Flags
+
+```go
+serveCmd.Flags().StringVar(&addr, "addr", "", "listen address")
+serveCmd.MarkFlagRequired("addr")
+```
+
+### Flag Groups
+
+```go
+// Mutually exclusive: only one allowed
+serveCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+
+// Required together: all or none
+serveCmd.MarkFlagsRequiredTogether("username", "password")
+
+// One required: at least one
+serveCmd.MarkFlagsOneRequired("json", "yaml", "text")
+```
+
+### Flag Validation in PreRunE
+
+```go
+PreRunE: func(cmd *cobra.Command, args []string) error {
+    format, _ := cmd.Flags().GetString("format")
+    switch format {
+    case "json", "yaml":
+    default:
+        return fmt.Errorf("invalid --format: %s (want json|yaml)", format)
+    }
+    return nil
+},
+```
+
+### Hidden and Deprecated Flags
+
+```go
+cmd.Flags().MarkHidden("internal-debug")
+cmd.Flags().MarkDeprecated("colour", "use --color instead")
+```
+
+## Hooks (Execution Lifecycle)
+
+Order: `PersistentPreRun` > `PreRun` > `Run` > `PostRun` > `PersistentPostRun`
+
+```go
+var deployCmd = &cobra.Command{
+    Use: "deploy",
+    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+        // runs before this cmd AND all children
+        return initConfig()
+    },
+    PreRunE: func(cmd *cobra.Command, args []string) error {
+        // runs before this cmd only — good for validation
+        return validateFlags(cmd)
+    },
+    RunE: func(cmd *cobra.Command, args []string) error {
+        // main logic
+        return doDeploy(args)
+    },
+    PostRunE: func(cmd *cobra.Command, args []string) error {
+        // cleanup after this cmd
+        return nil
+    },
+}
+```
+
+**Key rule**: Parent `PersistentPreRun` runs before child `PreRun`. If a child defines `PersistentPreRun`, it **overrides** the parent's (it does not chain). Call parent explicitly if needed.
+
+## Error Handling
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    cmd.SilenceUsage = true    // don't print usage on runtime errors
+    cmd.SilenceErrors = true   // suppress Cobra's own error printing
+
+    if err := doWork(); err != nil {
+        return fmt.Errorf("deploy failed: %w", err)
+    }
+    return nil
+},
+```
+
+- `nil` return = exit code 0
+- Non-nil error = message to stderr + non-zero exit
+- Use `SilenceUsage = true` so runtime errors don't dump help text
+
+## Shell Completions
+
+### Generation Commands
+
+Add a `completion` subcommand (Cobra can auto-generate this):
+
+```go
+// Cobra provides this automatically if you don't override it
+// Users run: myapp completion bash|zsh|fish|powershell
+```
+
+### Custom Completions
+
+```go
+var statusCmd = &cobra.Command{
+    Use:       "status [environment]",
+    ValidArgs: []string{"dev", "staging", "production"},
+    // OR dynamic:
+    ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+        if len(args) != 0 {
+            return nil, cobra.ShellCompDirectiveNoFileComp
+        }
+        return []string{"dev", "staging", "production"}, cobra.ShellCompDirectiveNoFileComp
+    },
+}
+```
+
+### Flag Completions
+
+```go
+cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    return []string{"json", "yaml", "csv"}, cobra.ShellCompDirectiveNoFileComp
+})
+
+cmd.MarkFlagFilename("config", "yaml", "yml", "json")  // complete file paths
+cmd.MarkFlagDirname("output")                            // complete directories
+```
+
+### Shell Completion Directives
+
+```go
+cobra.ShellCompDirectiveDefault       // default (file completion)
+cobra.ShellCompDirectiveNoFileComp    // no file completion
+cobra.ShellCompDirectiveNoSpace       // no space after completion
+cobra.ShellCompDirectiveFilterDirs    // only directories
+cobra.ShellCompDirectiveFilterFileExt // filter by extension
+cobra.ShellCompDirectiveKeepOrder     // preserve suggestion order
+cobra.ShellCompDirectiveError         // error occurred
+```
+
+## Viper Integration
+
+```go
+import "github.com/spf13/viper"
+
+func initConfig() {
+    viper.SetConfigName("config")
+    viper.SetConfigType("yaml")
+    viper.AddConfigPath(".")
+    viper.AddConfigPath("$HOME/.myapp")
+
+    viper.SetEnvPrefix("MYAPP")
+    viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+    viper.AutomaticEnv()
+
+    viper.ReadInConfig() // ignore error if no config file
+}
+
+func init() {
+    cobra.OnInitialize(initConfig)
+
+    rootCmd.PersistentFlags().Int("port", 8080, "port")
+    viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
+}
+```
+
+**Precedence**: flag > env var > config file > default
+
+## Command Grouping
+
+```go
+func init() {
+    rootCmd.AddGroup(
+        &cobra.Group{ID: "core", Title: "Core Commands:"},
+        &cobra.Group{ID: "admin", Title: "Admin Commands:"},
+    )
+    rootCmd.AddCommand(serveCmd)    // serveCmd.GroupID = "core"
+    rootCmd.AddCommand(migrateCmd)  // migrateCmd.GroupID = "admin"
+}
+```
+
+Introduce grouping around 8-10 subcommands or when you have natural categories.
+
+## Documentation Generation
+
+```go
+import "github.com/spf13/cobra/doc"
+
+// Markdown (one file per command)
+doc.GenMarkdownTree(rootCmd, "./docs")
+
+// Man pages
+header := &doc.GenManHeader{Title: "MYAPP", Section: "1"}
+doc.GenManTree(rootCmd, header, "./man")
+
+// With custom frontmatter
+doc.GenMarkdownTreeCustom(rootCmd, "./docs", prepender, linkHandler)
+```
+
+## Project Organization
+
+### Simple (single cmd package)
+```
+cmd/
+  root.go       // rootCmd + Execute()
+  serve.go      // serveCmd
+  deploy.go     // deployCmd
+main.go          // calls cmd.Execute()
+```
+
+### Modular (feature packages)
+```
+cmd/
+  root.go
+internal/
+  serve/
+    command.go   // func NewCommand() *cobra.Command
+  deploy/
+    command.go
+```
+
+```go
+// internal/serve/command.go
+func NewCommand() *cobra.Command {
+    return &cobra.Command{
+        Use: "serve",
+        RunE: func(cmd *cobra.Command, args []string) error { ... },
+    }
+}
+
+// cmd/root.go
+rootCmd.AddCommand(serve.NewCommand())
+```
+
+## Common Mistakes
+
+- **Using `Run` instead of `RunE`**: Always prefer `RunE` so errors propagate correctly.
+- **Forgetting `SilenceUsage`**: Without it, every error dumps the full usage text.
+- **Overusing persistent flags**: Only for truly global concerns. Local flags are the default.
+- **Not setting `DisableAutoGenTag`**: Generated docs get noisy timestamp comments.
+- **Forgetting shorthand collisions**: Reserve `-h` for help, `-v` for version. Don't reuse across siblings.

--- a/.agents/skills/cobra/references/full-guide.md
+++ b/.agents/skills/cobra/references/full-guide.md
@@ -1,0 +1,394 @@
+# Cobra CLI Framework — Full Reference
+
+Source: [cobra.dev](https://cobra.dev/) — Build Modern CLIs That Users Love
+
+Used by: Kubernetes (kubectl), Docker, GitHub CLI, Hugo, Helm, Istio, Prometheus, and 173,000+ projects.
+
+---
+
+## Philosophy
+
+### 1. CLI as a User Interface
+
+The CLI is a user experience. Applications should be intuitive, discoverable, and helpful. Users explore through help commands, tab completion, and logical hierarchies. Commands need both `Short` descriptions and comprehensive `Long` documentation. Consistent patterns in naming, flag usage, and output formatting reduce cognitive load.
+
+### 2. Convention Over Configuration
+
+Sensible defaults minimize decision fatigue while preserving customization. Cobra provides automatic help generation, argument validation, error handling, and parent command integration out of the box.
+
+**Configuration hierarchy**: Flags > Environment variables > Config files > Defaults
+
+### 3. Batteries Included, But Swappable
+
+Built-in: command parsing, flag handling, shell completion (bash/zsh/fish/PowerShell), man page generation, markdown doc generation. All customizable via `SetHelpCommand()`, `SetUsageTemplate()`, custom validators, hooks, and completion functions.
+
+---
+
+## Command Pattern
+
+```
+appName command [arguments] --flag value
+```
+
+### Hook Execution Order
+
+1. `PersistentPreRun` (inherited from parent)
+2. `PreRun` (this command only)
+3. `Run`/`RunE` (main execution)
+4. `PostRun` (this command only)
+5. `PersistentPostRun` (inherited from parent)
+
+---
+
+## First CLI Tutorial
+
+```bash
+mkdir my-cli && cd my-cli
+go mod init my-cli
+go get -u github.com/spf13/cobra@latest
+go install github.com/spf13/cobra-cli@latest
+cobra-cli init
+cobra-cli add serve
+go build -o my-cli
+./my-cli serve
+```
+
+---
+
+## Working with Commands
+
+### Basic Command
+
+```go
+var greetCmd = &cobra.Command{
+    Use:   "greet [name]",
+    Short: "Greet someone",
+    Long:  "Greet someone with a friendly message.",
+    Example: `  myapp greet World
+  myapp greet --uppercase Alice`,
+    Args: cobra.MaximumNArgs(1),
+    RunE: func(cmd *cobra.Command, args []string) error {
+        name := "World"
+        if len(args) > 0 {
+            name = args[0]
+        }
+        fmt.Printf("Hello, %s!\n", name)
+        return nil
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(greetCmd)
+}
+```
+
+### Aliases
+
+```go
+var installCmd = &cobra.Command{
+    Use:     "install [packages]",
+    Aliases: []string{"i", "add"},
+    // ...
+}
+```
+
+### Error Handling with RunE
+
+Prefer `RunE` over `Run`:
+- `cmd.SilenceUsage = true` prevents usage display for runtime errors
+- `cmd.SilenceErrors = true` suppresses Cobra's error printing
+- `nil` returns exit code 0; errors trigger stderr + non-zero exit
+
+### Command Grouping
+
+```go
+rootCmd.AddGroup(
+    &cobra.Group{ID: "core", Title: "Core Commands:"},
+    &cobra.Group{ID: "admin", Title: "Admin Commands:"},
+)
+```
+
+Introduce grouping around 8-10 subcommands or when natural categories emerge.
+
+### Organization: Simple Layout
+
+Single `cmd` package with one file per command.
+
+### Organization: Modular Layout
+
+Feature packages that return `*cobra.Command` via constructor functions (`NewCommand()`). Isolates dependencies — serve features won't import build feature code.
+
+---
+
+## Working with Flags
+
+### Local Flags
+
+Defined on a single command, don't inherit to children. Use as default.
+
+```go
+serveCmd.Flags().IntP("port", "p", 8080, "port to listen on")
+```
+
+### Persistent Flags
+
+Defined on parent, available to all descendants unless shadowed. Use sparingly.
+
+```go
+rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+```
+
+### Flag Types
+
+- `String`, `StringP`, `StringVar`, `StringVarP`
+- `Int`, `IntP`, `IntVar`, `IntVarP`
+- `Bool`, `BoolP`, `BoolVar`, `BoolVarP`
+- `Duration` (parses `300ms`, `5s`, `1m`)
+- `StringSlice` / `StringArray` (repeatable values)
+
+### Reading Patterns
+
+**On-demand** in RunE:
+```go
+port, err := cmd.Flags().GetInt("port")
+```
+
+**Variable binding** at init:
+```go
+var port int
+serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "port")
+```
+
+### Shorthand Flags
+
+Use the `P` variant methods. Avoid collisions across siblings. Reserve `-h` for help.
+
+### Required Flags
+
+```go
+loginCmd.Flags().StringVar(&user, "username", "", "username")
+loginCmd.MarkFlagRequired("username")
+```
+
+### Flag Validation in PreRunE
+
+```go
+PreRunE: func(cmd *cobra.Command, args []string) error {
+    if stdout && outPath != "" {
+        return fmt.Errorf("--stdout and --out are mutually exclusive")
+    }
+    switch format {
+    case "json", "yaml":
+    default:
+        return fmt.Errorf("invalid --format: %s (want json|yaml)", format)
+    }
+    return nil
+},
+```
+
+### Hidden & Deprecated Flags
+
+```go
+rootCmd.PersistentFlags().MarkHidden("config")
+rootCmd.PersistentFlags().MarkDeprecated("colour", "use --color instead")
+```
+
+Keep deprecated flags active for at least one minor release with clear messaging.
+
+### Viper Integration
+
+```go
+rootCmd.PersistentFlags().Int("port", 8080, "port to listen on")
+viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
+
+viper.SetEnvPrefix("flagsapp")
+viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+viper.AutomaticEnv()
+```
+
+Precedence: flag > env > config > default
+
+### Complete Flag Example
+
+```go
+var (
+    outPath string
+    stdout  bool
+    format  string
+    tags    []string
+)
+
+var exportCmd = &cobra.Command{
+    Use: "export",
+    PreRunE: func(cmd *cobra.Command, args []string) error {
+        if stdout && outPath != "" {
+            return fmt.Errorf("--stdout and --out are mutually exclusive")
+        }
+        switch format {
+        case "json", "yaml":
+        default:
+            return fmt.Errorf("invalid --format: %s (want json|yaml)", format)
+        }
+        return nil
+    },
+    RunE: func(cmd *cobra.Command, args []string) error {
+        fmt.Printf("Output: %s, Format: %s, Tags: %v\n", outPath, format, tags)
+        return nil
+    },
+}
+
+func init() {
+    exportCmd.Flags().StringVar(&outPath, "out", "", "write to file path")
+    exportCmd.Flags().BoolVar(&stdout, "stdout", false, "write to stdout")
+    exportCmd.Flags().StringVar(&format, "format", "json", "output format")
+    exportCmd.Flags().StringSliceVar(&tags, "tag", nil, "add tag (repeatable)")
+    rootCmd.AddCommand(exportCmd)
+}
+```
+
+---
+
+## Shell Completions
+
+### Generation
+
+```bash
+# Bash
+myapp completion bash > myapp-completion.bash
+sudo cp myapp-completion.bash /etc/bash_completion.d/
+
+# Zsh
+myapp completion zsh > _myapp
+sudo cp _myapp /usr/local/share/zsh/site-functions/
+
+# Fish
+myapp completion fish > ~/.config/fish/completions/myapp.fish
+
+# PowerShell
+myapp completion powershell > myapp.ps1
+Add-Content $PROFILE ". /path/to/myapp.ps1"
+```
+
+### Custom Completions
+
+**Static:**
+```go
+ValidArgs: []string{"dev", "staging", "production"},
+```
+
+**Dynamic:**
+```go
+ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    return []string{"dev", "staging", "production"}, cobra.ShellCompDirectiveNoFileComp
+},
+```
+
+### Flag Completions
+
+```go
+cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    return []string{"json", "yaml", "csv"}, cobra.ShellCompDirectiveNoFileComp
+})
+
+cmd.MarkFlagFilename("config", "yaml", "yml", "json")
+cmd.MarkFlagDirname("output")
+```
+
+### Directives
+
+| Directive | Behavior |
+|-----------|----------|
+| `ShellCompDirectiveDefault` | Default file completion |
+| `ShellCompDirectiveNoFileComp` | No file completion |
+| `ShellCompDirectiveNoSpace` | No space after completion |
+| `ShellCompDirectiveFilterDirs` | Only directories |
+| `ShellCompDirectiveFilterFileExt` | Filter by extension |
+| `ShellCompDirectiveKeepOrder` | Preserve order |
+| `ShellCompDirectiveError` | Error occurred |
+
+---
+
+## Documentation Generation
+
+```go
+import "github.com/spf13/cobra/doc"
+
+// Markdown
+doc.GenMarkdownTree(rootCmd, "./docs")
+
+// With frontmatter
+doc.GenMarkdownTreeCustom(rootCmd, "./docs", prepender, linkHandler)
+
+// Man pages
+header := &doc.GenManHeader{Title: "MYAPP", Section: "1"}
+doc.GenManTree(rootCmd, header, "./man")
+
+// reStructuredText
+doc.GenReSTTree(rootCmd, "./docs")
+```
+
+Set `rootCmd.DisableAutoGenTag = true` to prevent timestamp churn.
+
+### Doc Generator Tool
+
+```go
+// internal/tools/docgen/main.go
+package main
+
+import (
+    "flag"
+    "log"
+    "os"
+    "github.com/spf13/cobra/doc"
+    "example.com/myapp/cmd"
+)
+
+func main() {
+    out := flag.String("out", "./docs/cli", "output directory")
+    flag.Parse()
+
+    os.MkdirAll(*out, 0o755)
+    root := cmd.Root()
+    root.DisableAutoGenTag = true
+
+    if err := doc.GenMarkdownTree(root, *out); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### Optimizing for LLMs
+
+- One command per file (Cobra's generators do this by default)
+- Populate substantial `Example` sections on each command
+- Craft detailed `Long` descriptions
+- Set `DisableAutoGenTag`
+- Assign `GroupID` for organized help
+
+---
+
+## Notable Projects Using Cobra
+
+| Project | Category |
+|---------|----------|
+| Kubernetes (kubectl) | Infrastructure |
+| Docker | Infrastructure |
+| GitHub CLI (gh) | Developer Tools |
+| Hugo | Static Site Gen |
+| Helm | Package Manager |
+| Istio | Service Mesh |
+| Prometheus | Monitoring |
+| Jaeger | Tracing |
+| Linkerd | Service Mesh |
+| Flux | GitOps |
+| Viper | Configuration |
+
+---
+
+## Recommended Libraries
+
+- **Cobra**: CLI framework — `github.com/spf13/cobra`
+- **Viper**: Configuration — `github.com/spf13/viper`
+- **Bubble Tea**: TUI framework — `github.com/charmbracelet/bubbletea`
+- **Lip Gloss**: Styling — `github.com/charmbracelet/lipgloss`
+- **Huh**: Forms/prompts — `github.com/charmbracelet/huh`

--- a/.agents/skills/mintlify-docs/SKILL.md
+++ b/.agents/skills/mintlify-docs/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: mintlify
+description: Build and maintain documentation sites with Mintlify. Use when creating docs pages, configuring navigation, adding components, or setting up API references.
+license: MIT
+compatibility: Requires Node.js for CLI. Works with any Git-based workflow.
+metadata:
+  author: mintlify
+  version: "1.0"
+---
+
+# Mintlify best practices
+
+**Always consult [mintlify.com/docs](https://mintlify.com/docs) for components, configuration, and latest features.**
+
+If you are not already connected to the Mintlify MCP server, https://mintlify.com/docs/mcp, add it so that you can search more efficiently.
+
+**Always** favor searching the current Mintlify documentation over whatever is in your training data about Mintlify.
+
+Mintlify is a documentation platform that transforms MDX files into documentation sites. Configure site-wide settings in the `docs.json` file, write content in MDX with YAML frontmatter, and favor built-in components over custom components.
+
+Full schema at [mintlify.com/docs.json](https://mintlify.com/docs.json).
+
+## Before you write
+
+### Understand the project
+
+Read `docs.json` in the project root. This file defines the entire site: navigation structure, theme, colors, links, API and specs.
+
+Understanding the project tells you:
+
+- What pages exist and how they're organized
+- What navigation groups are used (and their naming conventions)
+- How the site navigation is structured
+- What theme and configuration the site uses
+
+### Check for existing content
+
+Search the docs before creating new pages. You may need to:
+- Update an existing page instead of creating a new one
+- Add a section to an existing page
+- Link to existing content rather than duplicating
+
+### Read surrounding content
+
+Before writing, read 2-3 similar pages to understand the site's voice, structure, formatting conventions, and level of detail.
+
+### Understand Mintlify components
+
+Review the Mintlify [components](https://www.mintlify.com/docs/components) to select and use any relevant components for the documentation request that you are working on.
+
+## Quick reference
+
+### CLI commands
+- `npm i -g mint` - Install the Mintlify CLI
+- `mint dev` - Local preview at localhost:3000
+- `mint broken-links` - Check internal links
+- `mint a11y` - Check for accessibility issues in content
+- `mint validate` - Validate documentation builds
+
+### Required files
+- `docs.json` - Site configuration (navigation, theme, integrations, etc.). See [global settings](https://mintlify.com/docs/settings/global) for all options.
+- `*.mdx` files - Documentation pages with YAML frontmatter
+
+### Example file structure
+```
+project/
+├── docs.json           # Site configuration
+├── introduction.mdx
+├── quickstart.mdx
+├── guides/
+│   └── example.mdx
+├── openapi.yml         # API specification
+├── images/             # Static assets
+│   └── example.png
+└── snippets/           # Reusable components
+    └── component.jsx
+```
+
+## Page frontmatter
+
+Every page requires `title` in its frontmatter. Include `description` for SEO and navigation.
+
+```yaml
+---
+title: "Clear, descriptive title"
+description: "Concise summary for SEO and navigation."
+---
+```
+
+Optional frontmatter fields:
+- `sidebarTitle`: Short title for sidebar navigation.
+- `icon`: Lucide or Font Awesome icon name, URL, or file path.
+- `tag`: Label next to the page title in the sidebar (for example, "NEW").
+- `mode`: Page layout mode (`default`, `wide`, `custom`).
+- `keywords`: Array of terms related to the page content for local search and SEO.
+- Any custom YAML fields for use with personalization or conditional content.
+
+## File conventions
+
+- Match existing naming patterns in the directory
+- If there are no existing files or inconsistent file naming patterns, use kebab-case: `getting-started.mdx`, `api-reference.mdx`
+- Use root-relative paths without file extensions for internal links: `/getting-started/quickstart`
+- Do not use relative paths (`../`) or absolute URLs for internal pages
+- When you create a new page, add it to `docs.json` navigation or it won't appear in the sidebar
+
+## Organize content
+
+When a user asks about anything related to site-wide configurations, start by understanding the [global settings](https://www.mintlify.com/docs/organize/settings). See if a setting in the `docs.json` file can be updated to achieve what the user wants.
+
+### Navigation
+
+The `navigation` property in `docs.json` controls site structure. Choose one primary pattern at the root level, then nest others within it.
+
+**Choose your primary pattern:**
+
+| Pattern | When to use |
+|---------|-------------|
+| **Groups** | Default. Single audience, straightforward hierarchy |
+| **Tabs** | Distinct sections with different audiences (Guides vs API Reference) or content types |
+| **Anchors** | Want persistent section links at sidebar top. Good for separating docs from external resources |
+| **Dropdowns** | Multiple doc sections users switch between, but not distinct enough for tabs |
+| **Products** | Multi-product company with separate documentation per product |
+| **Versions** | Maintaining docs for multiple API/product versions simultaneously |
+| **Languages** | Localized content |
+
+**Within your primary pattern:**
+
+- **Groups** - Organize related pages. Can nest groups within groups, but keep hierarchy shallow
+- **Menus** - Add dropdown navigation within tabs for quick jumps to specific pages
+- **`expanded: false`** - Collapse nested groups by default. Use for reference sections users browse selectively
+- **`openapi`** - Auto-generate pages from OpenAPI spec. Add at group/tab level to inherit
+
+**Common combinations:**
+- Tabs containing groups (most common for docs with API reference)
+- Products containing tabs (multi-product SaaS)
+- Versions containing tabs (versioned API docs)
+- Anchors containing groups (simple docs with external resource links)
+
+### Links and paths
+
+- **Internal links:** Root-relative, no extension: `/getting-started/quickstart`
+- **Images:** Store in `/images`, reference as `/images/example.png`
+- **External links:** Use full URLs, they open in new tabs automatically
+
+## Customize docs sites
+
+**What to customize where:**
+- **Brand colors, fonts, logo** → `docs.json`. See [global settings](https://mintlify.com/docs/settings/global)
+- **Component styling, layout tweaks** → `custom.css` at project root
+- **Dark mode** → Enabled by default. Only disable with `"appearance": "light"` in `docs.json` if brand requires it
+
+Start with `docs.json`. Only add `custom.css` when you need styling that config doesn't support.
+
+## Write content
+
+### Components
+
+The [components overview](https://mintlify.com/docs/components) organizes all components by purpose: structure content, draw attention, show/hide content, document APIs, link to pages, and add visual context. Start there to find the right component.
+
+**Common decision points:**
+
+| Need | Use |
+|------|-----|
+| Hide optional details | `<Accordion>` |
+| Long code examples | `<Expandable>` |
+| User chooses one option | `<Tabs>` |
+| Linked navigation cards | `<Card>` in `<Columns>` |
+| Sequential instructions | `<Steps>` |
+| Code in multiple languages | `<CodeGroup>` |
+| API parameters | `<ParamField>` |
+| API response fields | `<ResponseField>` |
+
+**Callouts by severity:**
+- `<Note>` - Supplementary info, safe to skip
+- `<Info>` - Helpful context such as permissions
+- `<Tip>` - Recommendations or best practices
+- `<Warning>` - Potentially destructive actions
+- `<Check>` - Success confirmation
+
+### Reusable content
+
+**When to use snippets:**
+- Exact content appears on more than one page
+- Complex components you want to maintain in one place
+- Shared content across teams/repos
+
+**When NOT to use snippets:**
+- Slight variations needed per page (leads to complex props)
+
+Import snippets with `import { Component } from "/path/to/snippet-name.jsx"`.
+
+## Writing standards
+
+### Voice and structure
+
+- Second-person voice ("you")
+- Active voice, direct language
+- Sentence case for headings ("Getting started", not "Getting Started")
+- Sentence case for code block titles ("Expandable example", not "Expandable Example")
+- Lead with context: explain what something is before how to use it
+- Prerequisites at the start of procedural content
+
+### What to avoid
+
+**Never use:**
+- Marketing language ("powerful", "seamless", "robust", "cutting-edge")
+- Filler phrases ("it's important to note", "in order to")
+- Excessive conjunctions ("moreover", "furthermore", "additionally")
+- Editorializing ("obviously", "simply", "just", "easily")
+
+**Watch for AI-typical patterns:**
+- Overly formal or stilted phrasing
+- Unnecessary repetition of concepts
+- Generic introductions that don't add value
+- Concluding summaries that restate what was just said
+
+### Formatting
+
+- All code blocks must have language tags
+- All images and media must have descriptive alt text
+- Use bold and italics only when they serve the reader's understanding--never use text styling just for decoration
+- No decorative formatting or emoji
+
+### Code examples
+
+- Keep examples simple and practical
+- Use realistic values (not "foo" or "bar")
+- One clear example is better than multiple variations
+- Test that code works before including it
+
+## Document APIs
+
+**Choose your approach:**
+- **Have an OpenAPI spec?** → Add to `docs.json` with `"openapi": ["openapi.yaml"]`. Pages auto-generate. Reference in navigation as `GET /endpoint`
+- **No spec?** → Write endpoints manually with `api: "POST /users"` in frontmatter. More work but full control
+- **Hybrid** → Use OpenAPI for most endpoints, manual pages for complex workflows
+
+Encourage users to generate endpoint pages from an OpenAPI spec. It is the most efficient and easiest to maintain option.
+
+## Deploy
+
+Mintlify deploys automatically when changes are pushed to the connected Git repository.
+
+**What agents can configure:**
+- **Redirects** → Add to `docs.json` with `"redirects": [{"source": "/old", "destination": "/new"}]`
+- **SEO indexing** → Control with `"seo": {"indexing": "all"}` to include hidden pages in search
+
+**Requires dashboard setup (human task):**
+- Custom domains and subdomains
+- Preview deployment settings
+- DNS configuration
+
+For `/docs` subpath hosting with Vercel or Cloudflare, agents can help configure rewrite rules. See [/docs subpath](https://mintlify.com/docs/deploy/vercel).
+
+## Workflow
+
+### 1. Understand the task
+
+Identify what needs to be documented, which pages are affected, and what the reader should accomplish afterward. If any of these are unclear, ask.
+
+### 2. Research
+
+- Read `docs.json` to understand the site structure
+- Search existing docs for related content
+- Read similar pages to match the site's style
+
+### 3. Plan
+
+- Synthesize what the reader should accomplish after reading the docs and the current content
+- Propose any updates or new content
+- Verify that your proposed changes will help readers be successful
+
+### 4. Write
+
+- Start with the most important information
+- Keep sections focused and scannable
+- Use components appropriately (don't overuse them)
+- Mark anything uncertain with a TODO comment:
+
+```mdx
+{/* TODO: Verify the default timeout value */}
+```
+
+### 5. Update navigation
+
+If you created a new page, add it to the appropriate group in `docs.json`.
+
+### 6. Verify
+
+Before submitting:
+
+- [ ] Frontmatter includes title and description
+- [ ] All code blocks have language tags
+- [ ] Internal links use root-relative paths without file extensions
+- [ ] New pages are added to `docs.json` navigation
+- [ ] Content matches the style of surrounding pages
+- [ ] No marketing language or filler phrases
+- [ ] TODOs are clearly marked for anything uncertain
+- [ ] Run `mint broken-links` to check links
+- [ ] Run `mint validate` to find any errors
+
+## Edge cases
+
+### Migrations
+
+If a user asks about migrating to Mintlify, ask if they are using ReadMe or Docusaurus. If they are, use the [@mintlify/scraping](https://www.npmjs.com/package/@mintlify/scraping) CLI to migrate content. If they are using a different platform to host their documentation, help them manually convert their content to MDX pages using Mintlify components.
+
+### Hidden pages
+
+Any page that is not included in the `docs.json` navigation is hidden. Use hidden pages for content that should be accessible by URL or indexed for the assistant or search, but not discoverable through the sidebar navigation.
+
+### Exclude pages
+
+The `.mintignore` file is used to exclude files from a documentation repository from being processed.
+
+## Common gotchas
+
+1. **Component imports** - JSX components need explicit import, MDX components don't
+2. **Frontmatter required** - Every MDX file needs `title` at minimum
+3. **Code block language** - Always specify language identifier
+4. **Never use `mint.json`** - `mint.json` is deprecated. Only ever use `docs.json`
+
+## Resources
+
+- [Documentation](https://mintlify.com/docs)
+- [Configuration schema](https://mintlify.com/docs.json)
+- [Feature requests](https://github.com/orgs/mintlify/discussions/categories/feature-requests)
+- [Bugs and feedback](https://github.com/orgs/mintlify/discussions/categories/bugs-feedback)

--- a/.agents/skills/mintlify/SKILL.md
+++ b/.agents/skills/mintlify/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: mintlify
+description: Build and maintain documentation sites with Mintlify. Use when creating docs pages, configuring navigation, adding components, or setting up API references.
+license: MIT
+compatibility: Requires Node.js for CLI. Works with any Git-based workflow.
+metadata:
+  author: mintlify
+  version: "1.0"
+---
+
+# Mintlify best practices
+
+**Always consult [mintlify.com/docs](https://mintlify.com/docs) for components, configuration, and latest features.**
+
+If you are not already connected to the Mintlify MCP server, https://mintlify.com/docs/mcp, add it so that you can search more efficiently.
+
+**Always** favor searching the current Mintlify documentation over whatever is in your training data about Mintlify.
+
+Mintlify is a documentation platform that transforms MDX files into documentation sites. Configure site-wide settings in the `docs.json` file, write content in MDX with YAML frontmatter, and favor built-in components over custom components.
+
+Full schema at [mintlify.com/docs.json](https://mintlify.com/docs.json).
+
+## Before you write
+
+### Understand the project
+
+Read `docs.json` in the project root. This file defines the entire site: navigation structure, theme, colors, links, API and specs.
+
+Understanding the project tells you:
+
+- What pages exist and how they're organized
+- What navigation groups are used (and their naming conventions)
+- How the site navigation is structured
+- What theme and configuration the site uses
+
+### Check for existing content
+
+Search the docs before creating new pages. You may need to:
+- Update an existing page instead of creating a new one
+- Add a section to an existing page
+- Link to existing content rather than duplicating
+
+### Read surrounding content
+
+Before writing, read 2-3 similar pages to understand the site's voice, structure, formatting conventions, and level of detail.
+
+### Understand Mintlify components
+
+Review the Mintlify [components](https://www.mintlify.com/docs/components) to select and use any relevant components for the documentation request that you are working on.
+
+## Quick reference
+
+### CLI commands
+- `npm i -g mint` - Install the Mintlify CLI
+- `mint dev` - Local preview at localhost:3000
+- `mint broken-links` - Check internal links
+- `mint a11y` - Check for accessibility issues in content
+- `mint validate` - Validate documentation builds
+
+### Required files
+- `docs.json` - Site configuration (navigation, theme, integrations, etc.). See [global settings](https://mintlify.com/docs/settings/global) for all options.
+- `*.mdx` files - Documentation pages with YAML frontmatter
+
+### Example file structure
+```
+project/
+├── docs.json           # Site configuration
+├── introduction.mdx
+├── quickstart.mdx
+├── guides/
+│   └── example.mdx
+├── openapi.yml         # API specification
+├── images/             # Static assets
+│   └── example.png
+└── snippets/           # Reusable components
+    └── component.jsx
+```
+
+## Page frontmatter
+
+Every page requires `title` in its frontmatter. Include `description` for SEO and navigation.
+
+```yaml
+---
+title: "Clear, descriptive title"
+description: "Concise summary for SEO and navigation."
+---
+```
+
+Optional frontmatter fields:
+- `sidebarTitle`: Short title for sidebar navigation.
+- `icon`: Lucide or Font Awesome icon name, URL, or file path.
+- `tag`: Label next to the page title in the sidebar (for example, "NEW").
+- `mode`: Page layout mode (`default`, `wide`, `custom`).
+- `keywords`: Array of terms related to the page content for local search and SEO.
+- Any custom YAML fields for use with personalization or conditional content.
+
+## File conventions
+
+- Match existing naming patterns in the directory
+- If there are no existing files or inconsistent file naming patterns, use kebab-case: `getting-started.mdx`, `api-reference.mdx`
+- Use root-relative paths without file extensions for internal links: `/getting-started/quickstart`
+- Do not use relative paths (`../`) or absolute URLs for internal pages
+- When you create a new page, add it to `docs.json` navigation or it won't appear in the sidebar
+
+## Organize content
+
+When a user asks about anything related to site-wide configurations, start by understanding the [global settings](https://www.mintlify.com/docs/organize/settings). See if a setting in the `docs.json` file can be updated to achieve what the user wants.
+
+### Navigation
+
+The `navigation` property in `docs.json` controls site structure. Choose one primary pattern at the root level, then nest others within it.
+
+**Choose your primary pattern:**
+
+| Pattern | When to use |
+|---------|-------------|
+| **Groups** | Default. Single audience, straightforward hierarchy |
+| **Tabs** | Distinct sections with different audiences (Guides vs API Reference) or content types |
+| **Anchors** | Want persistent section links at sidebar top. Good for separating docs from external resources |
+| **Dropdowns** | Multiple doc sections users switch between, but not distinct enough for tabs |
+| **Products** | Multi-product company with separate documentation per product |
+| **Versions** | Maintaining docs for multiple API/product versions simultaneously |
+| **Languages** | Localized content |
+
+**Within your primary pattern:**
+
+- **Groups** - Organize related pages. Can nest groups within groups, but keep hierarchy shallow
+- **Menus** - Add dropdown navigation within tabs for quick jumps to specific pages
+- **`expanded: false`** - Collapse nested groups by default. Use for reference sections users browse selectively
+- **`openapi`** - Auto-generate pages from OpenAPI spec. Add at group/tab level to inherit
+
+**Common combinations:**
+- Tabs containing groups (most common for docs with API reference)
+- Products containing tabs (multi-product SaaS)
+- Versions containing tabs (versioned API docs)
+- Anchors containing groups (simple docs with external resource links)
+
+### Links and paths
+
+- **Internal links:** Root-relative, no extension: `/getting-started/quickstart`
+- **Images:** Store in `/images`, reference as `/images/example.png`
+- **External links:** Use full URLs, they open in new tabs automatically
+
+## Customize docs sites
+
+**What to customize where:**
+- **Brand colors, fonts, logo** → `docs.json`. See [global settings](https://mintlify.com/docs/settings/global)
+- **Component styling, layout tweaks** → `custom.css` at project root
+- **Dark mode** → Enabled by default. Only disable with `"appearance": "light"` in `docs.json` if brand requires it
+
+Start with `docs.json`. Only add `custom.css` when you need styling that config doesn't support.
+
+## Write content
+
+### Components
+
+The [components overview](https://mintlify.com/docs/components) organizes all components by purpose: structure content, draw attention, show/hide content, document APIs, link to pages, and add visual context. Start there to find the right component.
+
+**Common decision points:**
+
+| Need | Use |
+|------|-----|
+| Hide optional details | `<Accordion>` |
+| Long code examples | `<Expandable>` |
+| User chooses one option | `<Tabs>` |
+| Linked navigation cards | `<Card>` in `<Columns>` |
+| Sequential instructions | `<Steps>` |
+| Code in multiple languages | `<CodeGroup>` |
+| API parameters | `<ParamField>` |
+| API response fields | `<ResponseField>` |
+
+**Callouts by severity:**
+- `<Note>` - Supplementary info, safe to skip
+- `<Info>` - Helpful context such as permissions
+- `<Tip>` - Recommendations or best practices
+- `<Warning>` - Potentially destructive actions
+- `<Check>` - Success confirmation
+
+### Reusable content
+
+**When to use snippets:**
+- Exact content appears on more than one page
+- Complex components you want to maintain in one place
+- Shared content across teams/repos
+
+**When NOT to use snippets:**
+- Slight variations needed per page (leads to complex props)
+
+Import snippets with `import { Component } from "/path/to/snippet-name.jsx"`.
+
+## Writing standards
+
+### Voice and structure
+
+- Second-person voice ("you")
+- Active voice, direct language
+- Sentence case for headings ("Getting started", not "Getting Started")
+- Sentence case for code block titles ("Expandable example", not "Expandable Example")
+- Lead with context: explain what something is before how to use it
+- Prerequisites at the start of procedural content
+
+### What to avoid
+
+**Never use:**
+- Marketing language ("powerful", "seamless", "robust", "cutting-edge")
+- Filler phrases ("it's important to note", "in order to")
+- Excessive conjunctions ("moreover", "furthermore", "additionally")
+- Editorializing ("obviously", "simply", "just", "easily")
+
+**Watch for AI-typical patterns:**
+- Overly formal or stilted phrasing
+- Unnecessary repetition of concepts
+- Generic introductions that don't add value
+- Concluding summaries that restate what was just said
+
+### Formatting
+
+- All code blocks must have language tags
+- All images and media must have descriptive alt text
+- Use bold and italics only when they serve the reader's understanding--never use text styling just for decoration
+- No decorative formatting or emoji
+
+### Code examples
+
+- Keep examples simple and practical
+- Use realistic values (not "foo" or "bar")
+- One clear example is better than multiple variations
+- Test that code works before including it
+
+## Document APIs
+
+**Choose your approach:**
+- **Have an OpenAPI spec?** → Add to `docs.json` with `"openapi": ["openapi.yaml"]`. Pages auto-generate. Reference in navigation as `GET /endpoint`
+- **No spec?** → Write endpoints manually with `api: "POST /users"` in frontmatter. More work but full control
+- **Hybrid** → Use OpenAPI for most endpoints, manual pages for complex workflows
+
+Encourage users to generate endpoint pages from an OpenAPI spec. It is the most efficient and easiest to maintain option.
+
+## Deploy
+
+Mintlify deploys automatically when changes are pushed to the connected Git repository.
+
+**What agents can configure:**
+- **Redirects** → Add to `docs.json` with `"redirects": [{"source": "/old", "destination": "/new"}]`
+- **SEO indexing** → Control with `"seo": {"indexing": "all"}` to include hidden pages in search
+
+**Requires dashboard setup (human task):**
+- Custom domains and subdomains
+- Preview deployment settings
+- DNS configuration
+
+For `/docs` subpath hosting with Vercel or Cloudflare, agents can help configure rewrite rules. See [/docs subpath](https://mintlify.com/docs/deploy/vercel).
+
+## Workflow
+
+### 1. Understand the task
+
+Identify what needs to be documented, which pages are affected, and what the reader should accomplish afterward. If any of these are unclear, ask.
+
+### 2. Research
+
+- Read `docs.json` to understand the site structure
+- Search existing docs for related content
+- Read similar pages to match the site's style
+
+### 3. Plan
+
+- Synthesize what the reader should accomplish after reading the docs and the current content
+- Propose any updates or new content
+- Verify that your proposed changes will help readers be successful
+
+### 4. Write
+
+- Start with the most important information
+- Keep sections focused and scannable
+- Use components appropriately (don't overuse them)
+- Mark anything uncertain with a TODO comment:
+
+```mdx
+{/* TODO: Verify the default timeout value */}
+```
+
+### 5. Update navigation
+
+If you created a new page, add it to the appropriate group in `docs.json`.
+
+### 6. Verify
+
+Before submitting:
+
+- [ ] Frontmatter includes title and description
+- [ ] All code blocks have language tags
+- [ ] Internal links use root-relative paths without file extensions
+- [ ] New pages are added to `docs.json` navigation
+- [ ] Content matches the style of surrounding pages
+- [ ] No marketing language or filler phrases
+- [ ] TODOs are clearly marked for anything uncertain
+- [ ] Run `mint broken-links` to check links
+- [ ] Run `mint validate` to find any errors
+
+## Edge cases
+
+### Migrations
+
+If a user asks about migrating to Mintlify, ask if they are using ReadMe or Docusaurus. If they are, use the [@mintlify/scraping](https://www.npmjs.com/package/@mintlify/scraping) CLI to migrate content. If they are using a different platform to host their documentation, help them manually convert their content to MDX pages using Mintlify components.
+
+### Hidden pages
+
+Any page that is not included in the `docs.json` navigation is hidden. Use hidden pages for content that should be accessible by URL or indexed for the assistant or search, but not discoverable through the sidebar navigation.
+
+### Exclude pages
+
+The `.mintignore` file is used to exclude files from a documentation repository from being processed.
+
+## Common gotchas
+
+1. **Component imports** - JSX components need explicit import, MDX components don't
+2. **Frontmatter required** - Every MDX file needs `title` at minimum
+3. **Code block language** - Always specify language identifier
+4. **Never use `mint.json`** - `mint.json` is deprecated. Only ever use `docs.json`
+
+## Resources
+
+- [Documentation](https://mintlify.com/docs)
+- [Configuration schema](https://mintlify.com/docs.json)
+- [Feature requests](https://github.com/orgs/mintlify/discussions/categories/feature-requests)
+- [Bugs and feedback](https://github.com/orgs/mintlify/discussions/categories/bugs-feedback)

--- a/docs/.mintlify/skills/buttons/SKILL.md
+++ b/docs/.mintlify/skills/buttons/SKILL.md
@@ -1,0 +1,1 @@
+../../../../.agents/skills/buttons/SKILL.md

--- a/docs/ai/skill-md.mdx
+++ b/docs/ai/skill-md.mdx
@@ -1,0 +1,84 @@
+---
+title: "skill.md"
+description: "Install the Buttons agent skill into Claude Code, Cursor, and other AI tools."
+icon: "brain"
+---
+
+`skill.md` is a machine-readable file that tells AI agents what your product can do, what inputs it needs, and what constraints apply. While [llms.txt](/ai/llms-txt) is a documentation index and [MCP](/ai/mcp-server) is a search API, `skill.md` is a **capability summary** — the agent loads it once and knows how to use Buttons.
+
+## Install the Buttons skill
+
+```bash
+npx skills add https://buttons.mintlify.app
+```
+
+This fetches the Buttons skill from the hosted discovery endpoint and installs it into your agent's skill directory. The skill includes every command, flag, the JSON output contract, argument types, and common usage patterns — all auto-generated from the Cobra command tree.
+
+## Discovery endpoints
+
+Mintlify hosts the skill at two standard endpoints:
+
+| Endpoint | URL |
+|---|---|
+| **Agent-skills 0.2.0** (recommended) | `https://buttons.mintlify.app/.well-known/agent-skills/index.json` |
+| **Individual skill** | `https://buttons.mintlify.app/.well-known/agent-skills/buttons/SKILL.md` |
+| **Legacy format** | `https://buttons.mintlify.app/.well-known/skills/index.json` |
+
+The agent-skills endpoint includes SHA256 integrity verification so tools can verify the skill hasn't been tampered with.
+
+## Manual installation
+
+If you prefer to install the skill manually instead of using `npx skills add`:
+
+<Tabs>
+  <Tab title="Claude Code">
+    The Buttons skill is already in the repo at `.agents/skills/buttons/SKILL.md`. Claude Code picks it up automatically when working in the Buttons repo.
+
+    For other repos, copy the skill:
+    ```bash
+    mkdir -p .agents/skills/buttons
+    curl -fsSL https://buttons.mintlify.app/.well-known/agent-skills/buttons/SKILL.md \
+      -o .agents/skills/buttons/SKILL.md
+    ```
+  </Tab>
+  <Tab title="Cursor / Windsurf">
+    Download the skill file and place it where your agent reads skills:
+    ```bash
+    curl -fsSL https://buttons.mintlify.app/.well-known/agent-skills/buttons/SKILL.md \
+      -o SKILL.md
+    ```
+    Then reference it in your agent's configuration.
+  </Tab>
+</Tabs>
+
+## What the skill contains
+
+The Buttons skill is auto-generated from the Cobra command tree via `go run ./internal/tools/skillgen`. It follows the [AgentSkills specification](https://agentskills.io/specification) and includes:
+
+- **YAML frontmatter** — name, description, license, compatibility, metadata
+- **Quick reference** — copy-paste examples for create, press, list, history, delete
+- **Full command reference** — every command and subcommand with flags table
+- **JSON output contract** — success/error shapes and all error codes
+- **Argument types** — string, int, bool with env var and template injection rules
+- **Button sources** — code, HTTP, file, agent with runtime details
+- **Common patterns** — lifecycle, agent context, local dev server examples
+- **Storage layout** — `~/.buttons/` directory structure
+
+## Keeping the skill current
+
+The skill auto-updates through two mechanisms:
+
+1. **In the repo** — the [docs-sync workflow](/.github/workflows/docs-sync.yml) regenerates `SKILL.md` whenever CLI code changes on main and opens a PR with updates
+2. **On Mintlify** — the hosted skill file updates whenever the docs deploy
+
+You never have to manually maintain the skill content. Change a command or flag in `cmd/*.go`, and the skill updates automatically.
+
+## skill.md vs llms.txt vs MCP
+
+| | skill.md | [llms.txt](/ai/llms-txt) | [MCP server](/ai/mcp-server) |
+|---|---|---|---|
+| **What it is** | Capability summary | Documentation index | Real-time search API |
+| **Agent loads it** | Once at session start | Once for discovery | On demand per query |
+| **Best for** | Teaching an agent how to use Buttons | RAG pipelines, embedding | Deep questions, page lookup |
+| **Size** | ~300 lines | ~50 lines (links only) | N/A (API) |
+| **Install** | `npx skills add <url>` | Fetch the URL | `claude mcp add` |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,7 +58,8 @@
             "group": "Coding agent",
             "pages": [
               "ai/mcp-server",
-              "ai/llms-txt"
+              "ai/llms-txt",
+              "ai/skill-md"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,6 +15,7 @@
         "groups": [
           {
             "group": "Getting started",
+            "public": true,
             "pages": [
               "index",
               "installation",
@@ -23,6 +24,7 @@
           },
           {
             "group": "Button types",
+            "public": true,
             "pages": [
               "buttons/code",
               "buttons/http-api",
@@ -32,6 +34,7 @@
           },
           {
             "group": "Concepts",
+            "public": true,
             "pages": [
               "concepts/arguments",
               "concepts/json-output",
@@ -41,6 +44,7 @@
           },
           {
             "group": "Deployment",
+            "public": true,
             "pages": [
               "deployment/docker",
               "deployment/install-script"
@@ -48,6 +52,7 @@
           },
           {
             "group": "Security",
+            "public": true,
             "pages": [
               "security/overview",
               "security/ssrf-protection",
@@ -56,6 +61,7 @@
           },
           {
             "group": "Coding agent",
+            "public": true,
             "pages": [
               "ai/mcp-server",
               "ai/llms-txt",
@@ -69,6 +75,7 @@
         "groups": [
           {
             "group": "Core commands",
+            "public": true,
             "pages": [
               "cli/buttons",
               "cli/buttons_create",
@@ -81,6 +88,7 @@
           },
           {
             "group": "Workflow commands",
+            "public": true,
             "expanded": false,
             "pages": [
               "cli/buttons_drawer",
@@ -92,6 +100,7 @@
           },
           {
             "group": "Configuration commands",
+            "public": true,
             "expanded": false,
             "pages": [
               "cli/buttons_batteries",
@@ -102,6 +111,7 @@
           },
           {
             "group": "Other",
+            "public": true,
             "expanded": false,
             "pages": [
               "cli/buttons_board",

--- a/internal/tools/skillgen/main.go
+++ b/internal/tools/skillgen/main.go
@@ -43,6 +43,23 @@ func main() {
 }
 
 func writeSkill(b *strings.Builder, root *cobra.Command) {
+	// YAML frontmatter per the AgentSkills specification
+	// (https://agentskills.io/specification).
+	b.WriteString("---\n")
+	b.WriteString("name: buttons\n")
+	b.WriteString("description: |\n")
+	b.WriteString("  Deterministic workflow engine for AI agents. Create and press\n")
+	b.WriteString("  reusable buttons (shell scripts, HTTP APIs, agent instructions)\n")
+	b.WriteString("  with typed inputs and structured JSON output. Use when wrapping\n")
+	b.WriteString("  repeatable actions, calling HTTP endpoints, or building multi-step\n")
+	b.WriteString("  workflows where each step is a named, typed, pressable button.\n")
+	b.WriteString("license: Apache-2.0\n")
+	b.WriteString("compatibility: Requires the buttons CLI binary installed (go install github.com/autonoco/buttons@latest or curl installer).\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  author: autonoco\n")
+	b.WriteString("  repository: https://github.com/autonoco/buttons\n")
+	b.WriteString("---\n\n")
+
 	b.WriteString("# Buttons CLI\n\n")
 	b.WriteString("Deterministic workflow engine for AI agents. Create reusable, composable actions with typed inputs and structured JSON output.\n\n")
 


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Buttons SKILL.md now follows the AgentSkills spec

The generated SKILL.md was missing the required YAML frontmatter per https://agentskills.io/specification. Now includes:

```yaml
---
name: buttons
description: |
  Deterministic workflow engine for AI agents...
license: Apache-2.0
compatibility: Requires the buttons CLI binary installed...
metadata:
  author: autonoco
  repository: https://github.com/autonoco/buttons
---
```

The skillgen tool (`internal/tools/skillgen`) is updated to emit this frontmatter automatically.

### 2. All agent skills committed to the repo

Six skills now ship with the repo so anyone who clones gets the full skill set:

| Skill | What it teaches |
|---|---|
| `buttons` | Buttons CLI reference (auto-generated from Cobra) |
| `cobra` | Cobra CLI framework patterns + full guide |
| `bubble-tea` | Bubble Tea TUI framework + full guide |
| `mintlify` | Mintlify docs configuration |
| `mintlify-docs` | Mintlify content writing |
| `cli-design-guidelines` | CLI UX best practices from clig.dev |

🤖 Generated with [Claude Code](https://claude.com/claude-code)