### PR TITLE
fix(create): raise default press timeout 60s → 300s

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -142,7 +142,11 @@ func init() {
 	createCmd.Flags().StringVar(&createBody, "body", "", "HTTP request body (supports {{arg}} templates)")
 	createCmd.Flags().StringVar(&createPrompt, "prompt", "", "prompt/instruction for the consuming agent (written to AGENT.md)")
 	createCmd.Flags().StringVarP(&createDescription, "description", "d", "", "button description")
-	createCmd.Flags().IntVar(&createTimeout, "timeout", 60, "execution timeout in seconds")
+	// 300s default: the old 60s cap bit real agent workloads — ETL jobs,
+	// long curls waiting on third-party APIs, DB migrations. Safety still
+	// comes from *having* a timeout, not from it being tight; users can
+	// shorten at create time or override per-press with --timeout.
+	createCmd.Flags().IntVar(&createTimeout, "timeout", 300, "execution timeout in seconds")
 	createCmd.Flags().StringVar(&createMaxResponseSize, "max-response-size", "", "max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M")
 	createCmd.Flags().BoolVar(&createAllowPrivateNetworks, "allow-private-networks", false, "allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.")
 	createCmd.Flags().StringArrayVar(&createArgs, "arg", nil, "argument definition (name:type:required|optional)")

--- a/test/integration/create_test.go
+++ b/test/integration/create_test.go
@@ -31,8 +31,8 @@ func TestCreate_Basic(t *testing.T) {
 	if btn.Runtime != "shell" {
 		t.Errorf("runtime = %q, want %q", btn.Runtime, "shell")
 	}
-	if btn.TimeoutSeconds != 60 {
-		t.Errorf("timeout = %d, want 60", btn.TimeoutSeconds)
+	if btn.TimeoutSeconds != 300 {
+		t.Errorf("timeout = %d, want 300 (default)", btn.TimeoutSeconds)
 	}
 	if btn.MCPEnabled {
 		t.Error("mcp_enabled should be false")


### PR DESCRIPTION
Dogfood flagged the 60s default as too tight. ETL jobs, long HTTP calls, and migrations hit the cap. Safety comes from having *a* timeout; shorten per-button at create time or per-press with --timeout.

Updated the integration test that asserted 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)