### PR TITLE
feat(history): auto-prune pressed/ to last 100 runs per button

### DIFF
--- a/internal/history/prune_test.go
+++ b/internal/history/prune_test.go
@@ -1,0 +1,96 @@
+package history
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPruneOldRuns_KeepsMostRecent(t *testing.T) {
+	dir := t.TempDir()
+	// Filenames are ISO-ish UTC timestamps in Record — use strings that
+	// sort correctly for this test.
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("2026-04-18T00-00-%02d.json", i)
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := pruneOldRuns(dir, 3); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 3 {
+		t.Fatalf("entries after prune = %d, want 3", len(entries))
+	}
+
+	// Remaining should be the three most recent names (sorted ascending,
+	// the last three are the newest by our timestamp convention).
+	wantRemaining := map[string]bool{
+		"2026-04-18T00-00-07.json": true,
+		"2026-04-18T00-00-08.json": true,
+		"2026-04-18T00-00-09.json": true,
+	}
+	for _, e := range entries {
+		if !wantRemaining[e.Name()] {
+			t.Errorf("unexpected survivor: %s", e.Name())
+		}
+	}
+}
+
+func TestPruneOldRuns_UnderLimit_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("2026-04-18T00-00-%02d.json", i)
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := pruneOldRuns(dir, 10); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 5 {
+		t.Errorf("entries = %d, want 5 (all survive)", len(entries))
+	}
+}
+
+func TestPruneOldRuns_IgnoresNonJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Mix json, non-json, and a subdir. Only json files are counted /
+	// subject to deletion.
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "c.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneOldRuns(dir, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect: README.txt + sub/ untouched; c.json, b.json survive; a.json gone.
+	for _, name := range []string{"README.txt", "sub", "b.json", "c.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("%s should still exist: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "a.json")); !os.IsNotExist(err) {
+		t.Errorf("a.json should be deleted; err = %v", err)
+	}
+}

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -15,6 +15,14 @@ import (
 
 const maxOutputBytes = 1 << 20 // 1MB
 
+// maxRunsPerButton caps how many press records we keep on disk per
+// button. After each Record, older entries beyond this cap are deleted
+// so `pressed/` doesn't grow unbounded for long-running automations.
+// 100 is generous for debugging ("what did the last few presses do?")
+// while still bounded — at ~1 MB per run that's 100 MB worst case per
+// button, and typical payloads are much smaller.
+const maxRunsPerButton = 100
+
 // Run represents a persisted execution record.
 type Run struct {
 	ButtonName     string            `json:"button_name"`
@@ -70,6 +78,44 @@ func Record(result *engine.Result) error {
 		return fmt.Errorf("failed to write run file: %w", err)
 	}
 
+	// Trim old runs so the pressed/ directory stays bounded. Swallow
+	// prune errors — a failed prune shouldn't fail the press path the
+	// user actually cares about; worst case the directory grows a
+	// little and the next successful Record catches up.
+	_ = pruneOldRuns(pressedDir, maxRunsPerButton)
+
+	return nil
+}
+
+// pruneOldRuns keeps the N most recent *.json files in pressedDir and
+// deletes the rest. Ordering uses the filename (which is an ISO-ish
+// UTC timestamp set by Record) so we don't have to stat every file —
+// cheaper and monotonic with how files are named.
+func pruneOldRuns(pressedDir string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	entries, err := os.ReadDir(pressedDir)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	if len(names) <= keep {
+		return nil
+	}
+	// Sort ascending (oldest first) so the slice to delete is the head.
+	sort.Strings(names)
+	toDelete := names[:len(names)-keep]
+	for _, name := range toDelete {
+		// Best-effort; a single failed unlink shouldn't stop the rest.
+		_ = os.Remove(filepath.Join(pressedDir, name))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Every press appended a run file with no cap. For long-running automations the pressed/ directory grew unbounded.

history.Record now prunes to maxRunsPerButton (100) after each successful write. Ordering by filename (ISO-ish UTC timestamp) is monotonic with recency — no stat per entry. Prune errors are swallowed so a failing directory scan can't fail a press.

Three tests: keep-most-recent, under-limit no-op, non-json siblings untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)