### PR TITLE
feat(cli): Next: hint after successful commands

### DIFF
--- a/cmd/batteries.go
+++ b/cmd/batteries.go
@@ -75,6 +75,7 @@ var batteriesSetCmd = &cobra.Command{
 			})
 		}
 		fmt.Fprintf(os.Stderr, "set %s (%s)\n", key, scope)
+		printNextHint("use $BUTTONS_BAT_%s in any shell/code button", key)
 		return nil
 	},
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -127,7 +127,15 @@ Examples:
 		} else if btn.Runtime == "prompt" {
 			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", filepath.Join(btnDir, "AGENT.md"))
 		}
-		fmt.Fprintf(os.Stderr, "  Press: buttons press %s\n", btn.Name)
+		// Build a press hint that's actually runnable — if the button
+		// has required args, stub them so the user can fill in values.
+		pressExample := "buttons press " + btn.Name
+		for _, a := range btn.Args {
+			if a.Required {
+				pressExample += fmt.Sprintf(" --arg %s=<%s>", a.Name, a.Type)
+			}
+		}
+		printNextHint(pressExample)
 		return nil
 	},
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -60,6 +60,7 @@ Examples:
 		}
 
 		fmt.Fprintf(os.Stderr, "Deleted button: %s\n", name)
+		printNextHint("buttons list")
 		return nil
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -226,7 +226,7 @@ func printInitSummary(cwd string, alreadyExisted bool, agentMDPath string, insta
 	}
 
 	fmt.Fprintf(os.Stderr, "\n")
-	fmt.Fprintf(os.Stderr, "  Try: buttons create hello --code 'echo \"Hello from %s\"'\n", filepath.Base(cwd))
+	printNextHint("buttons create hello --code 'echo \"Hello from %s\"'", filepath.Base(cwd))
 	return nil
 }
 

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -135,6 +135,7 @@ Examples:
 			if result.Stdout != "" {
 				fmt.Fprint(os.Stdout, result.Stdout)
 			}
+			printNextHint("buttons history %s", btn.Name)
 			return nil
 		case "error":
 			fmt.Fprintf(os.Stderr, "✗ %s failed (exit %d) in %dms\n", btn.Name, result.ExitCode, result.DurationMs)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,22 @@ func handleServiceError(err error) error {
 	return fmt.Errorf("%s: %s", se.Code, se.Message)
 }
 
+// printNextHint emits a single muted "Next: ..." line to stderr so a
+// human in the terminal sees the common follow-up after a successful
+// command — the idea is: don't make users re-`--help` to find the
+// next move.
+//
+// Skipped in --json mode (machines don't need prose hints) and when
+// stdout is piped (if you're feeding output into a pipeline you
+// probably don't want chatter either). Using Fprintln keeps the line
+// on stderr so stdout stays clean for piping.
+func printNextHint(format string, args ...any) {
+	if jsonOutput || config.IsNonTTY() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "  Next: "+format+"\n", args...)
+}
+
 // exactArgs returns a PositionalArgs validator like cobra.ExactArgs but with
 // a human-friendly error message that includes usage hints.
 func exactArgs(n int) cobra.PositionalArgs {


### PR DESCRIPTION
Unifies the pattern create.go already implicitly used ("Press: buttons press X"). Every command with a natural follow-up now emits a single "Next: ..." line to stderr.

Gated so it never leaks into pipelines:
- skipped in --json mode
- skipped when stdout is not a TTY

Covers create, press, batteries set, delete, init. Helper lives in cmd/root.go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)