### PR TITLE
fix(release): disable buildx attestations so docker_manifests can verify

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,6 +130,18 @@ dockers:
       - "ghcr.io/autonoco/buttons:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      # Disable buildx attestation manifests. Without these flags, buildx
+      # >= 0.10 pushes an OCI image index with provenance + SBOM
+      # attestations. `docker manifest create` (used by the
+      # docker_manifests: block below) expects plain Docker v2 manifests
+      # and rejects the attestation index with "manifest verification
+      # failed for digest <sha>". Keeping attestations off here is the
+      # canonical fix for goreleaser + buildx + GHCR. Revisit when we
+      # migrate to dockers_v2 (goreleaser's new native buildx path),
+      # which creates multi-arch manifests via buildx itself and can
+      # keep attestations enabled.
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.title=buttons"
       - "--label=org.opencontainers.image.description=Deterministic workflow engine for AI agents"
       - "--label=org.opencontainers.image.source=https://github.com/autonoco/buttons"
@@ -151,6 +163,9 @@ dockers:
       - "ghcr.io/autonoco/buttons:latest-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      # Same attestation-disable rationale as the amd64 block above.
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.title=buttons"
       - "--label=org.opencontainers.image.description=Deterministic workflow engine for AI agents"
       - "--label=org.opencontainers.image.source=https://github.com/autonoco/buttons"


### PR DESCRIPTION
## Summary

v0.45.0 release failed with `manifest verification failed for digest sha256:b33f0d...` — 10 retries over 25 minutes, never recovered. Not a transient: the digest won't ever match.

### Root cause

`docker buildx` (via `use: buildx`) in the `dockers:` blocks publishes an **OCI image index with provenance + SBOM attestations** — default behavior for buildx >= 0.10, which ships with `setup-buildx-action@v4`. The separate `docker_manifests:` block uses the legacy `docker manifest create`, which expects plain Docker v2 manifests and rejects attestation manifests as digest-mismatches.

The per-arch image pushes succeed. The multi-arch manifest step fails.

### Fix

Disable provenance + SBOM attestations on both per-arch docker blocks with:

```yaml
- "--provenance=false"
- "--sbom=false"
```

Makes buildx emit plain Docker v2 manifests that `docker manifest create` can verify. Canonical answer for the goreleaser + buildx + GHCR stack. `goreleaser check` passes.

### Longer term

The deprecation warning on `dockers`/`docker_manifests` points at `dockers_v2`, which drives buildx natively and creates multi-arch manifests without the legacy tool — that path can keep attestations enabled. Separate PR once this unblocks v0.45.0.

### Re-release after merge

Once this lands, the failed v0.45.0 tag either needs to be deleted and re-pushed, or bump to v0.45.1. Release workflow won't re-run against a partial release without a new tag push.

## Test plan
- [x] `goreleaser check` passes locally
- [ ] Cut a new tag (v0.45.1 or re-push v0.45.0) and confirm release succeeds end-to-end on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)