### PR TITLE
feat(config): per-user settings with default-timeout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/settings"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Read and write per-user settings",
+	Long: `Manage per-user defaults stored in ~/.buttons/settings.json.
+
+Settings are global only — personal preferences shouldn't leak into
+project repos via .buttons/. Project-level knobs live on each button
+(e.g. 'buttons create --timeout N' pins a timeout for that button
+specifically).
+
+Known keys:
+  default-timeout   seconds used when 'buttons create' is run without
+                    an explicit --timeout flag (fallback: 300)
+
+Running ` + "`buttons config`" + ` with no subcommand prints the current values.
+
+Examples:
+  buttons config
+  buttons config set default-timeout 600
+  buttons config unset default-timeout`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return showConfig()
+	},
+}
+
+var configSetCmd = &cobra.Command{
+	Use:   "set KEY VALUE",
+	Short: "Set a setting",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc, err := settings.NewServiceFromEnv()
+		if err != nil {
+			return handleSettingsError(err)
+		}
+		if err := svc.Set(args[0], args[1]); err != nil {
+			return handleSettingsError(err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"key": args[0], "value": args[1]})
+		}
+		fmt.Fprintf(os.Stderr, "set %s = %s\n", args[0], args[1])
+		return nil
+	},
+}
+
+var configUnsetCmd = &cobra.Command{
+	Use:   "unset KEY",
+	Short: "Clear a setting (revert to built-in default)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc, err := settings.NewServiceFromEnv()
+		if err != nil {
+			return handleSettingsError(err)
+		}
+		if err := svc.Unset(args[0]); err != nil {
+			return handleSettingsError(err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"key": args[0], "unset": true})
+		}
+		fmt.Fprintf(os.Stderr, "unset %s\n", args[0])
+		return nil
+	},
+}
+
+// showConfig prints every known setting with its current value and
+// fallback source — so the user can see what's set vs what's using
+// the built-in default without hunting through the help output.
+func showConfig() error {
+	svc, err := settings.NewServiceFromEnv()
+	if err != nil {
+		return handleSettingsError(err)
+	}
+	st, err := svc.Load()
+	if err != nil {
+		return handleSettingsError(err)
+	}
+
+	if jsonOutput {
+		payload := map[string]any{}
+		if v, ok := st.DefaultTimeout(); ok {
+			payload[settings.KeyDefaultTimeout] = v
+		}
+		return config.WriteJSON(payload)
+	}
+
+	render := func(key string, value any, fallback string) {
+		if value == nil {
+			fmt.Fprintf(os.Stderr, "  %-18s  (unset — using %s)\n", key, fallback)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "  %-18s  %v\n", key, value)
+	}
+	if v, ok := st.DefaultTimeout(); ok {
+		render(settings.KeyDefaultTimeout, v, "")
+	} else {
+		render(settings.KeyDefaultTimeout, nil, "300s")
+	}
+	return nil
+}
+
+func handleSettingsError(err error) error {
+	if err == nil {
+		return nil
+	}
+	code := "VALIDATION_ERROR"
+	if jsonOutput {
+		_ = config.WriteJSONError(code, err.Error())
+		return errSilent
+	}
+	fmt.Fprintf(os.Stderr, "config: %v\n", err)
+	return errSilent
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configSetCmd)
+	configCmd.AddCommand(configUnsetCmd)
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -8,8 +8,15 @@ import (
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/settings"
 	"github.com/spf13/cobra"
 )
+
+// builtinCreateTimeoutDefault is the fallback timeout when the user
+// hasn't set one via 'buttons config set default-timeout' and didn't
+// pass --timeout explicitly. Kept close to the flag so the resolution
+// chain is readable in one place.
+const builtinCreateTimeoutDefault = 300
 
 var createFile string
 var createCode string
@@ -69,6 +76,13 @@ Examples:
 			return handleServiceError(err)
 		}
 
+		// Resolve effective timeout: explicit --timeout flag > user
+		// setting > built-in. cmd.Flags().Changed() is how we tell
+		// "user passed --timeout" apart from "user accepted the
+		// flag's default value" — matters because the flag's default
+		// is itself a fallback we want settings to override.
+		timeout := resolveCreateTimeout(cmd)
+
 		var maxResponseBytes int64
 		if createMaxResponseSize != "" {
 			maxResponseBytes, err = button.ParseSize(createMaxResponseSize)
@@ -99,7 +113,7 @@ Examples:
 			Body:                 createBody,
 			Prompt:               createPrompt,
 			Description:          createDescription,
-			TimeoutSeconds:       createTimeout,
+			TimeoutSeconds:       timeout,
 			MaxResponseBytes:     maxResponseBytes,
 			AllowPrivateNetworks: createAllowPrivateNetworks,
 			Args:                 argDefs,
@@ -147,6 +161,29 @@ Examples:
 		printNextHint(pressExample)
 		return nil
 	},
+}
+
+// resolveCreateTimeout picks the effective --timeout for this press:
+//
+//  1. Explicit --timeout flag on the command line.
+//  2. 'default-timeout' from ~/.buttons/settings.json.
+//  3. builtinCreateTimeoutDefault (300).
+//
+// Settings-read errors fall through silently to the built-in default
+// rather than failing the command — a bad settings file should never
+// block `buttons create`.
+func resolveCreateTimeout(cmd *cobra.Command) int {
+	if cmd.Flags().Changed("timeout") {
+		return createTimeout
+	}
+	if svc, err := settings.NewServiceFromEnv(); err == nil {
+		if st, err := svc.Load(); err == nil {
+			if v, ok := st.DefaultTimeout(); ok {
+				return v
+			}
+		}
+	}
+	return builtinCreateTimeoutDefault
 }
 
 func init() {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,163 @@
+// Package settings stores per-user defaults that apply across every
+// project. Single file at ~/.buttons/settings.json (mode 0600), nested
+// under a "defaults" block so new settings can land without a schema
+// bump.
+//
+// Why global-only: settings capture personal preference (how patient
+// are you; which runtime do you usually reach for). Making them
+// project-local would force every contributor to inherit another
+// person's taste, which isn't what anyone wants. Project-level knobs
+// exist at the per-button level (`buttons create --timeout N`).
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const schemaVersion = 1
+
+// Settings is the on-disk shape. Defaults is nested so adding sibling
+// blocks later (e.g. "ui", "history") doesn't require a v2 schema.
+type Settings struct {
+	SchemaVersion int      `json:"schema_version"`
+	Defaults      Defaults `json:"defaults"`
+}
+
+// Defaults collects every "used when the command didn't override"
+// knob. Pointer fields so unset keys can be distinguished from
+// zero-valued keys — we never want to apply a 0-second timeout
+// silently because someone set the key and then blanked the value.
+type Defaults struct {
+	TimeoutSeconds *int `json:"timeout_seconds,omitempty"`
+}
+
+// Service is the file-backed settings store. One file, one instance.
+type Service struct {
+	path string
+}
+
+// NewService constructs a Service with the settings file anchored at
+// globalDir/settings.json. globalDir should be the per-user buttons
+// home (normally ~/.buttons, or $BUTTONS_HOME when set for tests).
+func NewService(globalDir string) *Service {
+	return &Service{path: filepath.Join(globalDir, "settings.json")}
+}
+
+// NewServiceFromEnv resolves the settings path the same way the CLI
+// does so tests and production share one code path. $BUTTONS_HOME
+// overrides; otherwise ~/.buttons.
+func NewServiceFromEnv() (*Service, error) {
+	globalDir := os.Getenv("BUTTONS_HOME")
+	if globalDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("could not determine home directory: %w", err)
+		}
+		globalDir = filepath.Join(home, ".buttons")
+	}
+	return NewService(globalDir), nil
+}
+
+// ErrUnknownKey is returned when Set / Unset sees a key this build
+// doesn't recognise — better than silently writing a key nothing
+// reads, which is confusing when settings seem to have "no effect."
+var ErrUnknownKey = errors.New("unknown settings key")
+
+// Known flat keys. Kept in one place so the CLI, Get, and Set agree
+// on what exists.
+const (
+	KeyDefaultTimeout = "default-timeout"
+)
+
+// Load reads the settings file. A missing file returns a zero-value
+// Settings (with schema_version set) so callers don't have to
+// special-case first-run. A malformed file surfaces as an error —
+// silent reset would lose configuration.
+func (s *Service) Load() (*Settings, error) {
+	data, err := os.ReadFile(s.path) // #nosec G304 -- path fixed to settings.json under globalDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Settings{SchemaVersion: schemaVersion}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", s.path, err)
+	}
+	var st Settings
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", s.path, err)
+	}
+	if st.SchemaVersion == 0 {
+		st.SchemaVersion = schemaVersion
+	}
+	return &st, nil
+}
+
+// Save writes the settings file with 0o600 perms, creating the parent
+// directory if necessary. Always refreshes schema_version so a hand-
+// edited file can't accidentally downgrade.
+func (s *Service) Save(st *Settings) error {
+	st.SchemaVersion = schemaVersion
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create parent of %s: %w", s.path, err)
+	}
+	if err := os.WriteFile(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// Set updates a known key with a string value (parsed per the key's
+// type) and persists immediately. Unknown keys return ErrUnknownKey.
+func (s *Service) Set(key, value string) error {
+	st, err := s.Load()
+	if err != nil {
+		return err
+	}
+	switch key {
+	case KeyDefaultTimeout:
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("%s expects an integer, got %q", key, value)
+		}
+		if n <= 0 {
+			return fmt.Errorf("%s must be > 0, got %d", key, n)
+		}
+		st.Defaults.TimeoutSeconds = &n
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
+	}
+	return s.Save(st)
+}
+
+// Unset clears a known key and persists. No-op if the key wasn't set.
+func (s *Service) Unset(key string) error {
+	st, err := s.Load()
+	if err != nil {
+		return err
+	}
+	switch key {
+	case KeyDefaultTimeout:
+		st.Defaults.TimeoutSeconds = nil
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
+	}
+	return s.Save(st)
+}
+
+// DefaultTimeout returns (value, true) when the user has set one, else
+// (0, false). Caller supplies its own fallback so this package doesn't
+// have to agree with every caller on what "fallback when unset" is.
+func (st *Settings) DefaultTimeout() (int, bool) {
+	if st == nil || st.Defaults.TimeoutSeconds == nil {
+		return 0, false
+	}
+	return *st.Defaults.TimeoutSeconds, true
+}

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1,0 +1,92 @@
+package settings
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestService_LoadMissingFile(t *testing.T) {
+	svc := NewService(t.TempDir())
+	st, err := svc.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if st.SchemaVersion != schemaVersion {
+		t.Errorf("schema = %d, want %d", st.SchemaVersion, schemaVersion)
+	}
+	if _, ok := st.DefaultTimeout(); ok {
+		t.Errorf("expected DefaultTimeout unset on first load")
+	}
+}
+
+func TestService_SetAndLoad_DefaultTimeout(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(dir)
+	if err := svc.Set(KeyDefaultTimeout, "600"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	st, err := svc.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := st.DefaultTimeout()
+	if !ok {
+		t.Fatal("DefaultTimeout should be set")
+	}
+	if v != 600 {
+		t.Errorf("timeout = %d, want 600", v)
+	}
+}
+
+func TestService_Set_InvalidTimeout(t *testing.T) {
+	svc := NewService(t.TempDir())
+	cases := []string{"", "abc", "0", "-5"}
+	for _, c := range cases {
+		if err := svc.Set(KeyDefaultTimeout, c); err == nil {
+			t.Errorf("Set(%q) should fail", c)
+		}
+	}
+}
+
+func TestService_Unset(t *testing.T) {
+	svc := NewService(t.TempDir())
+	if err := svc.Set(KeyDefaultTimeout, "600"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Unset(KeyDefaultTimeout); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	st, _ := svc.Load()
+	if _, ok := st.DefaultTimeout(); ok {
+		t.Errorf("DefaultTimeout should be unset after Unset")
+	}
+}
+
+func TestService_UnknownKey(t *testing.T) {
+	svc := NewService(t.TempDir())
+	err := svc.Set("nope", "value")
+	if !errors.Is(err, ErrUnknownKey) {
+		t.Errorf("Set(nope): err = %v, want ErrUnknownKey", err)
+	}
+	err = svc.Unset("nope")
+	if !errors.Is(err, ErrUnknownKey) {
+		t.Errorf("Unset(nope): err = %v, want ErrUnknownKey", err)
+	}
+}
+
+func TestService_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(dir)
+	if err := svc.Set(KeyDefaultTimeout, "100"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 600", perm)
+	}
+}

--- a/test/integration/create_test.go
+++ b/test/integration/create_test.go
@@ -32,7 +32,7 @@ func TestCreate_Basic(t *testing.T) {
 		t.Errorf("runtime = %q, want %q", btn.Runtime, "shell")
 	}
 	if btn.TimeoutSeconds != 300 {
-		t.Errorf("timeout = %d, want 300 (default)", btn.TimeoutSeconds)
+		t.Errorf("timeout = %d, want 300 (built-in default when no --timeout and no settings)", btn.TimeoutSeconds)
 	}
 	if btn.MCPEnabled {
 		t.Error("mcp_enabled should be false")


### PR DESCRIPTION
## Summary

Per-user settings stored at `~/.buttons/settings.json` (mode 0600). Global only — personal preferences shouldn't leak into project repos via .buttons/. First wired key: `default-timeout`.

```
buttons config                            # show everything
buttons config set default-timeout 600    # save
buttons config unset default-timeout      # clear, back to built-in
```

### Timeout resolution at `buttons create`
1. Explicit `--timeout` flag
2. `default-timeout` from settings.json
3. Built-in 300s

`cmd.Flags().Changed("timeout")` is how we tell "user passed --timeout" apart from "user accepted the flag's declared default" — the flag's default is itself a fallback we want settings to override.

### Design choices
- **Nested schema** (`defaults: {timeout_seconds}`) so adding sibling blocks (ui, history) later doesn't bump `schema_version`.
- **Pointer fields** to distinguish unset from zero — never silently apply a 0-second timeout because someone blanked the key.
- **Settings-read errors fall through** to the built-in default. A garbled `settings.json` shouldn't block `buttons create`.
- **`default-runtime` deferred.** Touching runtime resolution broke `--url` / `--prompt` buttons (they rely on `runtime=""` as the "auto-infer HTTP" signal). Will land in a separate PR when there's a clean way to layer without fighting the empty-string-is-inference contract.

### Conflict with #62
Same integration-test edit (TestCreate_Basic asserts 300 now, was 60). Three-way merge when one lands first.

## Test plan
- [x] Unit tests for Load/Save/Set/Unset, invalid values, file mode 0o600
- [x] Smoke tested end-to-end: `config set` → `config` → `create` inherits → `config unset`
- [x] Full `go test ./...` and `gosec ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)