### PR TITLE
docs(help): surface common flags at top of create/press help

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -42,6 +42,15 @@ Arguments are defined with --arg in name:type:required|optional format.
 Supported types: string, int, bool. Args are injected as env vars for
 scripts or substituted into URL templates for API buttons.
 
+Common flags:
+  -f, --file PATH       copy an existing script file as this button's code
+      --code STRING     inline script body (shortcut for one-liners)
+      --url URL         turn this into an HTTP button
+      --arg SPEC        define an arg (name:type:required|optional, repeatable)
+      --timeout SECS    execution timeout (default: 300)
+  -d, --description S   human-readable description for 'buttons list'
+      --runtime NAME    shell | python | node  (default: shell)
+
 Examples:
   buttons create deploy                                  # scaffold, then edit main.sh
   buttons create etl --runtime python                    # scaffold, then edit main.py

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -28,6 +28,12 @@ Executes the action defined by the button, passing arguments as environment
 variables (BUTTONS_ARG_<NAME>) for code buttons, or as template substitutions
 for API buttons. Returns structured output in --json mode.
 
+Common flags:
+      --arg KEY=VALUE   pass an argument (repeatable; validated against the spec)
+      --timeout SECS    override the button's configured timeout for this press
+      --dry-run         print what would run without executing
+      --json            emit machine-readable output (default when stdout is piped)
+
 Examples:
   buttons press deploy --arg env=production
   buttons press weather --arg city=Miami --json


### PR DESCRIPTION
Dogfood: discovery tax. --timeout, --dry-run, --arg were buried in cobra's alphabetized flag dump. Added a "Common flags" section inside each Long description so the most-used flags read first, before the auto-generated list.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)