### PR TITLE
feat(batteries): implement set/get/list/rm with env injection into presses

### DIFF
--- a/cmd/batteries.go
+++ b/cmd/batteries.go
@@ -1,68 +1,258 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/autonoco/buttons/internal/config"
 	"github.com/spf13/cobra"
+
+	"github.com/autonoco/buttons/internal/battery"
+	"github.com/autonoco/buttons/internal/config"
+)
+
+// Flags for the scope-qualified subcommands. --global and --local are
+// mutually exclusive; the default scope falls back to "local when in a
+// project, global otherwise" so most commands require no flags.
+var (
+	batteriesFlagGlobal bool
+	batteriesFlagLocal  bool
+	batteriesFlagReveal bool
 )
 
 var batteriesCmd = &cobra.Command{
 	Use:   "batteries",
 	Short: "Manage environment variables and secrets",
+	Long: `Batteries are key/value pairs injected into every button press
+as BUTTONS_BAT_<KEY>=<value>. Use them to store API tokens and other
+secrets outside your button scripts.
+
+Scopes:
+  global   ~/.buttons/batteries.json  — available from every project
+  local    .buttons/batteries.json    — only when pressing inside the
+                                        project; overrides global on
+                                        key collision
+
+List / get read from both scopes (local overrides on collision). Set /
+rm target local when inside a project, global otherwise; pass --global
+or --local to pick explicitly.
+
+Keys must match [A-Z][A-Z0-9_]* (uppercase, digits, underscore).
+
+Examples:
+  buttons batteries set APIFY_TOKEN apify_api_xxx
+  buttons batteries set OPENAI_KEY sk-... --global
+  buttons batteries list
+  buttons batteries get APIFY_TOKEN
+  buttons batteries rm OLD_KEY`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},
 }
 
 var batteriesSetCmd = &cobra.Command{
-	Use:   "set [key] [value]",
-	Short: "Set an environment variable",
+	Use:   "set KEY VALUE",
+	Short: "Set a battery",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: implement in Phase 2.2 (#264)
-		if jsonOutput {
-			_ = config.WriteJSONError("NOT_IMPLEMENTED", "batteries set not yet implemented")
-			return errSilent
+		key, value := args[0], args[1]
+		svc, err := newBatteryService()
+		if err != nil {
+			return handleBatteryError(err)
 		}
-		fmt.Fprintln(os.Stderr, "batteries set: not yet implemented")
+		scope, err := resolveBatteryScope(svc)
+		if err != nil {
+			return handleBatteryError(err)
+		}
+		if err := svc.Set(key, value, scope); err != nil {
+			return handleBatteryError(err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{
+				"key":   key,
+				"scope": string(scope),
+			})
+		}
+		fmt.Fprintf(os.Stderr, "set %s (%s)\n", key, scope)
+		return nil
+	},
+}
+
+var batteriesGetCmd = &cobra.Command{
+	Use:   "get KEY",
+	Short: "Print a battery value",
+	Long: `Print the raw value of a battery to stdout. Intended for shell
+substitution, e.g. ` + "`curl -H \"Authorization: Bearer $(buttons batteries get APIFY_TOKEN)\" ...`" + `.
+
+Looks up local first (if in a project), then global. In --json mode the
+value is still returned raw — redaction only applies to ` + "`list`" + `.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		svc, err := newBatteryService()
+		if err != nil {
+			return handleBatteryError(err)
+		}
+		value, scope, err := svc.Get(key)
+		if err != nil {
+			return handleBatteryError(err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{
+				"key":   key,
+				"value": value,
+				"scope": string(scope),
+			})
+		}
+		fmt.Println(value)
 		return nil
 	},
 }
 
 var batteriesListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all environment variables",
+	Short: "List every battery",
+	Long: `List batteries from every scope. Values are redacted by default —
+pass --reveal to print them in full.
+
+Local entries that shadow a global key are shown after the global entry;
+at press time the local value wins.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: implement in Phase 2.2 (#264)
-		if jsonOutput {
-			_ = config.WriteJSONError("NOT_IMPLEMENTED", "batteries list not yet implemented")
-			return errSilent
+		svc, err := newBatteryService()
+		if err != nil {
+			return handleBatteryError(err)
 		}
-		fmt.Fprintln(os.Stderr, "batteries list: not yet implemented")
+		entries, err := svc.List()
+		if err != nil {
+			return handleBatteryError(err)
+		}
+
+		if jsonOutput {
+			payload := make([]map[string]any, 0, len(entries))
+			for _, e := range entries {
+				val := e.Value
+				if !batteriesFlagReveal {
+					val = battery.Redact(val)
+				}
+				payload = append(payload, map[string]any{
+					"key":   e.Key,
+					"value": val,
+					"scope": string(e.Scope),
+				})
+			}
+			return config.WriteJSON(payload)
+		}
+
+		if len(entries) == 0 {
+			fmt.Fprintln(os.Stderr, "no batteries set. try: buttons batteries set KEY value")
+			return nil
+		}
+		for _, e := range entries {
+			val := e.Value
+			if !batteriesFlagReveal {
+				val = battery.Redact(val)
+			}
+			fmt.Printf("  %-24s  %-8s  %s\n", e.Key, e.Scope, val)
+		}
 		return nil
 	},
 }
 
 var batteriesRmCmd = &cobra.Command{
-	Use:   "rm [key]",
-	Short: "Remove an environment variable",
-	Args:  cobra.ExactArgs(1),
+	Use:     "rm KEY",
+	Aliases: []string{"remove", "delete"},
+	Short:   "Remove a battery",
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// TODO: implement in Phase 2.2 (#264)
-		if jsonOutput {
-			_ = config.WriteJSONError("NOT_IMPLEMENTED", "batteries rm not yet implemented")
-			return errSilent
+		key := args[0]
+		svc, err := newBatteryService()
+		if err != nil {
+			return handleBatteryError(err)
 		}
-		fmt.Fprintln(os.Stderr, "batteries rm: not yet implemented")
+		scope, err := resolveBatteryScope(svc)
+		if err != nil {
+			return handleBatteryError(err)
+		}
+		if err := svc.Delete(key, scope); err != nil {
+			return handleBatteryError(err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{
+				"key":   key,
+				"scope": string(scope),
+			})
+		}
+		fmt.Fprintf(os.Stderr, "removed %s (%s)\n", key, scope)
 		return nil
 	},
+}
+
+// newBatteryService resolves the global and (optionally) local paths
+// and returns a ready-to-use Service. Uses battery.NewServiceFromEnv
+// so tests can inject scratch dirs via BUTTONS_HOME; the project-
+// discovery closure keeps the battery package decoupled from the
+// config package.
+func newBatteryService() (*battery.Service, error) {
+	return battery.NewServiceFromEnv(func() (string, bool) {
+		if !config.IsProjectLocal() {
+			return "", false
+		}
+		dir, err := config.DataDir()
+		if err != nil {
+			return "", false
+		}
+		return dir, true
+	})
+}
+
+// resolveBatteryScope maps --global / --local / default flag state to a
+// battery.Scope. Default is local-if-available, else global — matches
+// the "inside a project you usually mean local" intuition.
+func resolveBatteryScope(svc *battery.Service) (battery.Scope, error) {
+	if batteriesFlagGlobal && batteriesFlagLocal {
+		return "", errors.New("cannot pass both --global and --local")
+	}
+	if batteriesFlagGlobal {
+		return battery.ScopeGlobal, nil
+	}
+	if batteriesFlagLocal {
+		return battery.ScopeLocal, nil
+	}
+	return svc.ResolveDefaultScope(), nil
+}
+
+func handleBatteryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	code := "VALIDATION_ERROR"
+	switch {
+	case errors.Is(err, battery.ErrNotFound):
+		code = "NOT_FOUND"
+	case errors.Is(err, battery.ErrLocalUnavailable):
+		code = "MISSING_ARG"
+	}
+	if jsonOutput {
+		_ = config.WriteJSONError(code, err.Error())
+		return errSilent
+	}
+	fmt.Fprintf(os.Stderr, "batteries: %v\n", err)
+	return errSilent
 }
 
 func init() {
 	rootCmd.AddCommand(batteriesCmd)
 	batteriesCmd.AddCommand(batteriesSetCmd)
+	batteriesCmd.AddCommand(batteriesGetCmd)
 	batteriesCmd.AddCommand(batteriesListCmd)
 	batteriesCmd.AddCommand(batteriesRmCmd)
+
+	for _, c := range []*cobra.Command{batteriesSetCmd, batteriesRmCmd} {
+		c.Flags().BoolVar(&batteriesFlagGlobal, "global", false, "target the global batteries file (~/.buttons/batteries.json)")
+		c.Flags().BoolVar(&batteriesFlagLocal, "local", false, "target the project-local batteries file (.buttons/batteries.json)")
+	}
+	batteriesListCmd.Flags().BoolVar(&batteriesFlagReveal, "reveal", false, "print values in full instead of redacted")
 }

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -95,7 +95,20 @@ Examples:
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 		defer cancel()
 
-		result := engine.Execute(ctx, btn, parsedArgs, codePath)
+		// Load batteries so secrets can reach the press as BUTTONS_BAT_<KEY>
+		// without the user hardcoding them in the script. A resolution error
+		// (e.g. unreadable batteries.json) should not silently skip; surface
+		// it with the rest of the press's structured-error handling.
+		batSvc, err := newBatteryService()
+		if err != nil {
+			return handleServiceError(err)
+		}
+		batteries, err := batSvc.Env()
+		if err != nil {
+			return handleServiceError(err)
+		}
+
+		result := engine.Execute(ctx, btn, parsedArgs, batteries, codePath)
 
 		// Attach prompt if AGENT.md has custom content (not the default template)
 		if promptMD := readPrompt(btn.Name); promptMD != "" {

--- a/internal/battery/battery.go
+++ b/internal/battery/battery.go
@@ -1,0 +1,349 @@
+// Package battery stores per-user and per-project environment variables
+// and secrets. Values are injected into button presses as
+// BUTTONS_BAT_<KEY>=<value> so shell / code buttons can read
+// `$BUTTONS_BAT_APIFY_TOKEN` without the token being baked into the
+// script file.
+//
+// Storage:
+//
+//	Global batteries  ~/.buttons/batteries.json
+//	Project batteries <project>/.buttons/batteries.json
+//
+// Both files are JSON maps of KEY → VALUE, wrapped in a small envelope
+// that carries a schema_version for future migrations. When a press
+// runs, the active environment is: global batteries + project batteries
+// (project overrides on key collision). Buttons don't see the scope
+// the value came from — only its KEY and VALUE.
+package battery
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// envelopeSchemaVersion is the top-level version tag stored in every
+// batteries.json file. Bump this when the on-disk shape changes.
+const envelopeSchemaVersion = 1
+
+// envelope is the on-disk shape of batteries.json. Storing batteries
+// under a nested key leaves room to add sibling fields later without a
+// v2 migration.
+type envelope struct {
+	SchemaVersion int               `json:"schema_version"`
+	Batteries     map[string]string `json:"batteries"`
+}
+
+// Scope names where a battery lives. A Scope is both an input (which
+// file to write) and an output (which file a list entry came from).
+type Scope string
+
+const (
+	// ScopeGlobal is ~/.buttons/batteries.json. Available in every press.
+	ScopeGlobal Scope = "global"
+	// ScopeLocal is the project .buttons/batteries.json for the active
+	// project directory. Only meaningful when running from inside a
+	// project tree; overrides ScopeGlobal on key collision.
+	ScopeLocal Scope = "local"
+)
+
+// keyPattern enforces POSIX env-var-friendly names. A malformed key
+// can't be exported to an exec.Cmd reliably and tends to indicate the
+// caller confused KEY and VALUE argument order.
+var keyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// Entry is one battery as surfaced by List. Value is the raw stored
+// string; redaction is the CLI's job, not the store's.
+type Entry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Scope Scope  `json:"scope"`
+}
+
+// Service is the file-backed battery store. Paths are resolved once at
+// construction; constructing a new Service is the way to react to a
+// cwd change mid-process (none of the CLI commands do that today).
+type Service struct {
+	globalPath string
+	// localPath is "" when the caller isn't inside a project tree. Set
+	// / rm operations that target local in that case return an error
+	// rather than silently falling back.
+	localPath string
+}
+
+// NewService constructs a Service with global + optional local paths.
+// globalDir is ~/.buttons (or $BUTTONS_HOME when set to its equivalent
+// per-user dir). localDir is the active project .buttons/ or "" if no
+// project is in scope.
+func NewService(globalDir, localDir string) *Service {
+	s := &Service{
+		globalPath: filepath.Join(globalDir, "batteries.json"),
+	}
+	if localDir != "" {
+		s.localPath = filepath.Join(localDir, "batteries.json")
+	}
+	return s
+}
+
+// NewServiceFromEnv resolves both paths from the environment in the
+// same way the CLI does, so press (cmd) and the TUI (internal/tui) can
+// share one implementation. Rules:
+//
+//   - $BUTTONS_HOME, if set, is treated as the global dir and no local
+//     layering is applied (tests and CI rely on this for determinism).
+//   - Otherwise global is ~/.buttons.
+//   - Local is the project-local .buttons/ walked up from
+//     projectDiscoverer (or nil to skip local layering entirely).
+//
+// projectDiscoverer is a function you pass in — typically
+// config.IsProjectLocal / config.DataDir — so this package stays
+// independent of the config package.
+func NewServiceFromEnv(projectDiscoverer func() (localDir string, ok bool)) (*Service, error) {
+	globalDir := os.Getenv("BUTTONS_HOME")
+	if globalDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("could not determine home directory: %w", err)
+		}
+		globalDir = filepath.Join(home, ".buttons")
+	}
+
+	localDir := ""
+	if os.Getenv("BUTTONS_HOME") == "" && projectDiscoverer != nil {
+		if dir, ok := projectDiscoverer(); ok && dir != globalDir {
+			localDir = dir
+		}
+	}
+
+	return NewService(globalDir, localDir), nil
+}
+
+// ErrLocalUnavailable is returned when an operation targets ScopeLocal
+// but no project directory is active.
+var ErrLocalUnavailable = errors.New("no project-local .buttons/ in scope; run from inside a project or use --global")
+
+// ErrNotFound is returned by Get / Delete when the key is absent.
+var ErrNotFound = errors.New("battery not found")
+
+// ValidateKey reports whether key matches the KEY convention. Exposed
+// so callers can validate before writing without reaching into the
+// store (useful for better error messages in the CLI).
+func ValidateKey(key string) error {
+	if !keyPattern.MatchString(key) {
+		return fmt.Errorf("invalid key %q: must match %s", key, keyPattern.String())
+	}
+	return nil
+}
+
+// ResolveDefaultScope picks ScopeLocal when a project is in scope, else
+// ScopeGlobal. Matches the "inside-a-project most people mean local"
+// intuition; the CLI's --global / --local flags override it.
+func (s *Service) ResolveDefaultScope() Scope {
+	if s.localPath != "" {
+		return ScopeLocal
+	}
+	return ScopeGlobal
+}
+
+// Set writes (or overwrites) a battery in the given scope.
+func (s *Service) Set(key, value string, scope Scope) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	path, err := s.pathFor(scope)
+	if err != nil {
+		return err
+	}
+	env, err := readEnvelope(path)
+	if err != nil {
+		return err
+	}
+	if env.Batteries == nil {
+		env.Batteries = map[string]string{}
+	}
+	env.Batteries[key] = value
+	return writeEnvelope(path, env)
+}
+
+// Get returns the raw value for key, preferring ScopeLocal when both
+// scopes have it. The returned Scope reports which file the value came
+// from — useful for CLI messaging.
+func (s *Service) Get(key string) (string, Scope, error) {
+	if err := ValidateKey(key); err != nil {
+		return "", "", err
+	}
+	if s.localPath != "" {
+		env, err := readEnvelope(s.localPath)
+		if err != nil {
+			return "", "", err
+		}
+		if v, ok := env.Batteries[key]; ok {
+			return v, ScopeLocal, nil
+		}
+	}
+	env, err := readEnvelope(s.globalPath)
+	if err != nil {
+		return "", "", err
+	}
+	if v, ok := env.Batteries[key]; ok {
+		return v, ScopeGlobal, nil
+	}
+	return "", "", ErrNotFound
+}
+
+// Delete removes key from the given scope.
+func (s *Service) Delete(key string, scope Scope) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	path, err := s.pathFor(scope)
+	if err != nil {
+		return err
+	}
+	env, err := readEnvelope(path)
+	if err != nil {
+		return err
+	}
+	if _, ok := env.Batteries[key]; !ok {
+		return ErrNotFound
+	}
+	delete(env.Batteries, key)
+	return writeEnvelope(path, env)
+}
+
+// List returns every battery from every scope in scope order (global
+// first, then local), each scope sorted by key. Local entries that
+// shadow global entries appear twice — CLI output can flag the shadow;
+// the Env method resolves the conflict.
+func (s *Service) List() ([]Entry, error) {
+	out := []Entry{}
+
+	globalEnv, err := readEnvelope(s.globalPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range sortedKeys(globalEnv.Batteries) {
+		out = append(out, Entry{Key: k, Value: globalEnv.Batteries[k], Scope: ScopeGlobal})
+	}
+
+	if s.localPath != "" {
+		localEnv, err := readEnvelope(s.localPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range sortedKeys(localEnv.Batteries) {
+			out = append(out, Entry{Key: k, Value: localEnv.Batteries[k], Scope: ScopeLocal})
+		}
+	}
+
+	return out, nil
+}
+
+// Env returns the flattened environment map used at press time: global
+// batteries merged with local batteries, local wins on collision. Keys
+// and values are returned raw — prefixing with BUTTONS_BAT_ is the
+// caller's responsibility so tests can inspect unprefixed values.
+func (s *Service) Env() (map[string]string, error) {
+	merged := map[string]string{}
+
+	globalEnv, err := readEnvelope(s.globalPath)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range globalEnv.Batteries {
+		merged[k] = v
+	}
+
+	if s.localPath != "" {
+		localEnv, err := readEnvelope(s.localPath)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range localEnv.Batteries {
+			merged[k] = v
+		}
+	}
+
+	return merged, nil
+}
+
+// Redact returns a display-safe rendering of value. Short values are
+// fully masked; longer ones keep the last 4 characters so an operator
+// can distinguish two similar secrets without leaking them wholesale.
+func Redact(value string) string {
+	if len(value) <= 4 {
+		return strings.Repeat("•", len(value))
+	}
+	return strings.Repeat("•", len(value)-4) + value[len(value)-4:]
+}
+
+// ------------------------------------------------------------------
+// Internal helpers
+// ------------------------------------------------------------------
+
+func (s *Service) pathFor(scope Scope) (string, error) {
+	switch scope {
+	case ScopeGlobal:
+		return s.globalPath, nil
+	case ScopeLocal:
+		if s.localPath == "" {
+			return "", ErrLocalUnavailable
+		}
+		return s.localPath, nil
+	default:
+		return "", fmt.Errorf("unknown scope %q", scope)
+	}
+}
+
+// readEnvelope loads an envelope from disk. A missing file is treated
+// as an empty envelope so callers don't have to special-case first-run.
+// A malformed file surfaces as an error — silent reset would lose data.
+func readEnvelope(path string) (envelope, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path fixed to batteries.json under DataDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return envelope{SchemaVersion: envelopeSchemaVersion, Batteries: map[string]string{}}, nil
+		}
+		return envelope{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return envelope{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if env.Batteries == nil {
+		env.Batteries = map[string]string{}
+	}
+	return env, nil
+}
+
+// writeEnvelope serializes env to path with 0o600 perms, creating the
+// parent directory if needed (global path under ~/.buttons/ should
+// always exist, but the project path can race a project-dir deletion).
+func writeEnvelope(path string, env envelope) error {
+	env.SchemaVersion = envelopeSchemaVersion
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create parent of %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/battery/battery_test.go
+++ b/internal/battery/battery_test.go
@@ -1,0 +1,172 @@
+package battery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateKey(t *testing.T) {
+	cases := []struct {
+		key string
+		ok  bool
+	}{
+		{"APIFY_TOKEN", true},
+		{"OPENAI_KEY_2", true},
+		{"A", true},
+		{"", false},
+		{"lowercase", false},
+		{"1LEADING_DIGIT", false},
+		{"HAS-DASH", false},
+		{"HAS SPACE", false},
+	}
+	for _, tc := range cases {
+		err := ValidateKey(tc.key)
+		if (err == nil) != tc.ok {
+			t.Errorf("ValidateKey(%q) ok=%v, err=%v", tc.key, tc.ok, err)
+		}
+	}
+}
+
+func TestRedact(t *testing.T) {
+	cases := map[string]string{
+		"":          "",
+		"a":         "•",
+		"abcd":      "••••",
+		"abcde":     "•bcde",
+		"longvalue": "•••••alue",
+	}
+	for in, want := range cases {
+		if got := Redact(in); got != want {
+			t.Errorf("Redact(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestService_SetGetDelete_GlobalOnly(t *testing.T) {
+	globalDir := t.TempDir()
+	svc := NewService(globalDir, "")
+
+	if err := svc.Set("APIFY_TOKEN", "secret", ScopeGlobal); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	v, scope, err := svc.Get("APIFY_TOKEN")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if v != "secret" {
+		t.Errorf("value = %q, want secret", v)
+	}
+	if scope != ScopeGlobal {
+		t.Errorf("scope = %q, want global", scope)
+	}
+
+	if err := svc.Delete("APIFY_TOKEN", ScopeGlobal); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, _, err := svc.Get("APIFY_TOKEN"); err != ErrNotFound {
+		t.Errorf("after delete, err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestService_LocalOverridesGlobal(t *testing.T) {
+	globalDir := t.TempDir()
+	localDir := t.TempDir()
+	svc := NewService(globalDir, localDir)
+
+	if err := svc.Set("TOKEN", "global-value", ScopeGlobal); err != nil {
+		t.Fatalf("set global: %v", err)
+	}
+	if err := svc.Set("TOKEN", "local-value", ScopeLocal); err != nil {
+		t.Fatalf("set local: %v", err)
+	}
+
+	v, scope, err := svc.Get("TOKEN")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if v != "local-value" {
+		t.Errorf("value = %q, want local-value", v)
+	}
+	if scope != ScopeLocal {
+		t.Errorf("scope = %q, want local", scope)
+	}
+
+	env, err := svc.Env()
+	if err != nil {
+		t.Fatalf("env: %v", err)
+	}
+	if env["TOKEN"] != "local-value" {
+		t.Errorf("env TOKEN = %q, want local-value", env["TOKEN"])
+	}
+}
+
+func TestService_LocalUnavailable(t *testing.T) {
+	svc := NewService(t.TempDir(), "")
+	if err := svc.Set("FOO", "bar", ScopeLocal); err != ErrLocalUnavailable {
+		t.Errorf("Set(local) err = %v, want ErrLocalUnavailable", err)
+	}
+	if err := svc.Delete("FOO", ScopeLocal); err != ErrLocalUnavailable {
+		t.Errorf("Delete(local) err = %v, want ErrLocalUnavailable", err)
+	}
+}
+
+func TestService_List_BothScopes(t *testing.T) {
+	globalDir := t.TempDir()
+	localDir := t.TempDir()
+	svc := NewService(globalDir, localDir)
+
+	if err := svc.Set("A_GLOBAL", "g", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Set("Z_GLOBAL", "z", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Set("B_LOCAL", "b", ScopeLocal); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := svc.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(entries))
+	}
+	// Global first, sorted alphabetically.
+	if entries[0].Key != "A_GLOBAL" || entries[0].Scope != ScopeGlobal {
+		t.Errorf("entries[0] = %+v", entries[0])
+	}
+	if entries[1].Key != "Z_GLOBAL" || entries[1].Scope != ScopeGlobal {
+		t.Errorf("entries[1] = %+v", entries[1])
+	}
+	if entries[2].Key != "B_LOCAL" || entries[2].Scope != ScopeLocal {
+		t.Errorf("entries[2] = %+v", entries[2])
+	}
+}
+
+func TestService_InvalidKey(t *testing.T) {
+	svc := NewService(t.TempDir(), "")
+	if err := svc.Set("lowercase", "v", ScopeGlobal); err == nil {
+		t.Errorf("Set(lowercase key) should fail")
+	}
+	if _, _, err := svc.Get("lowercase"); err == nil {
+		t.Errorf("Get(lowercase key) should fail")
+	}
+}
+
+func TestService_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(dir, "")
+	if err := svc.Set("FOO", "bar", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "batteries.json"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 600", perm)
+	}
+}

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -20,7 +20,10 @@ const sigTermGrace = 5 * time.Second
 
 // Execute runs a button with the given args and returns a Result.
 // For code/file buttons, codePath is the path to the code file in the button folder.
-func Execute(ctx context.Context, btn *button.Button, args map[string]string, codePath string) *Result {
+// batteries is the caller-provided map of battery KEY → VALUE; each entry is
+// injected into the child process as BUTTONS_BAT_<KEY> so shell / code buttons
+// can read secrets without baking them into the script file. Pass nil to skip.
+func Execute(ctx context.Context, btn *button.Button, args, batteries map[string]string, codePath string) *Result {
 	start := time.Now()
 	result := &Result{
 		Button:    btn.Name,
@@ -68,8 +71,17 @@ func Execute(ctx context.Context, btn *button.Button, args map[string]string, co
 	cmd := exec.Command(interpreter, codePath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Build environment: inherit current + button env + args as BUTTONS_ARG_<NAME>
+	// Build environment: inherit current + batteries + button env + args.
+	// Order matters: batteries precede button env which precede args, so a
+	// button-defined Env can override a battery and a per-press arg can
+	// override either (matches the specificity users expect — most specific
+	// wins). Keys exposed to the child process:
+	//   BUTTONS_BAT_<KEY>  battery value
+	//   BUTTONS_ARG_<NAME> arg value
 	env := os.Environ()
+	for k, v := range batteries {
+		env = append(env, "BUTTONS_BAT_"+k+"="+v)
+	}
 	for k, v := range btn.Env {
 		env = append(env, k+"="+v)
 	}

--- a/internal/engine/execute_test.go
+++ b/internal/engine/execute_test.go
@@ -4,12 +4,45 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/autonoco/buttons/internal/button"
 )
+
+// TestExecute_BatteriesInjectedAsEnv verifies the caller-provided
+// batteries map lands on the child process as BUTTONS_BAT_<KEY>. This
+// is the core contract of the batteries feature — a shell button has
+// to be able to read a battery with no ceremony.
+func TestExecute_BatteriesInjectedAsEnv(t *testing.T) {
+	dir := t.TempDir()
+	codePath := filepath.Join(dir, "main.sh")
+	script := "#!/bin/sh\nprintf %s \"$BUTTONS_BAT_APIFY_TOKEN\"\n"
+	if err := os.WriteFile(codePath, []byte(script), 0o700); err != nil { // #nosec G306 -- script must be executable
+		t.Fatal(err)
+	}
+
+	btn := &button.Button{
+		Name:           "echo-token",
+		Runtime:        "shell",
+		TimeoutSeconds: 5,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result := Execute(ctx, btn, nil, map[string]string{"APIFY_TOKEN": "secret123"}, codePath)
+
+	if result.Status != "ok" {
+		t.Fatalf("status=%q stderr=%q", result.Status, result.Stderr)
+	}
+	if result.Stdout != "secret123" {
+		t.Errorf("stdout = %q, want secret123", result.Stdout)
+	}
+}
 
 // streamingServer returns an httptest server that streams `total`
 // bytes of 'a' characters in 64 KB chunks with explicit flushes.
@@ -57,7 +90,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Default(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
@@ -92,7 +125,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Custom(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := Execute(ctx, btn, map[string]string{}, "")
+		result := Execute(ctx, btn, map[string]string{}, nil, "")
 		if result.Status != "ok" {
 			t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
 		}
@@ -119,7 +152,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Custom(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := Execute(ctx, btn, map[string]string{}, "")
+		result := Execute(ctx, btn, map[string]string{}, nil, "")
 		if result.Status != "ok" {
 			t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
 		}
@@ -156,7 +189,7 @@ func TestExecuteHTTP_SSRFBlocksLocalhostByDefault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, "")
 
 	if result.Status != "error" {
 		t.Fatalf("expected status 'error' for SSRF-blocked request, got %q", result.Status)
@@ -191,7 +224,7 @@ func TestExecuteHTTP_SSRFPerButtonOverride(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("expected status 'ok' with per-button override, got %q; stderr=%q", result.Status, result.Stderr)
@@ -224,7 +257,7 @@ func TestExecuteHTTP_SSRFEnvVarOverride(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("expected status 'ok' with env var override, got %q; stderr=%q", result.Status, result.Stderr)
@@ -254,7 +287,7 @@ func TestExecuteHTTP_SmallResponseUnaffected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -9,7 +9,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/autonoco/buttons/internal/battery"
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/engine"
 )
 
@@ -291,7 +293,20 @@ func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
 	m.status[name] = statusRunning
 
 	codePath, _ := m.svc.CodePath(name)
-	pressCmd := runPress(btn, codePath)
+
+	// Load batteries on each press so a battery added in another shell
+	// shows up without restarting the TUI. Silent fallback to empty env
+	// if resolution fails — the TUI can't usefully surface a batteries
+	// read error mid-press, and the user can always hit the CLI for a
+	// full error report.
+	batteries := map[string]string{}
+	if batSvc, err := battery.NewServiceFromEnv(tuiBatteryDiscoverer); err == nil {
+		if env, err := batSvc.Env(); err == nil {
+			batteries = env
+		}
+	}
+
+	pressCmd := runPress(btn, codePath, batteries)
 
 	// Start the spinner only if not already ticking — avoids tick storm.
 	if !m.ticking {
@@ -301,15 +316,29 @@ func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
 	return m, pressCmd
 }
 
-func runPress(btn *button.Button, codePath string) tea.Cmd {
+func runPress(btn *button.Button, codePath string, batteries map[string]string) tea.Cmd {
 	name := btn.Name
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(btn.TimeoutSeconds)*time.Second)
 		defer cancel()
 
-		result := engine.Execute(ctx, btn, nil, codePath)
+		result := engine.Execute(ctx, btn, nil, batteries, codePath)
 		return pressDoneMsg{name: name, result: result}
 	}
+}
+
+// tuiBatteryDiscoverer is the project-dir discoverer passed to
+// battery.NewServiceFromEnv — shared shape with the CLI helper but
+// defined here so the tui package doesn't reach into cmd.
+func tuiBatteryDiscoverer() (string, bool) {
+	if !config.IsProjectLocal() {
+		return "", false
+	}
+	dir, err := config.DataDir()
+	if err != nil {
+		return "", false
+	}
+	return dir, true
 }
 
 func (m Model) handlePressDone(msg pressDoneMsg) Model {


### PR DESCRIPTION
## Summary

Biggest pain point from your Apify dogfooding: `buttons batteries set` returned `NOT_IMPLEMENTED`, forcing Claude to bake the token into four `main.sh` files. This wires up the full store → inject pipeline so secrets stay out of script files.

## What's in

**Storage** — new `internal/battery` package with a file-backed store at `~/.buttons/batteries.json` (global) and `<project>/.buttons/batteries.json` (local). Local overrides global on key collision. 0600 perms. Stored JSON carries `schema_version` for migrations.

**CLI**
- `buttons batteries set KEY VALUE [--global|--local]` — default scope is local-in-project, global otherwise.
- `buttons batteries get KEY` — raw value to stdout for `$(buttons batteries get TOKEN)` shell patterns.
- `buttons batteries list [--reveal]` — values redacted by default (`••••••••last4`), full with `--reveal`.
- `buttons batteries rm KEY [--global|--local]`.
- Keys validated against `^[A-Z][A-Z0-9_]*$` so `buttons batteries set lowercase val` fails loudly.

**Engine** — `engine.Execute` grows a `batteries map[string]string` param. Every entry exports as `BUTTONS_BAT_<KEY>`. Ordered: battery → button.Env → per-press args (most-specific wins). `cmd/press` and `internal/tui/board` both load batteries via `battery.NewServiceFromEnv` before each press.

**Tests** — 6 unit tests in `internal/battery` plus a new engine test that writes a real shell script to `t.TempDir`, presses it with a battery, and asserts `$BUTTONS_BAT_*` was read by the child.

## What's out (next PRs)

- `{{bat.KEY}}` template substitution for HTTP button URL / headers / body. HTTP buttons still need env-var-in-template today; separate PR when HTTP templating lands.
- MCP tool access to batteries (Phase 2.3).
- Arg defaults and array arg type — the other two items from the dogfood session.

## End-to-end check

```
$ BUTTONS_HOME=/tmp/sbx buttons batteries set APIFY_TOKEN secret_xyz123
$ BUTTONS_HOME=/tmp/sbx buttons create show-token --runtime shell --code 'echo token=\$BUTTONS_BAT_APIFY_TOKEN'
$ BUTTONS_HOME=/tmp/sbx buttons press show-token
{ \"ok\": true, \"data\": { \"stdout\": \"token=secret_xyz123\n\", ... } }
```

## Test plan
- [x] `go build ./... && go vet ./... && go test -count=1 ./...`
- [x] `gosec ./...` — 0 issues
- [x] CLI smoke: set / get / list (redacted + reveal) / rm, invalid key rejection
- [x] End-to-end: shell button reads battery via `\$BUTTONS_BAT_*`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)