### PR TITLE
feat(cli): buttons init for project-local .buttons directory

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a project-local .buttons directory",
+	Long: `Create a .buttons/ directory in the current working directory so
+buttons are scoped to this project instead of the global ~/.buttons/.
+
+Project-local buttons are discovered automatically: any buttons
+command run inside this directory (or a subdirectory) will use the
+local .buttons/ folder. Buttons created here won't appear when you
+run commands from other projects.
+
+The global ~/.buttons/ is still used as a fallback when no project-
+local .buttons/ exists in the directory tree.
+
+A .gitignore is created inside .buttons/ to exclude run history
+(pressed/) from version control while keeping button specs, code
+files, and agent instructions committed.
+
+Examples:
+  cd my-project
+  buttons init
+  buttons create deploy --code './scripts/deploy.sh' --arg env:string:required
+  # → button lives in my-project/.buttons/buttons/deploy/`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot determine working directory: %w", err)
+		}
+
+		buttonsDir := filepath.Join(cwd, ".buttons")
+
+		if info, err := os.Stat(buttonsDir); err == nil && info.IsDir() {
+			if jsonOutput {
+				return config.WriteJSON(map[string]any{
+					"path":    buttonsDir,
+					"created": false,
+					"message": ".buttons already exists",
+				})
+			}
+			fmt.Fprintf(os.Stderr, ".buttons/ already exists in %s\n", cwd)
+			return nil
+		}
+
+		dirs := []string{
+			buttonsDir,
+			filepath.Join(buttonsDir, "buttons"),
+			filepath.Join(buttonsDir, "drawers"),
+		}
+		for _, d := range dirs {
+			if err := os.MkdirAll(d, 0700); err != nil {
+				return fmt.Errorf("failed to create %s: %w", d, err)
+			}
+		}
+
+		// Create a .gitignore inside .buttons/ that excludes run history
+		// but keeps button specs committed.
+		gitignore := `# Button specs, code files, and AGENT.md are committed.
+# Run history is per-machine and excluded.
+buttons/*/pressed/
+`
+		gitignorePath := filepath.Join(buttonsDir, ".gitignore")
+		if err := os.WriteFile(gitignorePath, []byte(gitignore), 0600); err != nil {
+			return fmt.Errorf("failed to write .gitignore: %w", err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{
+				"path":    buttonsDir,
+				"created": true,
+			})
+		}
+
+		fmt.Fprintf(os.Stderr, "Initialized .buttons/ in %s\n", cwd)
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "  Buttons created here are project-local and can be committed to git.\n")
+		fmt.Fprintf(os.Stderr, "  Run history (pressed/) is gitignored automatically.\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "  Try: buttons create hello --code 'echo \"Hello from %s\"'\n", filepath.Base(cwd))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/internal/button/name.go
+++ b/internal/button/name.go
@@ -25,7 +25,7 @@ var reservedNames = map[string]bool{
 	"create": true, "press": true, "list": true, "rm": true,
 	"board": true, "drawer": true, "batteries": true, "smash": true,
 	"store": true, "history": true, "help": true, "version": true,
-	"mcp": true, "serve": true, "update": true, "delete": true,
+	"mcp": true, "serve": true, "update": true, "delete": true, "init": true,
 }
 
 func IsReservedName(name string) bool {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -9,15 +9,59 @@ import (
 
 const dataDirName = ".buttons"
 
+// DataDir returns the active buttons data directory. Priority:
+//
+//  1. BUTTONS_HOME env var (explicit override)
+//  2. .buttons/ in the current directory or any parent (project-local)
+//  3. ~/.buttons/ (global fallback)
+//
+// Project-local discovery walks up from os.Getwd() looking for a
+// .buttons/ directory, the same way git walks up looking for .git/.
+// Use `buttons init` to create a project-local .buttons/ folder.
 func DataDir() (string, error) {
 	if override := os.Getenv("BUTTONS_HOME"); override != "" {
 		return override, nil
+	}
+	if projectDir, err := findProjectDir(); err == nil {
+		return projectDir, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("could not determine home directory: %w", err)
 	}
 	return filepath.Join(home, dataDirName), nil
+}
+
+// findProjectDir walks up from the current working directory looking
+// for a .buttons/ directory. Returns the path if found, or an error
+// if none exists between CWD and the filesystem root.
+func findProjectDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		candidate := filepath.Join(dir, dataDirName)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("no %s directory found", dataDirName)
+}
+
+// IsProjectLocal returns true if the active data directory is a
+// project-local .buttons/ (as opposed to the global ~/.buttons/).
+func IsProjectLocal() bool {
+	if os.Getenv("BUTTONS_HOME") != "" {
+		return false
+	}
+	_, err := findProjectDir()
+	return err == nil
 }
 
 func ButtonsDir() (string, error) {


### PR DESCRIPTION
## Summary

Adds project-scoped button support. Buttons can now live alongside your code instead of only in the global ~/.buttons/.

### Usage

```bash
cd my-project
buttons init           # creates .buttons/ in current directory
buttons create deploy --code './deploy.sh' --arg env:string:required
buttons press deploy --arg env=staging
```

Buttons created here are project-local — they don't appear when you run commands from other projects, and they can be committed to git.

### How discovery works

Same pattern as git finding .git/:

1. **BUTTONS_HOME env var** — highest priority, explicit override
2. **.buttons/ in CWD or any parent** — walk up until found
3. **~/.buttons/** — global fallback

### What buttons init creates

```
.buttons/
  buttons/          # button specs
  drawers/          # drawer specs (Phase 2)
  .gitignore        # excludes pressed/ (run history)
```

The .gitignore inside .buttons/ keeps run history (pressed/*.json) out of version control while letting button specs, code files, and AGENT.md be committed and shared.

### JSON output

```bash
$ buttons init --json
{"ok": true, "data": {"path": "/path/to/.buttons", "created": true}}
```

## Test plan

- [x] `go build` + `go test` — all pass
- [x] `gosec` — 0 issues
- [x] Smoke test: init → create → list in a temp directory — buttons saved to project-local .buttons/
- [x] Global fallback still works when no .buttons/ exists in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)