### PR TITLE
refactor: scaffold-by-default on create, drop --code-stdin

### DIFF
--- a/.agents/skills/buttons/SKILL.md
+++ b/.agents/skills/buttons/SKILL.md
@@ -27,7 +27,11 @@ Deterministic workflow engine for AI agents. Create reusable, composable actions
 ## Quick reference
 
 ```bash
-# Create buttons
+# Default: scaffold + edit + press. Creates main.sh with placeholder you edit.
+buttons create deploy --arg env:string:required
+# → edit ~/.buttons/buttons/deploy/main.sh, then: buttons press deploy --arg env=staging
+
+# Shortcuts for known content (skip the scaffold):
 buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required
 buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required
 buttons create deploy-checklist --prompt "Verify: tests pass, staging green, team notified"
@@ -114,10 +118,9 @@ buttons create [flags]
 | `--allow-private-networks` | bool | allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets. |
 | `--arg` | stringArray | argument definition (name:type:required|optional) |
 | `--body` | string | HTTP request body (supports {{arg}} templates) |
-| `--code` | string | inline script code |
-| `--code-stdin` | bool | read code from stdin |
+| `--code` | string | inline script code (shortcut for one-liners) |
 | `-d, --description` | string | button description |
-| `-f, --file` | string | path to script file |
+| `-f, --file` | string | copy an existing script file into the button folder |
 | `--header` | stringArray | HTTP header as 'Key: Value' (repeatable) |
 | `--max-response-size` | string | max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M |
 | `--method` | string | HTTP method for --url (default: GET) |
@@ -281,10 +284,12 @@ Pass at press time: `--arg key=value`
 
 ## Button sources
 
+`buttons create <name>` scaffolds a shell button with a placeholder `main.sh` the agent edits, then presses. Use a shortcut flag to skip the scaffold:
+
 | Flag | Source | Runtime |
 |------|--------|--------|
-| `--code` | Inline script | `--runtime shell\|python\|node` (default: shell) |
-| `--code-stdin` | Piped script from stdin | Same as `--code` |
+| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\|python\|node` (default: shell) |
+| `--code` | Inline script body (one-liners) | Same as above |
 | `-f`/`--file` | Existing script file (copied into button folder) | Detected from shebang |
 | `--url` | HTTP endpoint with `{{arg}}` templates | HTTP client |
 | `--prompt` | Instruction for the consuming agent | Returns text, no execution |

--- a/README.md
+++ b/README.md
@@ -123,24 +123,27 @@ buttons history weather
 
 ## Creating Buttons
 
-Four ways to create buttons. Use `--agent` as a modifier on any of them to attach an instruction for the consuming agent.
+Three button types. Use `--prompt` as a modifier on any of them to attach an instruction for the consuming agent.
 
 ### Code
 
 ```bash
-# Shell (default)
+# Scaffold + edit (default). Creates main.sh with a placeholder, tells you where to edit it.
+buttons create deploy --arg env:string:required
+# Then edit ~/.buttons/buttons/deploy/main.sh and press:
+buttons press deploy --arg env=staging
+
+# Or skip the scaffold with --code for one-liners
 buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME!"' --arg name:string:required
 
-# Python
-buttons create transform --runtime python --code 'import json; print(json.dumps({"ok": True}))'
+# Python scaffold
+buttons create transform --runtime python --arg input:string:required
 
-# Node
-buttons create parse --runtime node --code 'console.log(JSON.stringify({status: "ok"}))'
+# Node scaffold
+buttons create parse --runtime node
 
-# Multi-line via stdin
-buttons create etl --code-stdin <<'EOF'
-curl -s $BUTTONS_ARG_SOURCE | jq '.data[]'
-EOF
+# Or import an existing script file
+buttons create etl --file ./scripts/etl.sh --arg source:string:required
 ```
 
 ### API
@@ -290,17 +293,18 @@ Error codes: `NOT_FOUND`, `MISSING_ARG`, `VALIDATION_ERROR`, `TIMEOUT`, `SCRIPT_
 
 ## Create Flags
 
+By default, `buttons create <name>` scaffolds a shell button with a placeholder `main.sh` the agent can edit. Shortcut flags below let you skip the placeholder.
+
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--code` | | Inline script code |
-| `--code-stdin` | | Read code from piped stdin |
-| `--runtime` | | Code runtime: shell, python, node (default: shell) |
+| `--runtime` | | Scaffold runtime: shell, python, node (default: shell) |
+| `--code` | | Inline script body (shortcut for one-liners) |
+| `--file` | `-f` | Copy an existing script file into the button folder |
 | `--url` | | HTTP API endpoint (supports `{{arg}}` templates) |
 | `--method` | | HTTP method (default: GET) |
 | `--header` | | HTTP header as `Key: Value` (repeatable) |
 | `--body` | | HTTP request body (supports `{{arg}}` templates) |
-| `--file` | `-f` | Import a script file (copied into button folder) |
-| `--prompt` | | Prompt instruction for the consuming agent (standalone or modifier on any source) |
+| `--prompt` | | Prompt instruction written to AGENT.md (standalone or modifier on any source) |
 | `--arg` | | Argument: `name:type:required\|optional` |
 | `--description` | `-d` | Button description |
 | `--timeout` | | Execution timeout in seconds (default: 60) |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
+	"path/filepath"
 	"strings"
-
-	"github.com/mattn/go-isatty"
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
@@ -15,7 +13,6 @@ import (
 
 var createFile string
 var createCode string
-var createCodeStdin bool
 var createRuntime string
 var createURL string
 var createMethod string
@@ -31,51 +28,32 @@ var createArgs []string
 var createCmd = &cobra.Command{
 	Use:   "create [name]",
 	Short: "Create a new button",
-	Long: `Create a new button from a script file, inline code, or API endpoint.
+	Long: `Create a new button.
 
-A button wraps a single action with typed arguments, a timeout, and
-structured output. Provide --file for a script, --code for inline code,
-or --url for an HTTP API endpoint.
+By default, 'buttons create <name>' scaffolds a shell button with a
+placeholder main.sh the agent can edit, then press. Use --runtime to
+scaffold a Python or Node button instead.
+
+Provide a shortcut flag to skip the placeholder: --code for a one-line
+inline script, --file to copy an existing script, --url for an HTTP
+endpoint, or --prompt for a standalone instruction.
 
 Arguments are defined with --arg in name:type:required|optional format.
 Supported types: string, int, bool. Args are injected as env vars for
 scripts or substituted into URL templates for API buttons.
 
 Examples:
-  buttons create deploy -f ./scripts/deploy.sh --arg env:string:required
+  buttons create deploy                                  # scaffold, then edit main.sh
+  buttons create etl --runtime python                    # scaffold, then edit main.py
   buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required
+  buttons create k8s-deploy -f ./scripts/deploy.sh --arg env:string:required
   buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required
-  buttons create webhook --url https://api.example.com/hook --method POST
   buttons create graphql --url https://api.example.com/graphql --method POST \
     --header "Content-Type: application/json" --body '{"query": "{ viewer { login } }"}'
   buttons create check-logs --prompt "Use the Northflank CLI to read production logs and summarize errors"`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		code := createCode
-
-		// Read code from stdin if --code-stdin
-		if createCodeStdin {
-			if createFile != "" {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: "cannot use both --file and --code-stdin"})
-			}
-			if createCode != "" {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: "cannot use both --code and --code-stdin"})
-			}
-			if isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd()) {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: "--code-stdin requires piped input (stdin is a terminal)"})
-			}
-			data, err := io.ReadAll(io.LimitReader(os.Stdin, 65536+1))
-			if err != nil {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("failed to read stdin: %v", err)})
-			}
-			if len(data) > 65536 {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: "stdin code exceeds 64KB limit"})
-			}
-			if len(data) == 0 {
-				return handleServiceError(&button.ServiceError{Code: "VALIDATION_ERROR", Message: "no code provided on stdin"})
-			}
-			code = string(data)
-		}
 
 		argDefs, err := button.ParseArgDefs(createArgs)
 		if err != nil {
@@ -121,19 +99,42 @@ Examples:
 			return handleServiceError(err)
 		}
 
+		// Resolve the on-disk paths for the created button so callers can
+		// jump straight to the code file (scaffolded or otherwise).
+		btnDir, _ := config.ButtonDir(btn.Name)
+		var codePath string
+		if btn.URL == "" && btn.Runtime != "prompt" {
+			if p, err := svc.CodePath(btn.Name); err == nil {
+				codePath = p
+			}
+		}
+
 		if jsonOutput {
-			return config.WriteJSON(btn)
+			return config.WriteJSON(struct {
+				*button.Button
+				CodePath  string `json:"code_path,omitempty"`
+				ButtonDir string `json:"button_dir"`
+			}{
+				Button:    btn,
+				CodePath:  codePath,
+				ButtonDir: btnDir,
+			})
 		}
 
 		fmt.Fprintf(os.Stderr, "Created button: %s\n", btn.Name)
+		if codePath != "" {
+			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", codePath)
+		} else if btn.Runtime == "prompt" {
+			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", filepath.Join(btnDir, "AGENT.md"))
+		}
+		fmt.Fprintf(os.Stderr, "  Press: buttons press %s\n", btn.Name)
 		return nil
 	},
 }
 
 func init() {
-	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to script file")
-	createCmd.Flags().StringVar(&createCode, "code", "", "inline script code")
-	createCmd.Flags().BoolVar(&createCodeStdin, "code-stdin", false, "read code from stdin")
+	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "copy an existing script file into the button folder")
+	createCmd.Flags().StringVar(&createCode, "code", "", "inline script code (shortcut for one-liners)")
 	createCmd.Flags().StringVar(&createRuntime, "runtime", "", "code runtime: shell, python, node (default: shell)")
 	createCmd.Flags().StringVar(&createURL, "url", "", "HTTP API endpoint URL (supports {{arg}} templates)")
 	createCmd.Flags().StringVar(&createMethod, "method", "", "HTTP method for --url (default: GET)")

--- a/docs/buttons/code.mdx
+++ b/docs/buttons/code.mdx
@@ -1,107 +1,129 @@
 ---
 title: "Code buttons"
 sidebarTitle: "Code"
-description: "Wrap inline or file-based scripts as pressable, typed actions."
+description: "Wrap a shell, Python, or Node script as a pressable, typed action."
 ---
 
-Code buttons wrap a script — shell, Python, or Node — as a named action with typed arguments, a timeout, and structured output. Every code button stores its script as a file inside the button folder, whether you provide it inline with `--code` or import it from disk with `--file`.
+A code button is a script the runtime executes every time you press it. The script lives as a file inside the button folder, so you can edit it the same way you edit any other file.
 
-## Create from inline code
+## The default flow: scaffold, edit, press
 
-Pass the script body with `--code`:
+The simplest way to create a button is to let Buttons scaffold a placeholder script you can fill in. Declare the args you'll need up front — they're part of the button spec and can't be added later without recreating the button:
 
 ```bash
-buttons create greet \
-  --code 'echo "Hello, $BUTTONS_ARG_NAME"' \
-  --runtime shell \
-  --arg name:string:required \
-  -d "Print a greeting"
+buttons create greet --arg name:string:required
+# Created button: greet
+#   Edit:  /Users/you/.buttons/buttons/greet/main.sh
+#   Press: buttons press greet
 ```
 
-Press it:
+Open the scaffolded `main.sh` — it has a shebang, a TODO comment, and a hint about where args arrive:
+
+```bash
+#!/bin/sh
+set -eu
+
+# TODO: add your command here
+# Args arrive as $BUTTONS_ARG_<NAME>
+```
+
+Edit it to whatever you want:
+
+```bash
+#!/bin/sh
+echo "Hello, $BUTTONS_ARG_NAME"
+```
+
+Press:
 
 ```bash
 buttons press greet --arg name=Ada
-# Hello, Ada
+# → Hello, Ada
 ```
 
-For longer scripts, pipe from stdin with `--code-stdin`:
+<Note>
+  Args are declared at create time and stored in `button.json`. If you need to change them, delete and recreate the button — your `main.sh` is at the same path each time, so you can copy your edits over.
+</Note>
+
+## Scaffold in Python or Node
+
+Pass `--runtime` to scaffold with the right shebang and extension:
 
 ```bash
-cat scripts/deploy.sh | buttons create deploy \
-  --code-stdin \
-  --runtime shell \
-  --arg env:string:required \
-  -d "Deploy to an environment"
+buttons create parse-json --runtime python --arg input:string:required
+# → scaffolds main.py with:
+#     #!/usr/bin/env python3
+#     # TODO: add your code here
+#     # Args arrive as os.environ["BUTTONS_ARG_<NAME>"]
 ```
-
-Or use a heredoc:
 
 ```bash
-buttons create check-disk \
-  --code-stdin \
-  --runtime shell \
-  -d "Report disk usage" <<'EOF'
-df -h | awk 'NR==1 || /\/$/ {print}'
-EOF
+buttons create transform --runtime node --arg payload:string:required
+# → scaffolds main.js
 ```
 
-Inline code is capped at **64 KB**. Import from a file when your script is larger.
+| Flag value | Interpreter used | File written |
+|---|---|---|
+| `shell` (default) | `/bin/sh` | `main.sh` |
+| `python` | `python3` | `main.py` |
+| `node` | `node` | `main.js` |
 
-## Create from a file
+## Shortcuts for when you already know the code
 
-Use `-f` or `--file` to import an existing script. The file is copied into the button folder at create time so the button is self-contained:
+Three shortcuts let you skip the edit step when the script is trivial or already on disk.
+
+### `--code 'one-liner'`
+
+Pass a one-line script inline. Useful when the body is a single command and quoting isn't painful:
+
+```bash
+buttons create hostname --code 'hostname -f'
+buttons create ls-home --code 'ls -la ~' --runtime shell
+```
+
+Inline code is capped at **64 KB**. Beyond that, write it to a file and use `--file`.
+
+### `--file ./path/to/script.sh`
+
+Copy an existing script into the button folder. The file is copied (not symlinked) so the button is self-contained:
 
 ```bash
 buttons create deploy \
   --file ./scripts/deploy.sh \
   --arg env:string:required \
   --arg version:string:required \
-  -d "Deploy a tagged release to an environment"
+  -d "Deploy a tagged release"
 ```
 
-Press it the same way as any other button:
-
-```bash
-buttons press deploy --arg env=staging --arg version=v1.4.2
-```
-
-The source file is **copied**, not symlinked. Editing the original after creation has no effect. To update the script, recreate the button or edit the copy directly at `~/.buttons/buttons/<name>/main.<ext>`.
-
-File buttons have no size limit.
-
-## Choosing a runtime
-
-Use `--runtime` to pick the interpreter. The binary must be present on `$PATH` at press time.
-
-| Flag value | Interpreter used |
-|---|---|
-| `shell` | `/bin/sh` (default) |
-| `python` | `python3` |
-| `node` | `node` |
-
-```bash
-buttons create parse-json \
-  --code 'import json, os; print(json.loads(os.environ["BUTTONS_ARG_INPUT"])["key"])' \
-  --runtime python \
-  --arg input:string:required
-```
-
-<Note>
-  If you import a script with `--file` and it starts with a shebang, the OS uses that interpreter directly — no need to pass `--runtime`. When there is no shebang and no `--runtime`, Buttons defaults to `/bin/sh`.
-</Note>
+If the script has a shebang, the OS uses that interpreter directly — no need to pass `--runtime`. Without a shebang and without `--runtime`, Buttons defaults to `/bin/sh`.
 
 ## Argument injection
 
-Arguments are never interpolated into the script body. They arrive as environment variables named `BUTTONS_ARG_<NAME>` (uppercased).
+Arguments are never interpolated into the script body. They arrive as environment variables named `BUTTONS_ARG_<NAME>` (uppercased):
 
 ```bash
-# Arg declared as:  --arg bucket:string:required
-# Available in script as:
-echo "$BUTTONS_ARG_BUCKET"
+# Declared:  --arg bucket:string:required
+# Available:
+echo "$BUTTONS_ARG_BUCKET"           # shell
+os.environ["BUTTONS_ARG_BUCKET"]     # python
+process.env.BUTTONS_ARG_BUCKET       # node
 ```
 
-This prevents shell injection regardless of what value is passed at press time.
+This prevents shell injection regardless of what the caller passes at press time.
+
+## Where the code lives
+
+After `buttons create`, the button folder contains:
+
+```
+~/.buttons/buttons/<name>/
+  button.json     # spec: args, runtime, timeout
+  main.sh         # your code (or main.py / main.js)
+  AGENT.md        # notes for agents pressing this button
+  pressed/        # run history, one JSON file per press
+```
+
+Edit `main.sh` any time. Changes take effect on the next press — no recreate needed.
 
 ## Example: wrap a deploy script
 
@@ -133,4 +155,4 @@ buttons create k8s-deploy \
 - [Prompt buttons](/buttons/prompt) — attach an instruction to any button for the consuming agent
 - [Arguments](/concepts/arguments) — declare and pass typed args
 - [JSON output](/concepts/json-output) — capture results programmatically
-- [Folder structure](/concepts/folder-structure) — where the script lives on disk
+- [Folder structure](/concepts/folder-structure) — what lives inside a button folder

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -9,11 +9,15 @@ Create a new button
 
 ### Synopsis
 
-Create a new button from a script file, inline code, or API endpoint.
+Create a new button.
 
-A button wraps a single action with typed arguments, a timeout, and
-structured output. Provide --file for a script, --code for inline code,
-or --url for an HTTP API endpoint.
+By default, 'buttons create <name>' scaffolds a shell button with a
+placeholder main.sh the agent can edit, then press. Use --runtime to
+scaffold a Python or Node button instead.
+
+Provide a shortcut flag to skip the placeholder: --code for a one-line
+inline script, --file to copy an existing script, --url for an HTTP
+endpoint, or --prompt for a standalone instruction.
 
 Arguments are defined with --arg in name:type:required|optional format.
 Supported types: string, int, bool. Args are injected as env vars for
@@ -22,10 +26,11 @@ scripts or substituted into URL templates for API buttons.
 **Examples:**
 
 ```bash
-buttons create deploy -f ./scripts/deploy.sh --arg env:string:required
+buttons create deploy                                  # scaffold, then edit main.sh
+buttons create etl --runtime python                    # scaffold, then edit main.py
 buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required
+buttons create k8s-deploy -f ./scripts/deploy.sh --arg env:string:required
 buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required
-buttons create webhook --url https://api.example.com/hook --method POST
 buttons create graphql --url https://api.example.com/graphql --method POST \
   --header "Content-Type: application/json" --body '{"query": "{ viewer { login } }"}'
 buttons create check-logs --prompt "Use the Northflank CLI to read production logs and summarize errors"
@@ -41,10 +46,9 @@ buttons create [name] [flags]
       --allow-private-networks     allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.
       --arg stringArray            argument definition (name:type:required|optional)
       --body string                HTTP request body (supports {{arg}} templates)
-      --code string                inline script code
-      --code-stdin                 read code from stdin
+      --code string                inline script code (shortcut for one-liners)
   -d, --description string         button description
-  -f, --file string                path to script file
+  -f, --file string                copy an existing script file into the button folder
       --header stringArray         HTTP header as 'Key: Value' (repeatable)
   -h, --help                       help for create
       --max-response-size string   max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -38,3 +38,18 @@ func ExtForRuntime(runtime string) string {
 		return ".sh"
 	}
 }
+
+// scaffoldFor returns the placeholder body written to main.<ext> when a
+// button is created without --code or --file. The shebang makes the runtime
+// obvious when the agent opens the file; the TODO comment signals where to
+// put the real implementation.
+func scaffoldFor(runtime string) string {
+	switch runtime {
+	case "python", "python3":
+		return "#!/usr/bin/env python3\n# TODO: add your code here\n# Args arrive as os.environ[\"BUTTONS_ARG_<NAME>\"]\n"
+	case "node", "javascript", "js":
+		return "#!/usr/bin/env node\n// TODO: add your code here\n// Args arrive as process.env.BUTTONS_ARG_<NAME>\n"
+	default:
+		return "#!/bin/sh\nset -eu\n\n# TODO: add your command here\n# Args arrive as $BUTTONS_ARG_<NAME>\n"
+	}
+}

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -65,32 +65,34 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 	if sources > 1 {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "only one of --file, --code, or --url can be provided"}
 	}
-	if sources == 0 && !hasPrompt {
-		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "must provide --file, --code, --url, or --prompt"}
-	}
 
 	if hasCode && len(opts.Code) > maxCodeBytes {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "inline code exceeds 64KB limit"}
 	}
 
-	// Resolve runtime
+	// Resolve runtime. URL → http, prompt-only (no sources) → prompt,
+	// otherwise honor --runtime or default to shell. Bare `buttons create foo`
+	// scaffolds a shell button with a placeholder main.sh the agent can edit.
 	runtime := opts.Runtime
 	if hasURL {
 		runtime = "http"
 	} else if sources == 0 && hasPrompt {
-		runtime = "prompt" // standalone prompt button, no code/url/file
+		runtime = "prompt" // standalone prompt button, no code file
 	} else if runtime == "" {
 		runtime = "shell"
 	}
-	if opts.Runtime != "" && !hasCode {
-		if hasFile {
-			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "--runtime is only valid with --code (file-based buttons use shebangs)"}
-		}
+	// --runtime applies to code buttons written by buttons (scaffold or --code).
+	// --file uses the imported script's shebang, --url is HTTP, --prompt-only
+	// is text — all three ignore the runtime concept.
+	if opts.Runtime != "" {
 		if hasURL {
 			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "--runtime is not valid with --url"}
 		}
-		if sources > 0 {
-			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "--runtime requires --code"}
+		if hasFile {
+			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "--runtime is not valid with --file (file-based buttons use their own shebang)"}
+		}
+		if sources == 0 && hasPrompt {
+			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "--runtime is not valid with a prompt-only button"}
 		}
 	}
 
@@ -180,24 +182,35 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 		return nil, fmt.Errorf("failed to write button spec: %w", err)
 	}
 
-	// Write code file (for code and file-based buttons, not URL)
-	if hasCode || hasFile {
+	// Write code file for every code-based button. HTTP buttons (--url)
+	// and standalone prompt buttons (--prompt with no source) do not get
+	// a main.* file. Source priority: --code > --file > scaffold placeholder.
+	writeCodeFile := !hasURL && !(sources == 0 && hasPrompt)
+	if writeCodeFile {
 		ext := ExtForRuntime(runtime)
 		codePath := filepath.Join(btnDir, "main"+ext)
 
-		if hasCode {
+		switch {
+		case hasCode:
 			// #nosec G306 -- code files require the exec bit to run via /bin/sh, python3, node;
 			// 0700 keeps them user-private while allowing execution.
 			if err := os.WriteFile(codePath, []byte(opts.Code), 0700); err != nil {
 				return nil, fmt.Errorf("failed to write code file: %w", err)
 			}
-		} else {
+		case hasFile:
 			if err := copyFile(opts.FilePath, codePath); err != nil {
 				return nil, fmt.Errorf("failed to copy file: %w", err)
 			}
 			// #nosec G302 -- code files require the exec bit; see rationale above.
 			if err := os.Chmod(codePath, 0700); err != nil {
 				return nil, fmt.Errorf("failed to set code file permissions: %w", err)
+			}
+		default:
+			// Scaffold: write a placeholder the agent can edit. Shebang + TODO
+			// so opening the file reveals the runtime and what to do next.
+			// #nosec G306 -- see rationale above.
+			if err := os.WriteFile(codePath, []byte(scaffoldFor(runtime)), 0700); err != nil {
+				return nil, fmt.Errorf("failed to write scaffold: %w", err)
 			}
 		}
 	}

--- a/internal/button/service_test.go
+++ b/internal/button/service_test.go
@@ -104,6 +104,30 @@ func TestService_Create(t *testing.T) {
 	}
 }
 
+func TestService_Create_ScaffoldNoSource(t *testing.T) {
+	home := setupTestEnv(t)
+	svc := NewService()
+
+	// No FilePath, Code, URL, or Prompt — should scaffold a shell button.
+	btn, err := svc.Create(CreateOpts{Name: "scaffolded", TimeoutSeconds: 60})
+	if err != nil {
+		t.Fatalf("scaffold create failed: %v", err)
+	}
+	if btn.Runtime != "shell" {
+		t.Errorf("runtime = %q, want shell", btn.Runtime)
+	}
+
+	// main.sh should exist with the shebang placeholder.
+	codePath := filepath.Join(home, "buttons", "scaffolded", "main.sh")
+	data, err := os.ReadFile(codePath)
+	if err != nil {
+		t.Fatalf("scaffolded main.sh not found: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("scaffolded main.sh is empty, expected shebang + TODO")
+	}
+}
+
 func TestService_Create_CustomTimeout(t *testing.T) {
 	home := setupTestEnv(t)
 	script := createTestScript(t, home)

--- a/internal/tools/skillgen/main.go
+++ b/internal/tools/skillgen/main.go
@@ -73,7 +73,10 @@ func writeSkill(b *strings.Builder, root *cobra.Command) {
 	// Quick reference
 	b.WriteString("## Quick reference\n\n")
 	b.WriteString("```bash\n")
-	b.WriteString("# Create buttons\n")
+	b.WriteString("# Default: scaffold + edit + press. Creates main.sh with placeholder you edit.\n")
+	b.WriteString("buttons create deploy --arg env:string:required\n")
+	b.WriteString("# → edit ~/.buttons/buttons/deploy/main.sh, then: buttons press deploy --arg env=staging\n\n")
+	b.WriteString("# Shortcuts for known content (skip the scaffold):\n")
 	b.WriteString("buttons create greet --code 'echo \"Hello, $BUTTONS_ARG_NAME\"' --arg name:string:required\n")
 	b.WriteString("buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required\n")
 	b.WriteString("buttons create deploy-checklist --prompt \"Verify: tests pass, staging green, team notified\"\n")
@@ -133,10 +136,11 @@ func writeSkill(b *strings.Builder, root *cobra.Command) {
 
 	// Button sources
 	b.WriteString("## Button sources\n\n")
+	b.WriteString("`buttons create <name>` scaffolds a shell button with a placeholder `main.sh` the agent edits, then presses. Use a shortcut flag to skip the scaffold:\n\n")
 	b.WriteString("| Flag | Source | Runtime |\n")
 	b.WriteString("|------|--------|--------|\n")
-	b.WriteString("| `--code` | Inline script | `--runtime shell\\|python\\|node` (default: shell) |\n")
-	b.WriteString("| `--code-stdin` | Piped script from stdin | Same as `--code` |\n")
+	b.WriteString("| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\\|python\\|node` (default: shell) |\n")
+	b.WriteString("| `--code` | Inline script body (one-liners) | Same as above |\n")
 	b.WriteString("| `-f`/`--file` | Existing script file (copied into button folder) | Detected from shebang |\n")
 	b.WriteString("| `--url` | HTTP endpoint with `{{arg}}` templates | HTTP client |\n")
 	b.WriteString("| `--prompt` | Instruction for the consuming agent | Returns text, no execution |\n\n")

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -83,33 +82,6 @@ func (e *testEnv) run(args ...string) result {
 	e.t.Helper()
 	cmd := exec.Command(e.binary, args...)
 	cmd.Env = append(os.Environ(), "BUTTONS_HOME="+e.home)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			e.t.Fatalf("failed to run command: %v", err)
-		}
-	}
-
-	return result{
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		ExitCode: exitCode,
-	}
-}
-
-func (e *testEnv) runWithStdin(stdinContent string, args ...string) result {
-	e.t.Helper()
-	cmd := exec.Command(e.binary, args...)
-	cmd.Env = append(os.Environ(), "BUTTONS_HOME="+e.home)
-	cmd.Stdin = strings.NewReader(stdinContent)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/test/integration/inline_code_test.go
+++ b/test/integration/inline_code_test.go
@@ -62,16 +62,28 @@ func TestCreate_MutualExclusion_FileAndCode(t *testing.T) {
 	}
 }
 
-func TestCreate_MutualExclusion_NeitherFileNorCode(t *testing.T) {
+func TestCreate_Scaffold_NoSource(t *testing.T) {
 	env := newTestEnv(t)
 
+	// With no source flag, create scaffolds a shell button with a placeholder main.sh.
 	res := env.run("create", "test", "--json")
-	if res.ExitCode == 0 {
-		t.Fatal("expected non-zero exit")
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", res.ExitCode, res.Stderr)
 	}
-	resp := parseJSON(t, res.Stdout)
-	if resp.Error.Code != "VALIDATION_ERROR" {
-		t.Errorf("code = %q, want VALIDATION_ERROR", resp.Error.Code)
+
+	btn := parseButton(t, parseJSON(t, res.Stdout).Data)
+	if btn.Runtime != "shell" {
+		t.Errorf("runtime = %q, want shell", btn.Runtime)
+	}
+
+	// main.sh should exist with the shebang placeholder so the agent can open it.
+	codePath := filepath.Join(env.home, "buttons", "test", "main.sh")
+	data, err := os.ReadFile(codePath)
+	if err != nil {
+		t.Fatalf("scaffolded main.sh not found: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "#!/bin/sh") {
+		t.Errorf("main.sh should start with shebang, got: %q", string(data[:min(len(data), 40)]))
 	}
 }
 
@@ -142,53 +154,27 @@ func TestPress_InlineCode_CodeFileExists(t *testing.T) {
 	}
 }
 
-func TestCreate_InlineCode_CodeStdin(t *testing.T) {
+func TestCreate_Scaffold_Python(t *testing.T) {
 	env := newTestEnv(t)
 
-	res := env.runWithStdin("echo 'hello from stdin'", "create", "stdin-test", "--code-stdin", "--json")
+	// With --runtime python and no source, create scaffolds main.py.
+	res := env.run("create", "test", "--runtime", "python", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("expected exit 0, got %d: %s", res.ExitCode, res.Stderr)
 	}
 
-	resp := parseJSON(t, res.Stdout)
-	if !resp.OK {
-		t.Fatal("expected ok: true")
+	btn := parseButton(t, parseJSON(t, res.Stdout).Data)
+	if btn.Runtime != "python" {
+		t.Errorf("runtime = %q, want python", btn.Runtime)
 	}
 
-	res = env.run("press", "stdin-test", "--json")
-	if res.ExitCode != 0 {
-		t.Fatalf("press failed: %s", res.Stderr)
+	codePath := filepath.Join(env.home, "buttons", "test", "main.py")
+	data, err := os.ReadFile(codePath)
+	if err != nil {
+		t.Fatalf("scaffolded main.py not found: %v", err)
 	}
-	pr := parsePressResult(t, parseJSON(t, res.Stdout).Data)
-	if !strings.Contains(pr.Stdout, "hello from stdin") {
-		t.Errorf("stdout = %q, want to contain 'hello from stdin'", pr.Stdout)
-	}
-}
-
-func TestCreate_MutualExclusion_FileAndCodeStdin(t *testing.T) {
-	env := newTestEnv(t)
-	script := env.createScript("test.sh")
-
-	res := env.runWithStdin("echo hi", "create", "test", "--file", script, "--code-stdin", "--json")
-	if res.ExitCode == 0 {
-		t.Fatal("expected non-zero exit for --file + --code-stdin")
-	}
-	resp := parseJSON(t, res.Stdout)
-	if resp.Error.Code != "VALIDATION_ERROR" {
-		t.Errorf("code = %q, want VALIDATION_ERROR", resp.Error.Code)
-	}
-}
-
-func TestCreate_RuntimeWithoutCode(t *testing.T) {
-	env := newTestEnv(t)
-
-	res := env.run("create", "test", "--runtime", "python", "--json")
-	if res.ExitCode == 0 {
-		t.Fatal("expected non-zero exit for --runtime without --code")
-	}
-	resp := parseJSON(t, res.Stdout)
-	if resp.Error.Code != "VALIDATION_ERROR" {
-		t.Errorf("code = %q, want VALIDATION_ERROR", resp.Error.Code)
+	if !strings.HasPrefix(string(data), "#!/usr/bin/env python3") {
+		t.Errorf("main.py should start with python shebang, got: %q", string(data[:min(len(data), 40)]))
 	}
 }
 
@@ -242,19 +228,6 @@ func TestCreate_InlineCode_ExceedsMaxSize(t *testing.T) {
 	res := env.run("create", "test", "--code", bigCode, "--json")
 	if res.ExitCode == 0 {
 		t.Fatal("expected non-zero exit for code > 64KB")
-	}
-	resp := parseJSON(t, res.Stdout)
-	if resp.Error.Code != "VALIDATION_ERROR" {
-		t.Errorf("code = %q, want VALIDATION_ERROR", resp.Error.Code)
-	}
-}
-
-func TestCreate_MutualExclusion_CodeAndCodeStdin(t *testing.T) {
-	env := newTestEnv(t)
-
-	res := env.runWithStdin("echo hi", "create", "test", "--code", "echo hello", "--code-stdin", "--json")
-	if res.ExitCode == 0 {
-		t.Fatal("expected non-zero exit for --code + --code-stdin")
 	}
 	resp := parseJSON(t, res.Stdout)
 	if resp.Error.Code != "VALIDATION_ERROR" {


### PR DESCRIPTION
## Summary

Makes `buttons create <name>` scaffold a shell button with a placeholder `main.sh` by default. Drops `--code-stdin`. Collapses four create entry points into a simpler mental model for agents.

## The new default flow

```bash
buttons create deploy --arg env:string:required
# Created button: deploy
#   Edit:  /Users/you/.buttons/buttons/deploy/main.sh
#   Press: buttons press deploy --arg env=staging
```

The scaffolded `main.sh`:

```bash
#!/bin/sh
set -eu

# TODO: add your command here
# Args arrive as $BUTTONS_ARG_<NAME>
```

Agent opens the file, writes the real code, presses the button. No quoting multi-line scripts on the command line, no separate `--code-stdin` API surface to learn.

## Shortcut flags still work

When the content is already known, skip the scaffold:

- `--code 'one-liner'` — inline, for trivial scripts
- `--file ./path.sh` — copy an existing script
- `--url 'https://...'` — HTTP button, no `main.sh`
- `--prompt 'text'` — prompt-only button, no `main.sh`
- `--runtime python|node` — scaffold `main.py` / `main.js` with the right shebang

## Breaking changes

- `--code-stdin` flag removed. Use `--file` (if content is on disk) or `--code "$(cat)"` (if piping).
- `buttons create <name>` with no source no longer errors — it scaffolds.
- `buttons create <name> --runtime python` with no source no longer errors — it scaffolds `main.py`.

## Kept guards

- `--runtime` still errors with `--file` (shebang conflict) and `--url` (no script) and `--prompt-only` (no script).
- `--file` / `--code` / `--url` still mutually exclusive with each other.

## Output changes

Create now emits the on-disk path so the agent can jump straight to editing:

```bash
$ buttons create deploy
Created button: deploy
  Edit:  /Users/you/.buttons/buttons/deploy/main.sh
  Press: buttons press deploy
```

JSON output adds `code_path` and `button_dir` fields alongside the button spec:

```json
{
  "ok": true,
  "data": {
    "schema_version": 2,
    "name": "deploy",
    "runtime": "shell",
    ...
    "code_path": "/Users/you/.buttons/buttons/deploy/main.sh",
    "button_dir": "/Users/you/.buttons/buttons/deploy"
  }
}
```

## Why

From design-review discussion: the three flags `--code`, `--code-stdin`, `--file` all produce the same output (a script file in the button folder). They differ only in where the input comes from. `--code-stdin` is redundant with `--file` and `--code "$(cat)"`. And forcing a source flag at create time is friction for the common agent flow — create a button, edit the code. Agents are great at editing files and bad at escaping shell quotes.

## Test plan

- [ ] `go build -o buttons .` succeeds
- [ ] `go test ./...` all green
- [ ] `buttons create hello` scaffolds `main.sh` with shebang
- [ ] `buttons create hello --runtime python` scaffolds `main.py` with python shebang
- [ ] `buttons create hello --code 'echo hi'` still works
- [ ] `buttons create hello --file ./script.sh` still works
- [ ] `buttons create hello --url https://...` still works
- [ ] `buttons create hello --prompt 'do the thing'` still works
- [ ] `buttons create hello --code-stdin` fails with "unknown flag"
- [ ] Pressing a scaffolded button (unedited) exits 0 with empty stdout
- [ ] After editing `main.sh`, `buttons press` runs the new code
- [ ] `mint broken-links` clean on the updated `code.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
