### PR TITLE
fix(ci+init): resolve gosec findings, stale stub, and multi-select picker trap

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -161,23 +161,26 @@ func resolveAgentTargets(cmd *cobra.Command) ([]string, error) {
 	return pickAgentsInteractive()
 }
 
-// pickAgentsInteractive shows the Huh multi-select picker. Returns the
-// set of selected target IDs, or an empty slice if the user submits
-// with nothing picked (implicit "none").
+// pickAgentsInteractive shows the Huh single-select picker. Users who
+// need multiple agents can pass them via `--agent cursor,claude` — most
+// people use one, and a single-select avoids the classic multi-select
+// trap of hitting enter without first pressing space to toggle.
 func pickAgentsInteractive() ([]string, error) {
-	options := make([]huh.Option[string], 0, len(agentskill.Targets))
+	const skipID = "__none__"
+	options := make([]huh.Option[string], 0, len(agentskill.Targets)+1)
 	for _, t := range agentskill.Targets {
 		options = append(options,
 			huh.NewOption(fmt.Sprintf("%s  — %s", t.Label, t.Description), t.ID),
 		)
 	}
+	options = append(options, huh.NewOption("None (skip)", skipID))
 
-	var selected []string
+	var selected string
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewMultiSelect[string]().
+			huh.NewSelect[string]().
 				Title("Install a Buttons skill file for your coding agent?").
-				Description("Space toggles, enter confirms. Select none to skip.").
+				Description("Arrow keys to move, enter to confirm.").
 				Options(options...).
 				Value(&selected),
 		),
@@ -190,7 +193,10 @@ func pickAgentsInteractive() ([]string, error) {
 		}
 		return nil, fmt.Errorf("agent picker: %w", err)
 	}
-	return selected, nil
+	if selected == "" || selected == skipID {
+		return nil, nil
+	}
+	return []string{selected}, nil
 }
 
 func validAgentIDs() string {

--- a/internal/agentskill/agentskill.go
+++ b/internal/agentskill/agentskill.go
@@ -221,8 +221,11 @@ func Install(opts InstallOpts) ([]WriteResult, error) {
 }
 
 func writeTarget(projectRoot string, t Target) (WriteResult, error) {
-	path := filepath.Join(projectRoot, t.Path)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	path, err := safeProjectPath(projectRoot, t.Path)
+	if err != nil {
+		return WriteResult{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return WriteResult{}, fmt.Errorf("create parent of %s: %w", path, err)
 	}
 
@@ -232,7 +235,7 @@ func writeTarget(projectRoot string, t Target) (WriteResult, error) {
 		// entirely. If the user hand-edits, the next `buttons init`
 		// will reset their changes; that's acceptable for a managed rule.
 		existed := fileExists(path)
-		if err := os.WriteFile(path, []byte(cursorRule), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(cursorRule), 0o600); err != nil { // #nosec G306 -- 0600 is intended
 			return WriteResult{}, fmt.Errorf("write %s: %w", path, err)
 		}
 		action := "created"
@@ -257,10 +260,10 @@ func writeTarget(projectRoot string, t Target) (WriteResult, error) {
 func writeMarkdownSection(path, targetID string) (WriteResult, error) {
 	section := markerStart + "\n" + Body + "\n" + markerEnd + "\n"
 
-	existing, err := os.ReadFile(path)
+	existing, err := os.ReadFile(path) // #nosec G304 -- path validated by safeProjectPath in writeTarget
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.WriteFile(path, []byte(section), 0600); err != nil {
+			if err := os.WriteFile(path, []byte(section), 0o600); err != nil {
 				return WriteResult{}, fmt.Errorf("write %s: %w", path, err)
 			}
 			return WriteResult{TargetID: targetID, Path: path, Action: "created"}, nil
@@ -278,7 +281,7 @@ func writeMarkdownSection(path, targetID string) (WriteResult, error) {
 		// rather than producing garbage.
 		if endIdx > startIdx {
 			updated := content[:startIdx] + strings.TrimSuffix(section, "\n") + content[endIdx:]
-			if err := os.WriteFile(path, []byte(updated), 0600); err != nil {
+			if err := os.WriteFile(path, []byte(updated), 0o600); err != nil { // #nosec G304 G703 -- path validated by safeProjectPath in writeTarget
 				return WriteResult{}, fmt.Errorf("write %s: %w", path, err)
 			}
 			return WriteResult{TargetID: targetID, Path: path, Action: "updated"}, nil
@@ -298,7 +301,7 @@ func writeMarkdownSection(path, targetID string) (WriteResult, error) {
 	}
 	b.WriteString(section)
 
-	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil { // #nosec G304 G703 -- path validated by safeProjectPath in writeTarget
 		return WriteResult{}, fmt.Errorf("write %s: %w", path, err)
 	}
 	return WriteResult{TargetID: targetID, Path: path, Action: "appended"}, nil
@@ -307,4 +310,22 @@ func writeMarkdownSection(path, targetID string) (WriteResult, error) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// safeProjectPath joins rel under projectRoot and verifies the result
+// stays inside the root. It rejects absolute rel paths and any that
+// escape via "..". Returned path is suitable for os.{Read,Write}File.
+func safeProjectPath(projectRoot, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("target path must be relative: %q", rel)
+	}
+	path := filepath.Join(projectRoot, rel)
+	relBack, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve target path %q: %w", rel, err)
+	}
+	if relBack == ".." || strings.HasPrefix(relBack, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("target path escapes project root: %q", rel)
+	}
+	return path, nil
 }

--- a/test/integration/json_test.go
+++ b/test/integration/json_test.go
@@ -4,20 +4,22 @@ import (
 	"testing"
 )
 
-func TestStub_BoardReturnsJSON(t *testing.T) {
+func TestBoard_JSONNotApplicable(t *testing.T) {
 	env := newTestEnv(t)
 
+	// `board` is an interactive TUI — invoking it with --json should refuse
+	// cleanly with NOT_APPLICABLE rather than attempting to render.
 	res := env.run("board", "--json")
 	if res.ExitCode == 0 {
-		t.Fatal("expected non-zero exit for stub command")
+		t.Fatal("expected non-zero exit for board --json")
 	}
 
 	resp := parseJSON(t, res.Stdout)
 	if resp.OK {
 		t.Fatal("expected ok: false")
 	}
-	if resp.Error.Code != "NOT_IMPLEMENTED" {
-		t.Errorf("code = %q, want NOT_IMPLEMENTED", resp.Error.Code)
+	if resp.Error.Code != "NOT_APPLICABLE" {
+		t.Errorf("code = %q, want NOT_APPLICABLE", resp.Error.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
Three fixes bundled to get main green again and fix a user-reported init UX trap:

1. **gosec (0 issues, was 3)** — `internal/agentskill`:
   - Add `safeProjectPath()` to validate target paths stay under project root
   - Tighten mkdir perms `0755 → 0o750` (G301)
   - Annotate now-validated Read/WriteFile calls with rationale (G304, G703)

2. **Stale stub test** — `test/integration/json_test.go`:
   - Rename `TestStub_BoardReturnsJSON` → `TestBoard_JSONNotApplicable`; assert `NOT_APPLICABLE` since `board` is a real TUI that refuses `--json`, not a stub

3. **`init` picker foot-gun** — `cmd/init.go`:
   - Replace `huh.MultiSelect` with `Select` + explicit "None (skip)" row. The multi-select required Space-to-toggle before Enter-to-confirm; users who navigated to a target and hit Enter saw "No agent skill files installed" with no clue why. Single-select matches the common case (one agent per project); multi-target still supported via `--agent cursor,claude`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...`
- [x] `gosec ./...` → 0 issues
- [x] Manual: `buttons init` → arrow to Claude Code → Enter → CLAUDE.md written
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)