### PR TITLE
fix(ci): use Node 24 for npm publish (native npm 11)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -100,17 +100,18 @@ jobs:
       # If TP is not yet configured for a package on the npm side, this
       # step fails loudly with a clear error from npm. Fix by adding the
       # package to the org's trusted publishers and re-running the job.
-      # npm Trusted Publishing requires npm >= 11.5.1 and Node >= 22.14.0.
-      # Node 22 LTS + an explicit upgrade to npm 11 satisfies both and keeps
-      # us on a stable LTS track.
+      #
+      # Node 24 is pinned intentionally: npm Trusted Publishing needs npm
+      # >= 11.5.1, which ships natively with Node 24.x. We previously tried
+      # Node 22 + `npm install -g npm@11`, but npm's in-place self-upgrade
+      # corrupts its own module graph (MODULE_NOT_FOUND on promise-retry)
+      # because the running npm's dependencies get swapped out mid-install.
+      # Using Node 24 avoids the self-upgrade entirely.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm to a Trusted Publishing-capable version
-        run: npm install -g npm@11
 
       - name: Publish to npm
         run: node scripts/publish-npm.mjs


### PR DESCRIPTION
## Problem

v0.11.0 release workflow failed at the npm publish step:

```
npm install -g npm@11
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

npm's in-place self-upgrade corrupts its module graph: the running npm's dependencies get swapped out mid-install before they've been used, so the second half of the install can't find what it needs.

Everything before that step succeeded — v0.11.0 is live on GitHub and ghcr.io. Only the npm publish step died.

## Fix

Use Node 24 (already active LTS), which ships with npm 11.x natively. No in-place upgrade needed, no module corruption, TP requirements (npm >= 11.5.1) still satisfied.

## What merging this does

- Auto-release bumps to `v0.12.0`
- Goreleaser re-publishes GitHub release + Docker image at v0.12.0
- npm publish step runs cleanly, publishing `@autono/buttons@0.12.0` plus 4 platform packages via Trusted Publishing

The stub `0.0.0-bootstrap` entries on the `bootstrap` dist-tag stay where they are — normal `npm install` resolves to `latest` which will be `0.12.0`.
