### PR TITLE
docs(ui): add design spec + implementation plan for the TUI

### DIFF
--- a/context/plans/buttons-ui/Buttons CLI.html
+++ b/context/plans/buttons-ui/Buttons CLI.html
@@ -1,0 +1,1771 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>buttons — CLI</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&family=Bowlby+One+SC&display=swap" rel="stylesheet">
+<style>
+/* ─────────────────────────────────────────────────────────────
+   TOKENS — anchored to the identity spec in internal/tui/styles.go
+   Ink #0A0A0A · Indicator #FF5A1F · Paper #F5F5F2
+   Aluminum #C5C5C0 · Dust #6E6E68
+   The TUI itself is dark by default (terminal). We pin an
+   ALUMINUM case around the terminal window to echo the TP-7 /
+   Nostromo hardware-panel inspo without inventing new colors.
+   ───────────────────────────────────────────────────────────── */
+:root{
+  --ink:#0A0A0A;
+  --indicator:#FF5A1F;
+  --indicator-dim:#7a2d10;
+  --paper:#F5F5F2;
+  --aluminum:#C5C5C0;
+  --dust:#6E6E68;
+
+  /* Terminal inside surface */
+  --term-bg:#0b0b0b;
+  --term-bg-2:#0f0f0f;
+  --term-fg:#e9e7df;
+  --term-dim:#8a8880;
+  --term-mute:#4a4844;
+  --term-line:#1f1e1a;
+
+  /* Hardware case */
+  --case-bg:#1a1a18;
+  --case-bg-2:#141413;
+  --case-edge:#2a2a27;
+  --case-stencil:#8a8880;
+  --panel-label:#b5b2a6;
+
+  --mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --disp: 'Bowlby One SC', 'Space Grotesk', sans-serif;
+  --sans: 'Space Grotesk', system-ui, sans-serif;
+}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:var(--sans);
+  background:
+    radial-gradient(1200px 800px at 30% 10%, #262622 0%, #0e0e0d 60%, #050505 100%);
+  color:var(--paper);
+  min-height:100vh;
+  padding:48px 24px 96px;
+  -webkit-font-smoothing:antialiased;
+}
+
+/* ─── Top meta bar ──────────────────────────────────────────── */
+.meta{
+  max-width:1280px;
+  margin:0 auto 28px;
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:24px;
+  color:var(--aluminum);
+}
+.meta .wordmark{
+  font-family:var(--disp);
+  font-size:28px;
+  letter-spacing:.02em;
+  color:var(--paper);
+  line-height:.95;
+}
+.meta .wordmark span{color:var(--indicator)}
+.meta .sub{
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--dust);
+  display:flex; gap:18px; flex-wrap:wrap;
+}
+.meta .sub b{color:var(--aluminum); font-weight:500}
+
+/* ─── Canvas grid of stations ───────────────────────────────── */
+.canvas{
+  max-width:1280px;
+  margin:0 auto;
+  display:grid;
+  grid-template-columns:repeat(12, 1fr);
+  gap:24px;
+}
+.station{
+  grid-column:span 12;
+  position:relative;
+}
+.station .caption{
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  color:var(--dust);
+  margin:0 0 10px 2px;
+  display:flex;
+  gap:14px;
+  align-items:baseline;
+}
+.station .caption b{color:var(--paper); font-weight:500}
+.station .caption em{color:var(--indicator); font-style:normal}
+
+/* ─── Hardware case wrapping the terminal ───────────────────── */
+.case{
+  background:
+    linear-gradient(180deg, #1e1e1b 0%, #141412 100%);
+  border-radius:22px;
+  padding:22px;
+  position:relative;
+  box-shadow:
+    0 2px 0 rgba(255,255,255,.04) inset,
+    0 -2px 0 rgba(0,0,0,.6) inset,
+    0 40px 80px -40px rgba(0,0,0,.9),
+    0 0 0 1px rgba(255,255,255,.03);
+  overflow:hidden;
+}
+.case::before{
+  /* subtle machined texture */
+  content:"";
+  position:absolute; inset:0;
+  background:
+    repeating-linear-gradient(0deg,
+      rgba(255,255,255,.012) 0 1px, transparent 1px 3px);
+  pointer-events:none;
+}
+.case-bar{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  padding:0 4px 16px;
+  color:var(--case-stencil);
+  font-family:var(--mono);
+  font-size:10px;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+}
+.case-bar .serial{margin-left:auto; color:var(--dust)}
+.case-bar .dots{display:flex; gap:6px}
+.case-bar .dots i{
+  width:10px; height:10px; border-radius:50%;
+  background:#2a2a27;
+  box-shadow:inset 0 1px 1px rgba(0,0,0,.7), 0 1px 0 rgba(255,255,255,.04);
+  display:block;
+}
+.case-bar .dots i.on{background:var(--indicator); box-shadow:0 0 8px rgba(255,90,31,.6), inset 0 1px 1px rgba(0,0,0,.6)}
+.case-bar .dots i.grn{background:#7a9a3a; box-shadow:0 0 6px rgba(130,170,60,.45), inset 0 1px 1px rgba(0,0,0,.6)}
+
+.bezel{
+  background:#070706;
+  border-radius:12px;
+  padding:14px;
+  box-shadow:
+    inset 0 0 0 1px #000,
+    inset 0 0 0 4px #0d0d0b,
+    inset 0 2px 14px rgba(0,0,0,.8);
+  position:relative;
+}
+.screen{
+  position:relative;
+  background:var(--term-bg);
+  border-radius:4px;
+  overflow:hidden;
+  box-shadow:
+    inset 0 0 60px rgba(0,0,0,.6),
+    inset 0 0 0 1px #000;
+}
+.screen.scanlines::after{
+  content:"";
+  position:absolute; inset:0;
+  background:repeating-linear-gradient(180deg,
+    rgba(255,255,255,.03) 0 1px, transparent 1px 3px);
+  pointer-events:none;
+  mix-blend-mode:overlay;
+}
+.screen::before{
+  /* glass sheen */
+  content:"";
+  position:absolute; inset:0;
+  background:
+    radial-gradient(140% 60% at 50% -10%, rgba(255,255,255,.06), transparent 60%);
+  pointer-events:none;
+}
+
+/* ─── Case footer chrome ─────────────────────────────────────── */
+.case-footer{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:16px 4px 0;
+  gap:18px;
+  color:var(--case-stencil);
+  font-family:var(--mono);
+  font-size:10px;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+}
+.case-footer .vents{
+  display:flex; gap:3px;
+}
+.case-footer .vents i{
+  display:block; width:3px; height:16px; border-radius:2px;
+  background:#0a0a09;
+  box-shadow:inset 0 0 0 1px #242421;
+}
+.case-footer .pill{
+  padding:4px 10px;
+  border-radius:2px;
+  border:1px solid #2a2a27;
+  color:var(--panel-label);
+  background:#0e0e0c;
+}
+.case-footer .pill.hot{color:var(--indicator); border-color:var(--indicator-dim)}
+
+/* ─── The TUI (inside .screen) ──────────────────────────────── */
+.tui{
+  font-family:var(--mono);
+  font-size:13px;
+  line-height:1.5;
+  color:var(--term-fg);
+  padding:18px 20px;
+  min-height:520px;
+  position:relative;
+  z-index:1;
+}
+.tui .row{display:flex; gap:0; align-items:center}
+
+/* Header */
+.tui-header{
+  display:flex; justify-content:space-between; align-items:center;
+  color:var(--term-fg);
+}
+.tui-header .brand{
+  font-weight:700;
+  letter-spacing:.02em;
+}
+.tui-header .brand::before{
+  content:"● ";
+  color:var(--indicator);
+  text-shadow:0 0 8px rgba(255,90,31,.5);
+  font-size:11px;
+  vertical-align:1px;
+}
+.tui-header .right{color:var(--term-dim)}
+.tui-header .right b{color:var(--term-fg); font-weight:500}
+
+.rule{
+  color:var(--term-mute);
+  margin:10px 0;
+  overflow:hidden;
+  white-space:nowrap;
+}
+
+/* Pinned cards row */
+.pins{
+  display:flex; gap:16px; padding:2px 0 2px;
+}
+.pin{
+  border:1px solid var(--term-mute);
+  padding:8px 18px;
+  color:var(--term-fg);
+  min-width:130px;
+  text-align:center;
+  font-weight:500;
+  letter-spacing:.02em;
+  position:relative;
+  cursor:pointer;
+  user-select:none;
+  transition:transform 60ms linear, box-shadow 60ms linear, background 60ms linear;
+}
+.pin:hover{
+  border-color:var(--term-fg);
+  box-shadow:0 0 0 1px var(--term-fg) inset;
+}
+.pin.sel{
+  border-color:var(--term-fg);
+  border-width:1px;
+  box-shadow:0 0 0 1px var(--term-fg) inset;
+  font-weight:700;
+}
+.pin.act{
+  border-color:var(--indicator);
+  color:var(--indicator);
+  box-shadow:0 0 0 1px var(--indicator) inset, 0 0 18px rgba(255,90,31,.18);
+  font-weight:700;
+}
+/* Mechanical press state for pinned buttons — same 4-frame choreo as pressbtn */
+.pin.kd{
+  transform:translateY(1px);
+  background:var(--term-line);
+  box-shadow:
+    inset 0 2px 0 rgba(0,0,0,.5),
+    inset 0 -1px 0 rgba(255,255,255,.04),
+    0 0 0 1px var(--term-fg) inset;
+}
+.pin.fire{
+  transform:translateY(1px);
+  background:var(--indicator);
+  color:#0a0a09;
+  border-color:var(--indicator);
+  box-shadow:0 0 22px rgba(255,90,31,.55), 0 0 0 1px var(--indicator) inset;
+}
+.pin.fire small{color:#0a0a09; opacity:.8}
+.pin small{
+  display:block;
+  font-size:9px;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  color:var(--term-dim);
+  margin-top:4px;
+}
+.pin.act small{color:var(--indicator)}
+.pin.act::after{
+  /* Little "tap to tail logs" hint on ACTIVE pins */
+  content:"↵ tail";
+  position:absolute;
+  top:-7px; right:-7px;
+  font-family:var(--mono);
+  font-size:9px;
+  letter-spacing:.18em;
+  padding:1px 5px;
+  background:#0b0b0b;
+  color:var(--indicator);
+  border:1px solid var(--indicator);
+  text-transform:uppercase;
+}
+
+/* List rows */
+.list{margin-top:2px}
+.list .lrow{
+  display:grid;
+  grid-template-columns:20px 1fr auto auto;
+  gap:10px;
+  padding:2px 0;
+  align-items:center;
+}
+.list .lrow .glyph{color:var(--term-mute); text-align:center}
+.list .lrow .name{color:var(--term-fg)}
+.list .lrow .name .arrow{color:var(--term-fg); font-weight:700}
+.list .lrow .meta{color:var(--term-dim)}
+.list .lrow.sel .name{font-weight:700}
+.list .lrow.sel .glyph{color:var(--term-fg)}
+.list .lrow.ok .glyph{color:#b9c28e}
+.list .lrow.err .glyph{color:var(--indicator)}
+.list .lrow.run .glyph{color:var(--indicator); text-shadow:0 0 6px rgba(255,90,31,.5)}
+.list .lrow.run .name{color:var(--indicator); font-weight:700}
+.list .lrow .badge{
+  background:var(--indicator);
+  color:#0a0a09;
+  padding:1px 8px;
+  font-weight:700;
+  letter-spacing:.24em;
+  font-size:10px;
+}
+
+/* Footer hints + press pill */
+.footer-row{
+  display:flex; justify-content:space-between; align-items:center;
+  gap:24px;
+  margin-top:6px;
+}
+.pressbtn{
+  background:var(--paper);
+  color:var(--ink);
+  padding:4px 18px;
+  font-weight:700;
+  letter-spacing:.02em;
+  border:1px solid var(--paper);
+  position:relative;
+}
+.pressbtn.disabled{
+  background:transparent;
+  color:var(--term-mute);
+  border-color:var(--term-mute);
+}
+.hints{
+  display:flex; gap:14px; align-items:center; color:var(--term-dim)
+}
+.kbd{
+  background:#1c1c19;
+  color:var(--term-fg);
+  padding:1px 8px;
+  font-weight:700;
+  letter-spacing:.02em;
+  border:1px solid #242420;
+  margin-right:6px;
+}
+.sep{color:var(--term-mute)}
+
+/* Toasts */
+.toast-ok{color:#b9c28e; margin-top:12px}
+.toast-ok::before{content:"✓  "; color:#b9c28e}
+.toast-err{color:var(--indicator); margin-top:12px}
+.toast-err::before{content:"!  "; color:var(--indicator)}
+
+/* Logs pane */
+.logs{margin-top:8px}
+.logs .title{color:var(--term-fg); font-weight:700}
+.logs .title .meta{color:var(--term-dim); font-weight:400; margin-left:10px}
+.logs .lg{
+  display:grid;
+  grid-template-columns:20px 80px 150px 1fr;
+  gap:10px;
+  padding:2px 0;
+  color:var(--term-dim);
+}
+.logs .lg .g.ok{color:#b9c28e}
+.logs .lg .g.er{color:var(--indicator)}
+.logs .lg .pv{color:var(--term-fg)}
+
+/* Arg form */
+.argform .label{color:var(--term-dim); margin-right:8px}
+.argform .field{
+  display:inline-block;
+  border-bottom:1px solid var(--term-mute);
+  min-width:200px;
+  padding:2px 4px;
+  color:var(--term-fg);
+}
+.argform .field.focus{
+  border-bottom-color:var(--indicator);
+  box-shadow:0 1px 0 var(--indicator);
+  color:var(--term-fg);
+}
+.argform .field .caret{
+  display:inline-block;
+  width:8px; height:1.1em;
+  background:var(--indicator);
+  vertical-align:-2px;
+  margin-left:1px;
+  animation:blink 1s steps(2,start) infinite;
+}
+@keyframes blink{50%{opacity:0}}
+.argform .hint{color:var(--term-mute); font-style:italic; margin-left:10px}
+
+/* Spec block (detail view) */
+.spec{
+  display:grid;
+  grid-template-columns:110px 1fr;
+  gap:0 18px;
+  color:var(--term-fg);
+}
+.spec dt{color:var(--term-dim); text-transform:lowercase}
+.spec dd{margin:0; color:var(--term-fg)}
+
+/* Diff-ish blocks for create wizard */
+.code{
+  background:#080807;
+  border:1px solid var(--term-line);
+  padding:8px 12px;
+  margin:6px 0;
+  color:var(--term-fg);
+  white-space:pre;
+  overflow:hidden;
+}
+.code .c{color:var(--term-dim)}
+.code .k{color:var(--term-fg); font-weight:700}
+.code .a{color:var(--indicator)}
+.code .s{color:#b9c28e}
+
+/* Dual-pane */
+.two-up{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:28px;
+}
+@media (max-width:1024px){ .two-up{grid-template-columns:1fr} }
+
+/* Theme variants */
+.screen.phos{
+  --term-fg:#b8f3c3;
+  --term-dim:#5aa06a;
+  --term-mute:#2d4a32;
+  --term-bg:#061109;
+  --term-line:#0f2014;
+}
+.screen.phos .tui-header .brand::before{color:#b8f3c3; text-shadow:0 0 8px rgba(184,243,195,.7)}
+.screen.phos .list .lrow.run .glyph,
+.screen.phos .list .lrow.run .name,
+.screen.phos .pin.act{color:#fff5a0; border-color:#fff5a0; box-shadow:0 0 0 1px #fff5a0 inset, 0 0 18px rgba(255,245,160,.2)}
+.screen.phos .list .lrow.err .glyph,
+.screen.phos .toast-err{color:#ff8a6c}
+.screen.phos .pressbtn{background:#b8f3c3; border-color:#b8f3c3; color:#06130a}
+.screen.phos .list .lrow .badge{background:#fff5a0; color:#06130a}
+.screen.phos{background:radial-gradient(120% 80% at 50% 0%, #0a2415 0%, #061109 70%)}
+
+.screen.amber{
+  --term-fg:#f7c472;
+  --term-dim:#a56b2c;
+  --term-mute:#3a2612;
+  --term-bg:#100803;
+  --term-line:#1a0e04;
+}
+.screen.amber .tui-header .brand::before{color:#ffbe5a; text-shadow:0 0 10px rgba(255,190,90,.8)}
+.screen.amber .pressbtn{background:#f7c472; border-color:#f7c472; color:#200f03}
+.screen.amber .list .lrow .badge{background:#ffbe5a; color:#200f03}
+
+.screen.paper{
+  --term-fg:#0a0a0a;
+  --term-dim:#6e6e68;
+  --term-mute:#c5c5c0;
+  --term-bg:#f5f5f2;
+  --term-line:#e4e3df;
+}
+.screen.paper .tui-header .brand::before{color:var(--indicator); text-shadow:none}
+.screen.paper .kbd{background:#e8e8e3; color:#0a0a0a; border-color:#d8d8d3}
+.screen.paper .pressbtn{background:#0a0a0a; color:#f5f5f2; border-color:#0a0a0a}
+.screen.paper .code{background:#ecebe6; border-color:#d8d8d3}
+
+/* ─── Tweaks panel ──────────────────────────────────────────── */
+.tweaks{
+  position:fixed; right:18px; bottom:18px;
+  background:#141413;
+  border:1px solid #2a2a27;
+  border-radius:10px;
+  padding:14px 14px 10px;
+  color:var(--paper);
+  font-family:var(--mono);
+  font-size:11px;
+  width:260px;
+  box-shadow:0 20px 50px -20px rgba(0,0,0,.9);
+  display:none;
+  z-index:40;
+}
+.tweaks.on{display:block}
+.tweaks h4{
+  margin:0 0 10px;
+  font-family:var(--disp);
+  font-size:13px;
+  letter-spacing:.12em;
+  color:var(--paper);
+}
+.tweaks h4 span{color:var(--indicator)}
+.tweaks .grp{margin-bottom:10px}
+.tweaks .lbl{
+  color:var(--dust);
+  font-size:9px;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  margin-bottom:4px;
+}
+.tweaks .seg{
+  display:grid;
+  grid-template-columns:repeat(4, 1fr);
+  gap:4px;
+}
+.tweaks .seg button{
+  background:#0e0e0c;
+  border:1px solid #2a2a27;
+  color:var(--paper);
+  padding:6px 0;
+  font-family:var(--mono);
+  font-size:10px;
+  cursor:pointer;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+.tweaks .seg button.on{background:var(--indicator); color:#0a0a09; border-color:var(--indicator)}
+.tweaks .row2{display:flex; gap:8px}
+.tweaks .row2 button{flex:1}
+
+/* Page sections */
+h2.section{
+  max-width:1280px;
+  margin:72px auto 18px;
+  font-family:var(--disp);
+  font-size:24px;
+  letter-spacing:.04em;
+  color:var(--paper);
+  display:flex; align-items:baseline; gap:14px;
+}
+h2.section small{
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  color:var(--dust);
+  font-weight:400;
+}
+h2.section::before{
+  content:"";
+  display:inline-block;
+  width:10px; height:10px;
+  background:var(--indicator);
+  box-shadow:0 0 10px rgba(255,90,31,.6);
+}
+
+.spinframe{animation:spin .9s steps(10) infinite}
+@keyframes spin{to{transform:rotate(1turn)}}
+
+.spin-b{display:inline-block; width:1ch; text-align:center}
+.spin-b::before{
+  content:"⠋";
+  animation:spinb .9s steps(10) infinite;
+}
+
+/* ─── Mechanical press treatment ────────────────────────────── */
+/* Real key-press on Enter: 80ms frame flip. Uses lipgloss-legal
+   moves: border thickness swap (Normal↔Thick), bg/fg invert, and
+   a 1-cell glyph change. All rendererable in Bubble Tea. */
+.pressbtn.kd{
+  transform:translateY(1px);
+  box-shadow:0 0 0 1px var(--paper) inset;
+  background:var(--term-fg);
+  color:var(--term-bg);
+  filter:brightness(.85);
+}
+.pressbtn:hover{filter:brightness(1.05); cursor:pointer}
+.pressbtn:active{transform:translateY(1px); filter:brightness(.85)}
+
+/* Row-level depress: thick border appears on keydown, glyph travels */
+.lrow.depress .name{text-shadow:0 0 0 var(--term-fg)}
+.lrow.depress{
+  background:linear-gradient(180deg, rgba(255,255,255,.04), transparent);
+}
+.lrow.depress .glyph{color:var(--indicator); text-shadow:0 0 8px rgba(255,90,31,.8)}
+
+/* Three-frame press travel for docs diagrams */
+.travel{
+  display:inline-grid;
+  grid-template-columns:repeat(5, auto);
+  gap:14px;
+  align-items:center;
+  color:var(--term-dim);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.travel .fr{
+  border:1px solid var(--term-mute);
+  padding:6px 14px;
+  color:var(--term-fg);
+  background:var(--term-bg-2);
+  min-width:90px;
+  text-align:center;
+  letter-spacing:.04em;
+}
+.travel .fr.rest{}
+.travel .fr.down{
+  border:1px solid var(--term-fg);
+  box-shadow:inset 0 2px 0 rgba(0,0,0,.4), inset 0 -1px 0 rgba(255,255,255,.05);
+  transform:translateY(1px);
+}
+.travel .fr.fire{
+  background:var(--indicator); color:#0a0a09; border-color:var(--indicator);
+  box-shadow:0 0 18px rgba(255,90,31,.35);
+}
+.travel .fr.back{border:1px solid var(--term-fg)}
+.travel .fr.ok{border-color:#b9c28e; color:#b9c28e}
+.travel .arrow{color:var(--term-mute)}
+
+/* Stream / logs scroll */
+.stream{
+  font-family:var(--mono);
+  font-size:12px;
+  color:var(--term-fg);
+  white-space:pre;
+  line-height:1.42;
+}
+.stream .ts{color:var(--term-mute)}
+.stream .sev-e{color:var(--indicator)}
+.stream .sev-w{color:#f0c060}
+.stream .sev-i{color:var(--term-dim)}
+.stream .sev-o{color:var(--term-fg)}
+.stream .sev-d{color:#8aaaff}
+.stream .cur::after{
+  content:"▋";
+  color:var(--indicator);
+  animation:blink 1s steps(2,start) infinite;
+  margin-left:2px;
+}
+
+/* Tab strip for logs view */
+.tabs{
+  display:flex;
+  gap:0;
+  border-bottom:1px solid var(--term-mute);
+  margin-top:2px;
+}
+.tab{
+  padding:4px 14px;
+  color:var(--term-dim);
+  border:1px solid transparent;
+  border-bottom:none;
+  margin-bottom:-1px;
+  letter-spacing:.02em;
+}
+.tab.on{
+  color:var(--term-fg);
+  border-color:var(--term-mute);
+  background:var(--term-bg-2);
+  font-weight:700;
+}
+.tab .num{
+  display:inline-block;
+  margin-left:6px;
+  padding:0 6px;
+  background:#1c1c19;
+  color:var(--term-fg);
+  font-size:10px;
+  letter-spacing:.04em;
+}
+.tab.on .num{background:var(--indicator); color:#0a0a09}
+
+/* Sparkline of run timing */
+.spark{
+  display:inline-grid;
+  grid-template-columns:repeat(24, 4px);
+  gap:2px;
+  align-items:end;
+  height:22px;
+}
+.spark i{
+  display:block;
+  width:4px;
+  background:var(--term-mute);
+}
+.spark i.ok{background:var(--term-dim)}
+.spark i.hot{background:var(--indicator)}
+.spark i.fail{background:var(--indicator); opacity:.5}
+
+/* Filter chips */
+.chips{display:flex; gap:6px; flex-wrap:wrap}
+.chips .chip{
+  border:1px solid var(--term-mute);
+  color:var(--term-dim);
+  padding:1px 8px;
+  letter-spacing:.04em;
+  font-size:11px;
+}
+.chips .chip.on{border-color:var(--term-fg); color:var(--term-fg); background:#1c1c19}
+.chips .chip.hot{border-color:var(--indicator); color:var(--indicator)}
+
+/* Meter bar */
+.meter{
+  display:grid;
+  grid-template-columns:70px 1fr 90px;
+  gap:10px;
+  align-items:center;
+  color:var(--term-dim);
+}
+.meter .bar{
+  height:10px;
+  background:var(--term-line);
+  position:relative;
+  overflow:hidden;
+}
+.meter .bar i{
+  display:block; height:100%;
+  background:linear-gradient(90deg, var(--term-dim), var(--term-fg));
+}
+.meter .bar.hot i{background:linear-gradient(90deg, var(--indicator-dim), var(--indicator))}
+@keyframes spinb{
+  0%{content:"⠋"} 10%{content:"⠙"} 20%{content:"⠹"} 30%{content:"⠸"}
+  40%{content:"⠼"} 50%{content:"⠴"} 60%{content:"⠦"} 70%{content:"⠧"}
+  80%{content:"⠇"} 90%{content:"⠏"}
+}
+
+/* Ensure consistent row widths */
+.tui .list .lrow .name, .tui .list .lrow .meta{white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+</style>
+</head>
+<body>
+
+<!-- META -->
+<div class="meta">
+  <div>
+    <div class="wordmark">buttons<span>●</span></div>
+    <div class="sub" style="margin-top:6px">
+      <span>CLI · TUI DESIGN</span>
+      <span>v0.2 · BOARD</span>
+      <span>autonoco/<b>buttons</b></span>
+    </div>
+  </div>
+  <div class="sub" style="text-align:right">
+    <span>N8N FOR AGENTS</span>
+    <span>BUBBLE TEA · LIPGLOSS</span>
+    <span>APACHE 2.0</span>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 01 — BOARD, IDLE + PINNED
+     ============================================================ -->
+<h2 class="section">Board <small>01 · ambient dashboard</small></h2>
+
+<div class="canvas">
+  <div class="station" id="st-board">
+    <div class="caption"><b>board / idle</b> <span>`buttons` — default invocation, pinned row + list</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i class="on"></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / BOARD</span>
+        <span class="serial">UNIT 7904W · ~/.buttons</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines" id="scr-board">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">btn<span style="color:var(--term-mute)">—</span><b>08</b> <span class="sep">·</span> <b>board</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────────────────</div>
+
+            <div class="pins">
+              <div class="pin sel">deploy<small>shell · 300s</small></div>
+              <div class="pin">weather<small>http · 60s</small></div>
+              <div class="pin">notify-slack<small>http · 60s</small></div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────────</div>
+
+            <div class="list">
+              <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-check</span><span class="meta">shell · 60s · 0 arg</span><span></span></div>
+              <div class="lrow err"><span class="glyph">✗</span><span class="name">  dh-pipeline</span><span class="meta">shell · 3600s · 2 arg</span><span></span></div>
+              <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-schema</span><span class="meta">shell · 60s · 1 arg</span><span></span></div>
+              <div class="lrow sel"><span class="glyph">›</span><span class="name"><span class="arrow">›</span> dh-tables</span><span class="meta">shell · 60s · 1 arg</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s · GET wttr.in/{{city}}</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  notify-slack</span><span class="meta">http · 60s · POST hooks.slack.com/…</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  repos-stargazers</span><span class="meta">http · 60s · POST api.github.com/graphql</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  deploy-checklist</span><span class="meta">prompt · 60s</span><span></span></div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────────</div>
+
+            <div class="footer-row">
+              <div class="pressbtn">press</div>
+              <div class="hints">
+                <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                <span><span class="kbd">L</span>logs</span><span class="sep">·</span>
+                <span><span class="kbd">?</span>help</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">TTY 1</span>
+        <span class="pill">UTF-8</span>
+        <span class="pill">256-COLOR</span>
+        <span class="pill hot">● REC</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 02 — RUNNING & DONE STATES
+     ============================================================ -->
+<h2 class="section">Press states <small>02 · running / ok / fail</small></h2>
+
+<div class="canvas">
+  <div class="station two-up">
+    <!-- RUNNING -->
+    <div>
+      <div class="caption"><b>running</b> <em>ACTIVE</em> <span>· spinner frame, pinned card pulses, toast held</span></div>
+      <div class="case">
+        <div class="case-bar">
+          <span class="dots"><i class="on"></i><i class="grn"></i><i></i></span>
+          <span>BTN-04 / BOARD</span>
+          <span class="serial">RUNTIME 00:00:03</span>
+        </div>
+        <div class="bezel">
+          <div class="screen scanlines">
+            <div class="tui">
+              <div class="tui-header">
+                <div class="brand">buttons</div>
+                <div class="right">btn—<b>08</b> <span class="sep">·</span> <b>board</b></div>
+              </div>
+              <div class="rule">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="pins">
+                <div class="pin act">deploy<small>● active · 3.2s</small></div>
+                <div class="pin">weather<small>http · 60s</small></div>
+                <div class="pin">notify-slack<small>http · 60s</small></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="list">
+                <div class="lrow run">
+                  <span class="glyph"><span class="spin-b"></span></span>
+                  <span class="name">› deploy</span>
+                  <span class="meta">shell · 300s · 1 arg</span>
+                  <span class="badge">↵ LOGS</span>
+                </div>
+                <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-check</span><span class="meta">shell · 60s</span><span></span></div>
+                <div class="lrow err"><span class="glyph">✗</span><span class="name">  dh-pipeline</span><span class="meta">shell · 3600s · 2 arg</span><span></span></div>
+                <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s</span><span></span></div>
+                <div class="lrow"><span class="glyph">□</span><span class="name">  notify-slack</span><span class="meta">http · 60s</span><span></span></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="footer-row">
+                <div class="pressbtn disabled">press</div>
+                <div class="hints">
+                  <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                  <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                  <span><span class="kbd">L</span>logs</span>
+                </div>
+              </div>
+              <div class="toast-err" style="color:var(--indicator)">●  deploy running… stdout streaming to ~/.buttons/buttons/deploy/pressed/</div>
+            </div>
+          </div>
+        </div>
+        <div class="case-footer">
+          <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <span class="pill hot">● ACTIVE</span>
+          <span class="pill">ENV +3</span>
+          <span class="pill">TTY 1</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- OK TOAST -->
+    <div>
+      <div class="caption"><b>success</b> <span>· toast quiets to dust-green, status columns update</span></div>
+      <div class="case">
+        <div class="case-bar">
+          <span class="dots"><i></i><i class="grn"></i><i></i></span>
+          <span>BTN-04 / BOARD</span>
+          <span class="serial">LAST 437ms · EXIT 0</span>
+        </div>
+        <div class="bezel">
+          <div class="screen scanlines">
+            <div class="tui">
+              <div class="tui-header">
+                <div class="brand">buttons</div>
+                <div class="right">btn—<b>08</b> <span class="sep">·</span> <b>board</b></div>
+              </div>
+              <div class="rule">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="pins">
+                <div class="pin sel">deploy<small>shell · ok · 437ms</small></div>
+                <div class="pin">weather<small>http · 60s</small></div>
+                <div class="pin">notify-slack<small>http · 60s</small></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="list">
+                <div class="lrow ok sel"><span class="glyph">✓</span><span class="name"><span class="arrow">›</span> deploy</span><span class="meta">shell · 300s · 1 arg</span><span></span></div>
+                <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-check</span><span class="meta">shell · 60s</span><span></span></div>
+                <div class="lrow err"><span class="glyph">✗</span><span class="name">  dh-pipeline</span><span class="meta">shell · 3600s · 2 arg</span><span></span></div>
+                <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s</span><span></span></div>
+                <div class="lrow"><span class="glyph">□</span><span class="name">  notify-slack</span><span class="meta">http · 60s</span><span></span></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────</div>
+              <div class="footer-row">
+                <div class="pressbtn">press</div>
+                <div class="hints">
+                  <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                  <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                  <span><span class="kbd">L</span>logs</span>
+                </div>
+              </div>
+              <div class="toast-ok">pressed deploy · exit 0 · 437ms · recorded to pressed/2026-04-18T12-31-58.json</div>
+            </div>
+          </div>
+        </div>
+        <div class="case-footer">
+          <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <span class="pill">EXIT 0</span>
+          <span class="pill">437 ms</span>
+          <span class="pill">HIST +1</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 03 — LOGS PANE (toggled with L)
+     ============================================================ -->
+<h2 class="section">Logs pane <small>03 · shift+L toggles · scoped to focused button</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>board + logs</b> <span>· 5 most-recent runs for the row under the cursor</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i class="on"></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / BOARD · LOGS</span>
+        <span class="serial">HISTORY pressed/*.json</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">btn—<b>08</b> <span class="sep">·</span> <b>board</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────────────────</div>
+            <div class="list" style="margin-top:2px">
+              <div class="lrow sel ok"><span class="glyph">✓</span><span class="name"><span class="arrow">›</span> dh-pipeline</span><span class="meta">shell · 3600s · 2 arg</span><span></span></div>
+              <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-check</span><span class="meta">shell · 60s</span><span></span></div>
+              <div class="lrow err"><span class="glyph">✗</span><span class="name">  dh-schema</span><span class="meta">shell · 60s · 1 arg</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s</span><span></span></div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────────</div>
+
+            <div class="logs">
+              <div class="title">logs <span class="meta">· dh-pipeline · last 5</span></div>
+              <div style="height:6px"></div>
+              <div class="lg"><span class="g ok">✓</span><span>12:31:58</span><span>exit 0   ·  2437ms</span><span class="pv">pipeline synced 1,204 rows → warehouse.events</span></div>
+              <div class="lg"><span class="g ok">✓</span><span>11:58:14</span><span>exit 0   ·  2301ms</span><span class="pv">pipeline synced 988 rows → warehouse.events</span></div>
+              <div class="lg"><span class="g er">✗</span><span>11:02:44</span><span>exit 124 · 60004ms</span><span class="pv">timeout after 60s: dbt run --select staging_events</span></div>
+              <div class="lg"><span class="g ok">✓</span><span>10:40:09</span><span>exit 0   ·  2198ms</span><span class="pv">pipeline synced 1,102 rows → warehouse.events</span></div>
+              <div class="lg"><span class="g ok">✓</span><span>10:15:31</span><span>exit 0   ·  2104ms</span><span class="pv">pipeline synced 1,076 rows → warehouse.events</span></div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn">press</div>
+              <div class="hints">
+                <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                <span><span class="kbd">L</span>hide</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">LOGS OPEN</span>
+        <span class="pill">SCOPE dh-pipeline</span>
+        <span class="pill">LAST 5</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 04 — ARG PROMPT / PRESS FLOW
+     ============================================================ -->
+<h2 class="section">Press with args <small>04 · inline prompt replaces footer when the row has required args</small></h2>
+
+<div class="canvas">
+  <div class="station two-up">
+    <div>
+      <div class="caption"><b>arg entry</b> <span>· blinking caret on focused field; tab cycles</span></div>
+      <div class="case">
+        <div class="case-bar">
+          <span class="dots"><i></i><i class="grn"></i><i></i></span>
+          <span>BTN-04 / PRESS</span>
+          <span class="serial">deploy --arg env=_</span>
+        </div>
+        <div class="bezel">
+          <div class="screen scanlines">
+            <div class="tui">
+              <div class="tui-header">
+                <div class="brand">buttons</div>
+                <div class="right">press <b>deploy</b> <span class="sep">·</span> 1 required arg</div>
+              </div>
+              <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+
+              <div style="color:var(--term-fg); font-weight:700; margin-top:2px">deploy <span style="color:var(--term-dim); font-weight:400">— ship a release to a target env</span></div>
+
+              <div style="margin-top:10px" class="argform">
+                <div class="label">env  <span style="color:var(--term-mute)">string · required</span></div>
+                <div class="field focus">staging<span class="caret"></span></div>
+                <div class="hint">↵ to run · esc to cancel</div>
+              </div>
+
+              <div style="margin-top:6px" class="argform">
+                <div class="label">verbose  <span style="color:var(--term-mute)">bool · optional</span></div>
+                <div class="field">false</div>
+              </div>
+
+              <div class="rule" style="margin-top:20px">────────────────────────────────────────────────────────────────────────────</div>
+              <div style="color:var(--term-dim); margin-top:2px">
+                will run: <span style="color:var(--term-fg)">buttons press deploy --arg env=staging --arg verbose=false</span>
+              </div>
+              <div style="color:var(--term-mute); margin-top:2px">timeout 300s · runtime shell · exec ~/.buttons/buttons/deploy/main.sh</div>
+
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+              <div class="footer-row">
+                <div class="pressbtn">run press</div>
+                <div class="hints">
+                  <span><span class="kbd">⇥</span>next field</span><span class="sep">·</span>
+                  <span><span class="kbd">↵</span>run</span><span class="sep">·</span>
+                  <span><span class="kbd">⎋</span>back</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="case-footer">
+          <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <span class="pill">ARGS 1/2</span>
+          <span class="pill">DRY-RUN READY</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- FAILURE -->
+    <div>
+      <div class="caption"><b>failure</b> <span>· exit code + stderr preview on the toast line</span></div>
+      <div class="case">
+        <div class="case-bar">
+          <span class="dots"><i class="on"></i><i></i><i></i></span>
+          <span>BTN-04 / BOARD</span>
+          <span class="serial">EXIT 124 · TIMEOUT</span>
+        </div>
+        <div class="bezel">
+          <div class="screen scanlines">
+            <div class="tui">
+              <div class="tui-header">
+                <div class="brand">buttons</div>
+                <div class="right">btn—<b>08</b> <span class="sep">·</span> <b>board</b></div>
+              </div>
+              <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+              <div class="pins">
+                <div class="pin sel" style="border-color:var(--indicator); color:var(--indicator)">dh-pipeline<small style="color:var(--indicator)">✗ exit 124</small></div>
+                <div class="pin">deploy<small>shell · 300s</small></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+              <div class="list">
+                <div class="lrow err sel"><span class="glyph">✗</span><span class="name"><span class="arrow">›</span> dh-pipeline</span><span class="meta">shell · 3600s · 2 arg</span><span></span></div>
+                <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-check</span><span class="meta">shell · 60s</span><span></span></div>
+                <div class="lrow ok"><span class="glyph">✓</span><span class="name">  dh-schema</span><span class="meta">shell · 60s</span><span></span></div>
+                <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s</span><span></span></div>
+              </div>
+              <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+              <div class="footer-row">
+                <div class="pressbtn">retry</div>
+                <div class="hints">
+                  <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                  <span><span class="kbd">↵</span>retry</span><span class="sep">·</span>
+                  <span><span class="kbd">L</span>logs</span>
+                </div>
+              </div>
+              <div class="toast-err">press dh-pipeline: TIMEOUT after 60s — stderr: “waiting for db-primary…”</div>
+            </div>
+          </div>
+        </div>
+        <div class="case-footer">
+          <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <span class="pill hot">● FAULT</span>
+          <span class="pill">EXIT 124</span>
+          <span class="pill">TIMEOUT</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 05 — DETAIL VIEW (`buttons weather`)
+     ============================================================ -->
+<h2 class="section">Detail <small>05 · `buttons weather` · single-button spec sheet</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>detail</b> <span>· args, runtime, endpoint, last run — structured, scannable</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / DETAIL</span>
+        <span class="serial">weather · http</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">weather <span class="sep">·</span> <b>detail</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+            <div style="color:var(--term-fg); font-weight:700; font-size:15px; margin-top:4px">weather</div>
+            <div style="color:var(--term-dim); margin-top:2px">get current weather for a city via wttr.in JSON API</div>
+
+            <div style="margin-top:14px">
+              <dl class="spec">
+                <dt>runtime</dt><dd>http</dd>
+                <dt>method</dt><dd>GET</dd>
+                <dt>url</dt><dd>https://wttr.in/<span style="color:var(--indicator)">{{city}}</span>?format=j1</dd>
+                <dt>timeout</dt><dd>60s</dd>
+                <dt>max resp</dt><dd>10M</dd>
+                <dt>private</dt><dd>blocked</dd>
+              </dl>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div style="color:var(--term-dim); margin-bottom:4px">args</div>
+            <div class="spec" style="grid-template-columns:140px 80px 1fr">
+              <div style="color:var(--term-fg)">city</div><div style="color:var(--term-dim)">string</div><div style="color:var(--indicator)">required</div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div style="color:var(--term-dim)">usage</div>
+            <div class="code" style="margin-top:4px">
+<span class="k">buttons press</span> weather <span class="a">--arg</span> city=<span class="s">&lt;string&gt;</span>
+<span class="k">buttons press</span> weather <span class="a">--arg</span> city=<span class="s">Miami</span> <span class="a">--json</span>
+            </div>
+            <div style="color:var(--term-dim); margin-top:8px">last run · 2026-04-18 12:28 · ok · 612ms · city=Miami</div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn">press weather</div>
+              <div class="hints">
+                <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                <span><span class="kbd">e</span>edit</span><span class="sep">·</span>
+                <span><span class="kbd">h</span>history</span><span class="sep">·</span>
+                <span><span class="kbd">⎋</span>back</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">HTTP GET</span>
+        <span class="pill">10M CAP</span>
+        <span class="pill">NET PUBLIC</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 06 — EMPTY STATE
+     ============================================================ -->
+<h2 class="section">Empty state <small>06 · first run / fresh install</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>empty</b> <span>· teaches two real commands instead of a generic CTA</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i></i><i></i><i></i></span>
+        <span>BTN-04 / BOARD · EMPTY</span>
+        <span class="serial">~/.buttons/buttons/ · 0 files</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">btn—<b>00</b> <span class="sep">·</span> <b>board</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+            <div style="padding:36px 0 20px; text-align:left">
+              <div style="font-family:var(--disp); font-size:34px; color:var(--term-fg); letter-spacing:.02em">no buttons yet.</div>
+              <div style="color:var(--term-dim); margin-top:8px; max-width:60ch">
+                buttons are reusable actions with typed args and structured output.<br>
+                create one in another terminal — this board updates automatically.
+              </div>
+
+              <div class="code" style="margin-top:22px"><span class="c"># a shell one-liner</span>
+<span class="k">buttons create</span> hello <span class="a">--code</span> <span class="s">'echo hi'</span></div>
+              <div class="code"><span class="c"># a URL</span>
+<span class="k">buttons create</span> weather <span class="a">--url</span> <span class="s">'https://wttr.in/{{city}}?format=j1'</span> <span class="a">--arg</span> city:string:required</div>
+              <div class="code"><span class="c"># an agent prompt</span>
+<span class="k">buttons create</span> deploy-checklist <span class="a">--prompt</span> <span class="s">"verify staging is green before shipping"</span></div>
+            </div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn disabled">press</div>
+              <div class="hints">
+                <span>listening for changes…</span><span class="sep">·</span>
+                <span><span class="kbd">^C</span>exit</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">WATCH ~/.buttons</span>
+        <span class="pill">POLL 2s</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 07 — THEME ALT (PAPER · INK)
+     ============================================================ -->
+<h2 class="section">Theme: paper <small>07 · ink/paper terminal · honors the identity spec’s light mode</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>paper theme</b> <span>· F5F5F2 bg, 0A0A0A ink, indicator still reserved for ACTIVE</span></div>
+    <div class="case" style="background:linear-gradient(180deg,#ecece7 0%, #d6d5cf 100%)">
+      <div class="case-bar" style="color:#3c3a36">
+        <span class="dots"><i class="on" style="background:var(--indicator)"></i><i class="grn"></i><i style="background:#c9c7bf"></i></span>
+        <span style="color:#3c3a36">BTN-04 / BOARD · PAPER</span>
+        <span class="serial" style="color:#6b6963">UNIT 7904W</span>
+      </div>
+      <div class="bezel" style="background:#cfcdc6; box-shadow:inset 0 0 0 1px #b8b5ad, inset 0 0 0 4px #dcdad3, inset 0 2px 10px rgba(0,0,0,.25)">
+        <div class="screen paper">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand" style="color:#0a0a0a">buttons</div>
+              <div class="right">btn—<b>08</b> <span class="sep">·</span> <b>board</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="pins">
+              <div class="pin act">deploy<small>● active · 2.8s</small></div>
+              <div class="pin sel">dh-check<small>shell · 60s</small></div>
+              <div class="pin">weather<small>http · 60s</small></div>
+            </div>
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="list">
+              <div class="lrow run"><span class="glyph"><span class="spin-b"></span></span><span class="name">› deploy</span><span class="meta">shell · 300s</span><span class="badge">ACTIVE</span></div>
+              <div class="lrow ok sel"><span class="glyph">✓</span><span class="name"><span class="arrow">›</span> dh-check</span><span class="meta">shell · 60s</span><span></span></div>
+              <div class="lrow err"><span class="glyph">✗</span><span class="name">  dh-pipeline</span><span class="meta">shell · 3600s</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  weather</span><span class="meta">http · 60s</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  notify-slack</span><span class="meta">http · 60s</span><span></span></div>
+            </div>
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn">press</div>
+              <div class="hints">
+                <span><span class="kbd">↑↓</span>nav</span><span class="sep">·</span>
+                <span><span class="kbd">↵</span>press</span><span class="sep">·</span>
+                <span><span class="kbd">L</span>logs</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer" style="color:#3c3a36">
+        <div class="vents"><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i><i style="background:#b8b5ad; box-shadow:inset 0 0 0 1px #a5a29a"></i></div>
+        <span class="pill" style="background:#dcdad3; border-color:#b8b5ad; color:#3c3a36">TTY 1</span>
+        <span class="pill" style="background:#dcdad3; border-color:#b8b5ad; color:#3c3a36">UTF-8</span>
+        <span class="pill hot">● ACTIVE</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 08 — THEME ALT (PHOSPHOR GREEN)
+     ============================================================ -->
+<h2 class="section">Theme: phosphor <small>08 · Nostromo CRT · full-on diegetic mode</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>phosphor theme</b> <span>· BUTTONS_THEME=phosphor · scanlines on by default</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i class="grn"></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / BOARD · CRT</span>
+        <span class="serial">MU-TH-UR 6000 · ISSUE 3</span>
+      </div>
+      <div class="bezel">
+        <div class="screen phos scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">BUTTONS</div>
+              <div class="right">BTN—<b>08</b> <span class="sep">·</span> <b>BOARD</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="pins">
+              <div class="pin act">DEPLOY<small>● ACTIVE · 3.2s</small></div>
+              <div class="pin sel">DH-CHECK<small>SHELL · 60s</small></div>
+              <div class="pin">WEATHER<small>HTTP · 60s</small></div>
+            </div>
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="list">
+              <div class="lrow run"><span class="glyph"><span class="spin-b"></span></span><span class="name">› DEPLOY</span><span class="meta">SHELL · 300s</span><span class="badge">ACTIVE</span></div>
+              <div class="lrow ok sel"><span class="glyph">✓</span><span class="name"><span class="arrow">›</span> DH-CHECK</span><span class="meta">SHELL · 60s</span><span></span></div>
+              <div class="lrow err"><span class="glyph">✗</span><span class="name">  DH-PIPELINE</span><span class="meta">SHELL · 3600s</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  WEATHER</span><span class="meta">HTTP · 60s</span><span></span></div>
+              <div class="lrow"><span class="glyph">□</span><span class="name">  NOTIFY-SLACK</span><span class="meta">HTTP · 60s</span><span></span></div>
+            </div>
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn">PRESS</div>
+              <div class="hints">
+                <span><span class="kbd">↑↓</span>NAV</span><span class="sep">·</span>
+                <span><span class="kbd">↵</span>PRESS</span><span class="sep">·</span>
+                <span><span class="kbd">L</span>LOGS</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">PHOSPHOR P1</span>
+        <span class="pill">CRT 60HZ</span>
+        <span class="pill hot">● ACTIVE</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 09 — RUN LOGS (live stream + replay)
+     ============================================================ -->
+<h2 class="section">Run logs <small>09 · live stream · tailed while running, scroll-lockable when done</small></h2>
+
+<div class="canvas">
+  <div class="station" id="st-logs">
+    <div class="caption"><b>buttons logs deploy</b> <span>· click the pulsing <span style="color:var(--indicator)">● active</span> pin to tail · <span style="color:var(--paper)">L</span> from board · <span style="color:var(--paper)">↵</span> on an active row</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i class="on"></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / LOGS · DEPLOY</span>
+        <span class="serial">FOLLOW · 03.2s · EXIT —</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">deploy <span class="sep">·</span> <b>logs</b> <span class="sep">·</span> <span style="color:var(--indicator)">● follow</span></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+
+            <!-- Compact header: what's running, elapsed, follow state -->
+            <div style="display:grid; grid-template-columns:1fr auto; gap:20px; align-items:baseline; margin-top:4px">
+              <div>
+                <div style="color:var(--term-fg); font-weight:700">deploy <span style="color:var(--term-dim); font-weight:400">— shell · env=<span style="color:var(--term-fg)">staging</span></span></div>
+                <div style="color:var(--term-mute); margin-top:2px; font-size:11px">started 12:31:58  ·  press 0c5b  ·  pid 41238</div>
+              </div>
+              <div style="color:var(--indicator); font-weight:700; font-size:13px; letter-spacing:.04em">
+                <span class="spin-b"></span> 00:03 / 05:00
+              </div>
+            </div>
+
+            <!-- Stream -->
+            <div class="stream" style="margin-top:10px">
+<span class="ts">12:31:58.021</span> <span class="sev-i">info </span> deploy: starting — env=staging, ref=HEAD, sha=c8ab3f9
+<span class="ts">12:31:58.104</span> <span class="sev-o">stdout</span> ▸ resolving dependencies… <span style="color:var(--term-dim)">(pnpm-lock.yaml)</span>
+<span class="ts">12:31:58.612</span> <span class="sev-o">stdout</span> ▸ building api@2.8.1  <span style="color:var(--term-dim)">[▰▰▰▰▰▰▰▱▱▱] 72%</span>
+<span class="ts">12:31:59.884</span> <span class="sev-o">stdout</span> ▸ building web@2.8.1  <span style="color:var(--term-dim)">[▰▰▰▰▰▰▰▰▰▱] 91%</span>
+<span class="ts">12:32:00.451</span> <span class="sev-w">warn </span> using deprecated flag --legacy-peer-deps
+<span class="ts">12:32:01.002</span> <span class="sev-o">stdout</span> ▸ pushing image ghcr.io/autonoco/api:c8ab3f9  <span style="color:var(--term-dim)">(4.21 MB/s)</span>
+<span class="ts">12:32:01.880</span> <span class="sev-i">info </span> kube: applying manifests/staging/*.yaml
+<span class="ts">12:32:02.113</span> <span class="sev-o">stdout</span> ▸ deployment.apps/api configured
+<span class="ts">12:32:02.117</span> <span class="sev-o">stdout</span> ▸ deployment.apps/web configured
+<span class="ts">12:32:02.119</span> <span class="sev-o">stdout</span> ▸ service/api unchanged
+<span class="ts">12:32:02.612</span> <span class="sev-i">info </span> waiting for rollout… (api 0/3 ready)
+<span class="ts">12:32:03.104</span> <span class="sev-o">stdout</span> ▸ pod api-c8ab3f9-pvj2 <span style="color:#b9c28e">ready</span>  <span style="color:var(--term-dim)">(1/3)</span>
+<span class="ts">12:32:03.240</span> <span class="cur">waiting for rollout… (api 1/3 ready)</span></div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn" style="background:transparent; color:var(--indicator); border-color:var(--indicator)">■ cancel</div>
+              <div class="hints">
+                <span><span class="kbd">f</span>follow</span><span class="sep">·</span>
+                <span><span class="kbd">g/G</span>top/end</span><span class="sep">·</span>
+                <span><span class="kbd">⎋</span>back to board</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill hot">● FOLLOW</span>
+        <span class="pill">PRESS 0c5b</span>
+        <span class="pill">TAIL</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATION 10 — MECHANICAL PRESS / BUTTON TRAVEL
+     ============================================================ -->
+<h2 class="section">Mechanical press <small>10 · faking physical travel in a terminal</small></h2>
+
+<div class="canvas">
+  <div class="station">
+    <div class="caption"><b>press choreography</b> <span>· ~180ms total · all four frames use only lipgloss border/bg swaps</span></div>
+    <div class="case">
+      <div class="case-bar">
+        <span class="dots"><i class="on"></i><i class="grn"></i><i></i></span>
+        <span>BTN-04 / INTERACTION · PRESS</span>
+        <span class="serial">↵ KEYDOWN → 40ms TRAVEL → FIRE → 80ms HOLD → RELEASE</span>
+      </div>
+      <div class="bezel">
+        <div class="screen scanlines">
+          <div class="tui">
+            <div class="tui-header">
+              <div class="brand">buttons</div>
+              <div class="right">press <span class="sep">·</span> <b>choreography</b></div>
+            </div>
+            <div class="rule">────────────────────────────────────────────────────────────────────────────</div>
+
+            <!-- Frame strip -->
+            <div style="color:var(--term-dim); margin:8px 0 6px">the pressbtn across four frames</div>
+            <div class="travel">
+              <span class="fr rest">press</span>
+              <span class="arrow">→</span>
+              <span class="fr down">press</span>
+              <span class="arrow">→</span>
+              <span class="fr fire">● fire</span>
+            </div>
+            <div style="color:var(--term-mute); font-size:11px; margin-top:6px">rest (NormalBorder, paper fill) → keydown +40ms (ThickBorder, inset shadow, ↓1px) → fire +80ms (indicator fill, brief glow) → release → active</div>
+
+            <div style="margin:22px 0 6px; color:var(--term-dim)">the focused list row while the key is held</div>
+            <div class="list" style="border:1px dashed var(--term-mute); padding:6px 10px">
+              <div class="lrow sel depress">
+                <span class="glyph">●</span>
+                <span class="name"><span class="arrow">›</span> deploy</span>
+                <span class="meta">shell · 300s · 1 arg</span>
+                <span class="kbd">↵ held</span>
+              </div>
+            </div>
+            <div style="color:var(--term-mute); font-size:11px; margin-top:6px">glyph swaps <span style="color:var(--term-fg)">□</span> → <span style="color:var(--term-fg)">▣</span> → <span style="color:var(--indicator)">●</span> in sync. row gains a 1-line inset shadow. bubbletea sees the KeyPressMsg; we set a <code style="color:var(--paper)">pressPulse</code> model field, schedule a <code style="color:var(--paper)">tea.Tick(80ms)</code> to clear it.</div>
+
+            <div style="margin:22px 0 6px; color:var(--term-dim)">three-glyph travel (bonus — cycle every press)</div>
+            <div class="travel" style="grid-template-columns:repeat(7, auto)">
+              <span class="fr rest">□ deploy</span>
+              <span class="arrow">→</span>
+              <span class="fr down">▣ deploy</span>
+              <span class="arrow">→</span>
+              <span class="fr fire">◉ deploy</span>
+              <span class="arrow">→</span>
+              <span class="fr ok">✓ deploy</span>
+            </div>
+
+            <div class="rule" style="margin-top:22px">────────────────────────────────────────────────────────────────────────────</div>
+
+            <div style="color:var(--term-dim); margin-bottom:4px">implementation sketch — <span style="color:var(--term-mute)">internal/tui/board.go</span></div>
+<div class="code">
+<span class="c">// Model field: transient pressed-row name (cleared by pressReleaseMsg)</span>
+<span class="k">type</span> Model <span class="k">struct</span> {
+    ...
+    pressPulse     <span class="k">string</span>        <span class="c">// name of row currently showing "depressed" frame</span>
+    pressPulseFire <span class="k">bool</span>          <span class="c">// 2nd frame: indicator fill instead of inset</span>
+}
+
+<span class="c">// On Enter/Space, show 1st frame, schedule 2nd frame and release</span>
+<span class="k">case</span> <span class="s">"enter"</span>, <span class="s">" "</span>:
+    m.pressPulse = name
+    <span class="k">return</span> m, tea.Batch(
+        tea.Tick(40*time.Millisecond, <span class="k">func</span>(_ time.Time) tea.Msg { <span class="k">return</span> pressFireMsg{name} }),
+        tea.Tick(180*time.Millisecond, <span class="k">func</span>(_ time.Time) tea.Msg { <span class="k">return</span> pressReleaseMsg{name} }),
+        runPress(btn, codePath, batteries),
+    )
+
+<span class="c">// On mouse: honour real press/release semantics (bubbletea v2 distinguishes them)</span>
+<span class="k">case</span> tea.MouseClickMsg: <span class="c">// logical click — same as keyboard</span>
+<span class="k">case</span> tea.MouseMotionMsg: <span class="c">// for hover-indicator on rows if MouseModeCellMotion</span>
+</div>
+
+            <div class="rule" style="margin-top:14px">────────────────────────────────────────────────────────────────────────────</div>
+            <div class="footer-row">
+              <div class="pressbtn" id="demoBtn">press (try me)</div>
+              <div class="hints">
+                <span>click / space to feel the travel</span><span class="sep">·</span>
+                <span><span class="kbd">⎋</span>back</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="case-footer">
+        <div class="vents"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <span class="pill">KEYDOWN 40ms</span>
+        <span class="pill">FIRE 80ms</span>
+        <span class="pill hot">● ACTIVE</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ─── Pinned buttons: clickable with mechanical press ──────────
+   Same 4-frame travel as pressbtn: rest → kd (40ms) → fire (80ms)
+   → release. ACTIVE pins scroll to the run-logs station. */
+(function(){
+  const pins = document.querySelectorAll('.pin');
+  const logsStation = document.querySelector('h2.section + .canvas .station .case-bar span:nth-child(2)');
+  // find the run-logs canvas by its bar label
+  let logsCanvas = null;
+  document.querySelectorAll('.case-bar').forEach(bar=>{
+    if (bar.textContent.includes('LOGS')) logsCanvas = bar.closest('.canvas');
+  });
+
+  const travel = (el, onFire) => {
+    if (el.classList.contains('kd') || el.classList.contains('fire')) return;
+    el.classList.add('kd');
+    setTimeout(()=>{
+      el.classList.remove('kd');
+      el.classList.add('fire');
+      if (onFire) onFire();
+    }, 40);
+    setTimeout(()=>{
+      el.classList.remove('fire');
+    }, 220);
+  };
+
+  pins.forEach(p=>{
+    p.setAttribute('tabindex','0');
+    p.setAttribute('role','button');
+    const isActive = p.classList.contains('act');
+    p.addEventListener('click', ()=>{
+      travel(p, ()=>{
+        if (isActive && logsCanvas) {
+          logsCanvas.scrollIntoView({behavior:'smooth', block:'center'});
+        }
+      });
+    });
+    p.addEventListener('keydown', e=>{
+      if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); p.click(); }
+    });
+  });
+})();
+
+/* ─── Hint-strip: make "L logs" clickable jump to run-logs station ── */
+(function(){
+  const target = document.getElementById('st-logs');
+  if (!target) return;
+  document.querySelectorAll('.hints span').forEach(s=>{
+    const txt = s.textContent.trim().toLowerCase();
+    if (txt === 'llogs' || txt.endsWith(' logs') || txt.endsWith('logs')) {
+      if (!s.querySelector('.kbd')) return;
+      const label = (s.querySelector('.kbd').textContent || '').trim().toLowerCase();
+      if (label !== 'l') return;
+      s.style.cursor = 'pointer';
+      s.style.transition = 'color 120ms';
+      s.addEventListener('mouseenter', ()=>{ s.style.color = 'var(--term-fg)'; });
+      s.addEventListener('mouseleave', ()=>{ s.style.color = ''; });
+      s.addEventListener('click', ()=>{
+        target.scrollIntoView({behavior:'smooth', block:'start'});
+      });
+    }
+  });
+})();
+
+/* Interactive demo: press the button to see the travel */
+(function(){
+  const b = document.getElementById('demoBtn');
+  if (!b) return;
+  const fire = () => {
+    b.classList.add('kd');
+    setTimeout(()=>{
+      b.style.background = 'var(--indicator)';
+      b.style.color = '#0a0a09';
+      b.style.borderColor = 'var(--indicator)';
+    }, 40);
+    setTimeout(()=>{
+      b.classList.remove('kd');
+      b.style.background = '';
+      b.style.color = '';
+      b.style.borderColor = '';
+    }, 180);
+  };
+  b.addEventListener('click', fire);
+  document.addEventListener('keydown', e=>{
+    if ((e.key === ' ' || e.key === 'Enter') && document.activeElement === document.body) {
+      e.preventDefault(); fire();
+    }
+  });
+})();
+</script>
+
+<!-- ============================================================
+     NOTES
+     ============================================================ -->
+<div style="max-width:1280px; margin:72px auto 0; color:var(--aluminum); font-size:13px; line-height:1.6">
+  <h3 style="font-family:var(--disp); font-size:18px; color:var(--paper); letter-spacing:.04em; margin:0 0 10px">notes for the maintainer</h3>
+  <ul style="padding-left:18px; color:var(--dust)">
+    <li>Every glyph is real: ✓ ✗ □ › ● — all renderable with <code style="color:var(--paper)">lipgloss</code>. The spinner is the same braille cycle already in <code style="color:var(--paper)">styles.go</code>.</li>
+    <li>Hardware chrome around the terminal is for <em>marketing/docs</em> only — the actual TUI stops at the screen. Don't ship the bezel inside Bubble Tea.</li>
+    <li>Orange stays reserved for ACTIVE. Success toast is dust-green so the eye tracks failures first. Keep the rule in <code style="color:var(--paper)">styles.go</code>.</li>
+    <li>Press-with-args (station 04) is new — current TUI bails to CLI for required args. The arg form is a single-column bubbletea <code style="color:var(--paper)">huh?</code>-style prompt with Tab/Enter semantics.</li>
+    <li>Detail view (station 05) mirrors <code style="color:var(--paper)">cmd/detail.go</code> output but reorganized as a TUI page — same data, better hierarchy.</li>
+    <li>Paper & phosphor themes: gate on <code style="color:var(--paper)">BUTTONS_THEME</code> env (phosphor, paper, default). Current <code style="color:var(--paper)">BuildStyles()</code> only branches on dark/light — extend it.</li>
+  </ul>
+</div>
+
+<!-- ============================================================
+     TWEAKS PANEL — toggled via __activate_edit_mode
+     ============================================================ -->
+<div class="tweaks" id="tweaks">
+  <h4>tweaks<span>●</span></h4>
+  <div class="grp">
+    <div class="lbl">Theme</div>
+    <div class="seg" data-g="theme">
+      <button data-v="default" class="on">Default</button>
+      <button data-v="paper">Paper</button>
+      <button data-v="amber">Amber</button>
+      <button data-v="phos">Phos</button>
+    </div>
+  </div>
+  <div class="grp">
+    <div class="lbl">Scanlines</div>
+    <div class="row2" data-g="scan">
+      <button data-v="on" class="on">On</button>
+      <button data-v="off">Off</button>
+    </div>
+  </div>
+  <div class="grp">
+    <div class="lbl">Density</div>
+    <div class="row2" data-g="density">
+      <button data-v="sparse" class="on">Sparse</button>
+      <button data-v="dense">Dense</button>
+    </div>
+  </div>
+  <div style="color:var(--dust); font-size:9px; letter-spacing:.2em; text-transform:uppercase; margin-top:4px">applies to all stations</div>
+</div>
+
+<script>
+/* Tweaks plumbing */
+const DEFAULTS = /*EDITMODE-BEGIN*/{
+  "theme": "default",
+  "scan": "on",
+  "density": "dense"
+}/*EDITMODE-END*/;
+
+let state = {...DEFAULTS};
+
+function applyState(){
+  // Theme → swap the .screen class on every screen
+  document.querySelectorAll('.screen').forEach(scr=>{
+    // Leave the explicit .paper and .phos demos alone — they're locked to that theme in the design.
+    if (scr.dataset.lock) return;
+    scr.classList.remove('phos','amber','paper');
+    if (state.theme && state.theme !== 'default') scr.classList.add(state.theme);
+  });
+  // Scanlines
+  document.querySelectorAll('.screen').forEach(scr=>{
+    if (state.scan === 'off') scr.classList.remove('scanlines');
+    else scr.classList.add('scanlines');
+  });
+  // Density → tighter TUI line-height + padding
+  document.querySelectorAll('.tui').forEach(t=>{
+    t.style.lineHeight = state.density === 'dense' ? '1.32' : '1.5';
+    t.style.padding = state.density === 'dense' ? '14px 16px' : '18px 20px';
+    t.style.fontSize = state.density === 'dense' ? '12px' : '13px';
+  });
+  // Buttons in panel
+  document.querySelectorAll('.tweaks .seg, .tweaks .row2').forEach(grp=>{
+    const g = grp.dataset.g;
+    grp.querySelectorAll('button').forEach(b=>{
+      b.classList.toggle('on', b.dataset.v === state[g]);
+    });
+  });
+}
+
+// Lock the paper and phos demo screens so theme swap doesn't clobber them
+document.querySelectorAll('.screen.paper, .screen.phos').forEach(s => s.dataset.lock = "1");
+
+document.querySelectorAll('.tweaks button[data-v]').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const g = btn.parentElement.dataset.g;
+    state[g] = btn.dataset.v;
+    applyState();
+    try{
+      window.parent.postMessage({type:'__edit_mode_set_keys', edits:{[g]: state[g]}}, '*');
+    }catch(e){}
+  });
+});
+
+window.addEventListener('message', e=>{
+  const d = e.data || {};
+  if (d.type === '__activate_edit_mode') document.getElementById('tweaks').classList.add('on');
+  if (d.type === '__deactivate_edit_mode') document.getElementById('tweaks').classList.remove('on');
+});
+
+try{ window.parent.postMessage({type:'__edit_mode_available'}, '*'); }catch(e){}
+applyState();
+</script>
+
+</body>
+</html>

--- a/context/plans/buttons-ui/IMPLEMENTATION.md
+++ b/context/plans/buttons-ui/IMPLEMENTATION.md
@@ -1,0 +1,979 @@
+# Implementing the Buttons TUI
+
+> A working guide for the `buttons board` TUI. Everything in this doc maps
+> to a real symbol in `internal/tui/`. If you're here to add a new screen,
+> keep a terminal open on `internal/tui/board.go` and `internal/tui/styles.go`
+> — you'll be editing them.
+
+---
+
+## Contents
+
+1. [Architecture in 30 seconds](#architecture-in-30-seconds)
+2. [The identity rule, encoded](#the-identity-rule-encoded)
+3. [Lip Gloss style system (`styles.go`)](#lip-gloss-style-system-stylesgo)
+4. [The Bubble Tea model (`board.go`)](#the-bubble-tea-model-boardgo)
+5. [Input: keyboard, mouse, and layout hit-testing](#input-keyboard-mouse-and-layout-hit-testing)
+6. [Pressing buttons](#pressing-buttons)
+7. [Mechanical press choreography](#mechanical-press-choreography)
+8. [The logs view](#the-logs-view)
+9. [Themes (paper · phosphor · amber)](#themes-paper--phosphor--amber)
+10. [Testing the TUI](#testing-the-tui)
+11. [Anti-patterns we've rejected](#anti-patterns-weve-rejected)
+
+---
+
+## Architecture in 30 seconds
+
+Bubble Tea v2 + Lip Gloss v2, Elm-style:
+
+```
+┌─────────────┐      KeyPressMsg       ┌───────────────┐
+│   tea.Program  │ ─────────────────▶ │  Model.Update │
+│ (event loop)   │                    │  (pure)       │
+└─────────────┘      new Model+Cmd    └───────────────┘
+      ▲                                       │
+      │              Model.View()             │
+      │                                       ▼
+      │                              ┌───────────────┐
+      └──────────────────────────────│ Lip Gloss     │
+                      string frame   │ style.Render()│
+                                     └───────────────┘
+```
+
+Three files, three jobs:
+
+| File                     | Job                                                                 |
+|--------------------------|---------------------------------------------------------------------|
+| `internal/tui/app.go`    | Thin `Run()` entry — constructs the model, wires `tea.NewProgram`.  |
+| `internal/tui/styles.go` | Every Lip Gloss style, built once at startup from the identity spec.|
+| `internal/tui/board.go`  | The entire Elm triple: `Model`, `Init`, `Update`, `View`.           |
+
+Bubble Tea v2 changes worth knowing:
+
+- **Alt-screen and mouse mode live on the `tea.View`**, not `tea.NewProgram`.
+  Set `v.AltScreen = true` and `v.MouseMode = tea.MouseModeCellMotion`
+  inside `View()`.
+- **`tea.KeyPressMsg` and `tea.KeyReleaseMsg` are distinct.** We only
+  handle press. Release is reserved for the mechanical-press work
+  described later.
+- **`tea.MouseClickMsg` carries `.Mouse()` returning X/Y/button.**
+  Cell-motion mouse mode gives us hover coordinates too.
+
+---
+
+## The identity rule, encoded
+
+From the spec, baked into `styles.go` as a comment and a constraint:
+
+```go
+// Hard rule from the identity spec: orange (Indicator) is only used to
+// signal an active/running state. If you find yourself reaching for it
+// for decoration, don't.
+const (
+    hexInk       = "#0A0A0A"
+    hexIndicator = "#FF5A1F" // reserved for ACTIVE
+    hexPaper     = "#F5F5F2"
+    hexAluminum  = "#C5C5C0"
+    hexDust      = "#6E6E68"
+)
+```
+
+If you add a new style and it uses `colorIndicator` for anything that
+isn't "a press is running right now", you've broken the rule. The
+spinner, the `ButtonNameActive`, the `BadgeActive`, the `PinnedActive`
+card, and the `StatusError` line are the only legitimate users.
+
+> `StatusError` uses indicator because in the Buttons worldview, a
+> failure *is* an active concern — something needs your attention. This
+> is the one edge where "active" stretches beyond "running".
+
+---
+
+## Lip Gloss style system (`styles.go`)
+
+### Build once, render many
+
+All styles are assembled at startup by `BuildStyles()` and stashed on
+the model:
+
+```go
+type Model struct {
+    svc    *button.Service
+    styles Styles
+    // ...
+}
+
+func New(svc *button.Service, initial string) (*Model, error) {
+    m := &Model{
+        svc:    svc,
+        styles: BuildStyles(),
+        // ...
+    }
+    return m, nil
+}
+```
+
+Why: Lip Gloss style objects are immutable value types but allocating
+them per-render burns CPU on big lists. Build once; every `View()` call
+just calls `.Render(string)`.
+
+### Adaptive color via `lipgloss.LightDark`
+
+```go
+func BuildStyles() Styles {
+    hasDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+    ld := lipgloss.LightDark(hasDark)
+
+    colorPrimary   := ld(lipgloss.Color(hexInk),    lipgloss.Color(hexPaper))
+    colorSecondary := ld(lipgloss.Color(hexDust),   lipgloss.Color("#A8A8A0"))
+    colorMuted     := ld(lipgloss.Color(hexAluminum), lipgloss.Color("#3A3A38"))
+    // ...
+}
+```
+
+`ld(lightValue, darkValue)` returns the right color for the detected
+terminal. **Detection happens once** — we don't poll. If the user
+switches their terminal theme mid-session, they'll need to restart.
+That's fine; it's a terminal.
+
+### The Styles struct
+
+Every style the board uses, named by role not by appearance:
+
+```go
+type Styles struct {
+    Wordmark  lipgloss.Style  // the "buttons" logo
+    Label     lipgloss.Style
+    Divider   lipgloss.Style
+    Secondary lipgloss.Style
+    Muted     lipgloss.Style
+    Indicator lipgloss.Style
+
+    ButtonName         lipgloss.Style
+    ButtonNameSelected lipgloss.Style
+    ButtonNameActive   lipgloss.Style
+
+    BadgeActive           lipgloss.Style
+    ActionPrimary         lipgloss.Style  // the press pill
+    ActionSecondary       lipgloss.Style
+    ActionPrimaryDisabled lipgloss.Style
+    KeyChip               lipgloss.Style  // the ↑↓/↵ glyphs
+
+    PinnedIdle     lipgloss.Style  // pinned card, default
+    PinnedSelected lipgloss.Style  // pinned card, cursor on it
+    PinnedActive   lipgloss.Style  // pinned card, press running
+
+    StatusError lipgloss.Style
+    StatusOK    lipgloss.Style
+}
+```
+
+Name by *what it represents*, not *what it looks like*. Today
+`ButtonNameActive` is orange-and-bold; in a future theme it might be
+cyan-and-underlined. The code shouldn't change.
+
+### The three pinned-card states
+
+These compose the whole mechanical-button illusion — same three
+primitives, three border treatments:
+
+```go
+PinnedIdle: lipgloss.NewStyle().
+    Foreground(colorPrimary).
+    Border(lipgloss.NormalBorder()).
+    BorderForeground(colorMuted).
+    Padding(1, 3).
+    Align(lipgloss.Center),
+
+PinnedSelected: lipgloss.NewStyle().
+    Foreground(colorPrimary).
+    Bold(true).
+    Border(lipgloss.ThickBorder()).       // ← thicker border = "focused"
+    BorderForeground(colorPrimary).
+    Padding(1, 3).
+    Align(lipgloss.Center),
+
+PinnedActive: lipgloss.NewStyle().
+    Foreground(colorIndicator).
+    Bold(true).
+    Border(lipgloss.ThickBorder()).       // ← thick + orange = "running"
+    BorderForeground(colorIndicator).
+    Padding(1, 3).
+    Align(lipgloss.Center),
+```
+
+`NormalBorder` → `ThickBorder` is the *entire* physical-press metaphor.
+It costs you nothing extra at render time.
+
+### The spinner
+
+```go
+var spinnerFrames = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+func (s Styles) indicator(active bool, frame int) string {
+    if active {
+        if frame >= 0 {
+            return s.Indicator.Render(string(spinnerFrames[frame%len(spinnerFrames)]))
+        }
+        return s.Indicator.Render("■")
+    }
+    return s.Muted.Render("□")
+}
+```
+
+Standard Charm braille cycle. The `frame` argument comes from the
+`spinnerFrame` field on the model, incremented on every `tickMsg`.
+
+---
+
+## The Bubble Tea model (`board.go`)
+
+### Model shape
+
+```go
+type Model struct {
+    svc    *button.Service
+    styles Styles
+
+    buttons []button.Button
+
+    section      section       // pinned row or list
+    cursorPinned int
+    cursorList   int
+
+    status map[string]runStatus // per-button run state
+
+    lastErr string
+    lastOK  string              // transient success toast
+
+    spinnerFrame int
+    ticking      bool
+
+    logsOpen bool                // L toggle
+
+    width, height int
+}
+
+type runStatus int
+const (
+    statusIdle runStatus = iota
+    statusRunning
+    statusOK
+    statusFailed
+)
+```
+
+### The two tick loops
+
+Two kinds of periodic message, both implemented with `tea.Tick`:
+
+```go
+type tickMsg    time.Time // spinner, 90ms
+type refreshMsg time.Time // disk re-list, 2s
+
+const (
+    tickInterval    = 90 * time.Millisecond
+    refreshInterval = 2 * time.Second
+)
+
+func tickCmd() tea.Cmd {
+    return tea.Tick(tickInterval, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+func refreshCmd() tea.Cmd {
+    return tea.Tick(refreshInterval, func(t time.Time) tea.Msg { return refreshMsg(t) })
+}
+```
+
+Key optimization in `Update` — **don't keep ticking when nothing is
+running**:
+
+```go
+case tickMsg:
+    m.spinnerFrame++
+    if m.anyRunning() {
+        return m, tickCmd()   // reschedule
+    }
+    m.ticking = false          // flatline when idle
+    return m, nil
+```
+
+And in `pressButton`:
+
+```go
+if !m.ticking {
+    m.ticking = true
+    return m, tea.Batch(pressCmd, tickCmd())
+}
+return m, pressCmd
+```
+
+A board sitting open on an idle project must not cook the CPU.
+
+### The `Init` / `Update` / `View` triple
+
+```go
+func (m Model) Init() tea.Cmd { return refreshCmd() }
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.WindowSizeMsg:  // track dimensions for layout
+        m.width, m.height = msg.Width, msg.Height
+        return m, nil
+    case tea.KeyPressMsg:    // keyboard
+        return m.handleKey(msg)
+    case tea.MouseClickMsg:  // mouse
+        if msg.Mouse().Button == tea.MouseLeft {
+            return m.handleLeftClick(msg.Mouse().X, msg.Mouse().Y)
+        }
+        return m, nil
+    case pressDoneMsg:        // press finished
+        return m.handlePressDone(msg), nil
+    case tickMsg:             // spinner tick
+        m.spinnerFrame++
+        if m.anyRunning() { return m, tickCmd() }
+        m.ticking = false
+        return m, nil
+    case refreshMsg:          // disk sync
+        if buttons, err := m.svc.List(); err == nil {
+            m.buttons = buttons
+            if m.cursorList >= len(m.buttons) && len(m.buttons) > 0 {
+                m.cursorList = len(m.buttons) - 1
+            }
+        }
+        return m, refreshCmd()
+    }
+    return m, nil
+}
+```
+
+`Update` is **value-receiver pure**. Never mutate `m` in place and
+return the original — the compiler won't catch it, Bubble Tea won't
+complain, but your state updates silently won't stick. Always return
+the modified copy.
+
+---
+
+## Input: keyboard, mouse, and layout hit-testing
+
+### Keyboard
+
+```go
+func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+    switch msg.String() {
+    case "ctrl+c":     return m, tea.Quit
+    case "up", "k":    return m.moveCursor(-1), nil
+    case "down", "j":  return m.moveCursor(1), nil
+    case "left", "h":  /* section-aware: left in pinned row, or hop to pinned from list */
+    case "right", "l": /* section-aware: right in pinned row */
+    case "tab":        /* swap sections */
+    case "enter", " ": return m.pressButton(m.currentButtonName())
+    case "L":          m.logsOpen = !m.logsOpen; return m, nil
+    }
+    return m, nil
+}
+```
+
+Two things to notice:
+
+- **Lower-case `l` moves cursor right (vim).** The logs toggle gets
+  shift+L because its hint chip shows a capital — the glyph the user
+  sees on screen *is* the key they need to press.
+- **No `q` binding.** The board is an ambient dashboard. Pressing `q`
+  to dismiss it would imply it's a prompt you're trapped inside.
+  Ctrl+C stays as an unadvertised escape hatch.
+
+### Mouse (cell-motion mode)
+
+The view ends with:
+
+```go
+v := tea.NewView(content)
+v.AltScreen = true
+v.MouseMode = tea.MouseModeCellMotion
+return v
+```
+
+Cell-motion gives us X/Y per click *and* hover. Click handling reuses
+the layout calculation:
+
+```go
+func (m Model) handleLeftClick(x, y int) (tea.Model, tea.Cmd) {
+    l := m.computeLayout()
+
+    if y >= l.footerY0 && y <= l.footerY1 {
+        if l.pressEnabled && x >= l.pressX0 && x < l.pressX1 {
+            return m.pressButton(m.currentButtonName())
+        }
+        return m, nil
+    }
+
+    // Pinned row hit test
+    pinned := m.pinned()
+    if len(pinned) > 0 && y >= l.pinnedY0 && y <= l.pinnedY1 {
+        idx := pinnedIndexAtX(pinned, x)
+        if idx >= 0 {
+            m.section = sectionPinned
+            m.cursorPinned = idx
+            return m.pressButton(pinned[idx].Name)
+        }
+    }
+
+    // List row hit test
+    if len(m.buttons) > 0 && y >= l.listY0 && y <= l.listY1 {
+        rowIdx := y - l.listY0
+        if rowIdx >= 0 && rowIdx < len(m.buttons) {
+            m.section = sectionList
+            m.cursorList = rowIdx
+            return m.pressButton(m.buttons[rowIdx].Name)
+        }
+    }
+    return m, nil
+}
+```
+
+### `computeLayout` is the hinge
+
+Bubble Tea doesn't track where it rendered things. `View()` is a
+string; the terminal knows nothing. For mouse, **we recompute layout
+from model state** the same way `View()` composes the screen — the two
+can't drift because they're reading the same inputs:
+
+```go
+type layout struct {
+    pinnedY0, pinnedY1 int
+    listY0, listY1     int
+    footerY0, footerY1 int
+    pressX0, pressX1   int
+    pressEnabled       bool
+}
+
+const (
+    leftPad       = 2
+    pinnedHeight  = 5 // top border + pad + text + pad + bottom border
+    footerHeight  = 3 // bordered action pill height
+    headerHeight  = 1
+    dividerHeight = 1
+    sectionBlank  = 1
+)
+
+func (m Model) computeLayout() layout {
+    l := layout{}
+    y := headerHeight + dividerHeight + sectionBlank
+    if len(m.buttons) == 0 {
+        hero := m.renderEmptyHero()
+        y += countLines(hero) + sectionBlank + dividerHeight + sectionBlank
+    } else {
+        if m.hasPinned() {
+            l.pinnedY0 = y
+            l.pinnedY1 = y + pinnedHeight - 1
+            y = l.pinnedY1 + 1 + sectionBlank + dividerHeight + sectionBlank
+        }
+        l.listY0 = y
+        l.listY1 = y + len(m.buttons) - 1
+        y = l.listY1 + 1 + sectionBlank + dividerHeight + sectionBlank
+    }
+    l.footerY0 = y
+    l.footerY1 = y + footerHeight - 1
+    // press pill width = padding(2) + label + padding(2) + border(2)
+    pressW := len("press") + 6
+    l.pressX0 = leftPad
+    l.pressX1 = l.pressX0 + pressW
+    l.pressEnabled = m.currentButtonName() != ""
+    return l
+}
+```
+
+If you add a new visible section, **add its Y range to `layout`** and
+update `computeLayout` in the same commit that updates `View()`. Mouse
+clicks on the new section won't work until you do.
+
+---
+
+## Pressing buttons
+
+The press flow is five steps:
+
+1. **Guard** — one press in flight at a time.
+2. **Arg validation** — required args kick the user to the CLI.
+3. **Status flip** — `statusRunning` + spinner.
+4. **Execute** — `engine.Execute` on a goroutine via `tea.Cmd`.
+5. **Resolve** — `pressDoneMsg` returns result or error.
+
+```go
+func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
+    // 1. One at a time
+    for _, s := range m.status {
+        if s == statusRunning { return m, nil }
+    }
+
+    // find the button
+    var btn *button.Button
+    for i := range m.buttons {
+        if m.buttons[i].Name == name { btn = &m.buttons[i]; break }
+    }
+    if btn == nil { return m, nil }
+
+    // 2. Required-arg bail
+    for _, a := range btn.Args {
+        if a.Required {
+            m.lastErr = fmt.Sprintf("%s requires --arg %s; press from the CLI for now", name, a.Name)
+            return m, nil
+        }
+    }
+
+    // 3. Flip status
+    m.lastErr, m.lastOK = "", ""
+    m.status[name] = statusRunning
+
+    // 4. Execute on a goroutine — tea.Cmd
+    codePath, _ := m.svc.CodePath(name)
+    batteries := loadBatteries() // best-effort
+    pressCmd := runPress(btn, codePath, batteries)
+
+    // Start spinner tick if it isn't already ticking
+    if !m.ticking {
+        m.ticking = true
+        return m, tea.Batch(pressCmd, tickCmd())
+    }
+    return m, pressCmd
+}
+
+func runPress(btn *button.Button, codePath string, batteries map[string]string) tea.Cmd {
+    name := btn.Name
+    return func() tea.Msg {
+        ctx, cancel := context.WithTimeout(context.Background(),
+            time.Duration(btn.TimeoutSeconds)*time.Second)
+        defer cancel()
+
+        result := engine.Execute(ctx, btn, nil, batteries, codePath)
+        return pressDoneMsg{name: name, result: result}
+    }
+}
+
+// 5. Resolve
+func (m Model) handlePressDone(msg pressDoneMsg) Model {
+    if msg.err != nil || msg.result == nil || msg.result.Status != "ok" {
+        m.status[msg.name] = statusFailed
+        m.lastOK = ""
+        m.lastErr = fmt.Sprintf("press %s: %s", msg.name, errTypeFrom(msg))
+        return m
+    }
+    m.status[msg.name] = statusOK
+    m.lastErr = ""
+    m.lastOK = msg.name
+    return m
+}
+```
+
+Batteries (env injection from `~/.buttons/batteries`) are loaded *per
+press*, not at startup, so a battery added in another shell shows up
+without a TUI restart.
+
+---
+
+## Mechanical press choreography
+
+Terminals don't have CSS `:active`. We fake it with a **four-frame
+timeline** scheduled by `tea.Tick`. The model grows two transient
+fields and two messages:
+
+```go
+// Model fields
+pressPulse     string // name of row currently showing "depressed" frame
+pressPulseFire bool   // true during the fire frame (indicator fill)
+
+// Messages
+type pressFireMsg    struct{ name string } // +40ms — swap to fire frame
+type pressReleaseMsg struct{ name string } // +180ms — back to rest
+```
+
+Schedule three things on Enter/Space:
+
+```go
+case "enter", " ":
+    name := m.currentButtonName()
+    m.pressPulse = name
+    return m, tea.Batch(
+        tea.Tick(40*time.Millisecond,  func(_ time.Time) tea.Msg { return pressFireMsg{name} }),
+        tea.Tick(180*time.Millisecond, func(_ time.Time) tea.Msg { return pressReleaseMsg{name} }),
+        runPress(btn, codePath, batteries),
+    )
+```
+
+Handle the pulse messages:
+
+```go
+case pressFireMsg:
+    if m.pressPulse == msg.name { m.pressPulseFire = true }
+    return m, nil
+
+case pressReleaseMsg:
+    if m.pressPulse == msg.name {
+        m.pressPulse = ""
+        m.pressPulseFire = false
+    }
+    return m, nil
+```
+
+Render uses the pulse state to pick the right style for just this
+frame:
+
+```go
+func (m Model) renderPinnedCard(btn button.Button, selected bool) string {
+    style := m.styles.PinnedIdle
+    switch {
+    case m.status[btn.Name] == statusRunning:
+        style = m.styles.PinnedActive
+    case m.pressPulse == btn.Name && m.pressPulseFire:
+        style = m.styles.PinnedActive            // orange fire frame
+    case m.pressPulse == btn.Name:
+        style = m.styles.PinnedSelected          // depressed frame (thick border)
+    case selected:
+        style = m.styles.PinnedSelected
+    }
+    // ...
+}
+```
+
+### The four frames
+
+| Frame   | When         | Style                     | What the user sees                               |
+|---------|--------------|---------------------------|--------------------------------------------------|
+| Rest    | —            | `PinnedIdle`              | Normal border, muted foreground                  |
+| Keydown | +0ms         | `PinnedSelected`          | **Thick** border, bold — "I received the press"  |
+| Fire    | +40ms        | `PinnedActive`            | Thick **orange** border, orange fg — "committed" |
+| Release | +180ms       | back to idle / active     | Either rest, or persistent active if still running |
+
+The release can resolve *into* running-active, and it does so
+seamlessly because both frames share the thick orange border. The user
+sees "I pressed it → it's running" as one continuous gesture.
+
+### Mouse parity
+
+Bubble Tea v2 distinguishes `MouseClickMsg` (logical click) from
+`MouseMotionMsg` (hover / drag). We treat `MouseClickMsg` exactly like
+Enter — same `pressPulse` schedule, same fire/release timing. Terminal
+mouse events don't give us real press/release semantics, so emulating
+a timed pulse is the right move anyway.
+
+### List row pulse
+
+List rows get a subtler treatment: a 1-cell glyph swap plus a
+`ButtonNameActive` reveal for the keydown frame. The three-glyph cycle:
+
+```
+  □ deploy    →    ▣ deploy    →    ◉ deploy    →    ✓ deploy
+   rest         keydown +40ms     fire +80ms        done (or back to idle)
+```
+
+All four are rendered by `Styles.indicator()` with branch logic on
+`pressPulse` / `pressPulseFire`. No new styles needed.
+
+---
+
+## The logs view
+
+Toggled by `L`, sits between the list and the footer. Keep it
+**minimal** — it's a peek, not a dashboard. The full-screen logs view
+described below is reached by pressing `↵` on an active row or
+`buttons logs <name>` from the CLI.
+
+### Inline pane (5-row peek)
+
+```go
+const logsPaneLimit = 5
+
+func (m Model) renderLogs() string {
+    title := m.styles.HeroTitle.Render("logs")
+    target := m.currentButtonName()
+    if target == "" {
+        return indentBlock(title+"\n\n"+m.styles.Muted.Render("focus a button to see its history"), leftPad)
+    }
+
+    runs, err := history.List(target, logsPaneLimit)
+    if err != nil || len(runs) == 0 {
+        empty := m.styles.Muted.Render(
+            fmt.Sprintf("no runs for %s yet — press it to record one.", target))
+        return indentBlock(title+m.styles.Muted.Render("  ·  "+target)+"\n\n"+empty, leftPad)
+    }
+
+    // Width budget: subtract indent + fixed columns (glyph+time+exit+dur = ~38)
+    previewBudget := m.width - leftPad - 2 - 38
+    if previewBudget < 20 { previewBudget = 20 }
+
+    lines := []string{
+        title + m.styles.Muted.Render(fmt.Sprintf("  ·  %s  ·  last %d", target, len(runs))),
+        "",
+    }
+    for _, r := range runs {
+        lines = append(lines, m.renderLogRow(r, previewBudget))
+    }
+    return indentBlock(strings.Join(lines, "\n"), leftPad)
+}
+```
+
+Each row: `glyph · time · exit · duration · preview`. Preview is the
+first non-empty line of stdout (stderr when failed), truncated to fit:
+
+```go
+func (m Model) renderLogRow(r history.Run, previewBudget int) string {
+    glyph := m.styles.StatusOK.Render("✓")
+    if r.Status != "ok" { glyph = m.styles.StatusError.Render("✗") }
+
+    localTime := r.StartedAt.Local().Format("15:04:05")
+    meta := fmt.Sprintf("exit %-3d  %5dms", r.ExitCode, r.DurationMs)
+
+    source := r.Stdout
+    if r.Status != "ok" && r.Stderr != "" { source = r.Stderr }
+    preview := truncateDisplay(firstLineTrimmed(source), previewBudget)
+
+    return fmt.Sprintf("  %s  %s  %s  %s",
+        glyph,
+        m.styles.Muted.Render(localTime),
+        m.styles.Muted.Render(meta),
+        m.styles.Secondary.Render(preview))
+}
+```
+
+### Full-screen logs view (the `buttons logs <name>` subcommand)
+
+A second Bubble Tea program, invoked either from the CLI or by pressing
+`↵` on an active row in the board. Scope: **one press, live stream**.
+
+Minimal model:
+
+```go
+// internal/tui/logs.go
+type LogsModel struct {
+    styles  Styles
+    name    string         // button being followed
+    press   string         // press id (e.g. "0c5b")
+    pid     int
+    started time.Time
+    lines   []logLine      // streamed
+    follow  bool           // true = pin to tail
+    cancel  context.CancelFunc
+    done    bool
+    exit    int
+}
+
+type logLine struct {
+    ts    time.Time
+    sev   severity  // info, stdout, warn, stderr
+    text  string
+}
+
+type logLineMsg logLine
+type logDoneMsg struct{ exit int }
+```
+
+Input handling:
+
+```go
+case "f":       m.follow = !m.follow
+case "g":       /* jump to top */
+case "G":       /* jump to bottom, re-enable follow */
+case "esc", "q": return m, tea.Quit
+case "ctrl+c":  if m.cancel != nil { m.cancel() }
+```
+
+**Streaming is a goroutine that sends `logLineMsg`** to the program.
+`engine.Execute` exposes a line channel; bridge it to Bubble Tea:
+
+```go
+func streamLogs(ch <-chan engine.LogLine) tea.Cmd {
+    return func() tea.Msg {
+        line, ok := <-ch
+        if !ok { return logDoneMsg{} }
+        return logLineMsg(toLogLine(line))
+    }
+}
+
+// In Update, re-arm after each message:
+case logLineMsg:
+    m.lines = append(m.lines, logLine(msg))
+    return m, streamLogs(ch)
+```
+
+Render is three blocks:
+
+1. **Header**: `deploy — shell · env=staging  ·  started 12:31:58  ·  press 0c5b  ·  pid 41238` +
+   right-aligned elapsed counter and spinner.
+2. **Stream**: each line rendered as `ts sev text`, with severity
+   colored via styles (`Indicator` for error/stderr, `Secondary` for
+   stdout, `Muted` for info, a warn-yellow we'd add).
+3. **Footer**: `■ cancel`  +  `f follow · g/G top/end · esc back`.
+
+**Strip for simplicity**: no tabs, no sparkline, no CPU/mem/IO meters.
+The stream is the product. If someone wants statistics, they pipe the
+log file out of `~/.buttons/buttons/<name>/pressed/`.
+
+### A new severity-warn style
+
+Add to `styles.go` — the one new style we need:
+
+```go
+// In Styles struct:
+StatusWarn lipgloss.Style
+
+// In BuildStyles:
+colorWarn := lipgloss.Color("#F0C060") // amber, for `warn` severity only
+// ...
+StatusWarn: lipgloss.NewStyle().Foreground(colorWarn),
+```
+
+Use only for `severity == warn` log lines. Not decorative.
+
+---
+
+## Themes (paper · phosphor · amber)
+
+Gate on `BUTTONS_THEME`:
+
+```go
+type ThemeName string
+const (
+    ThemeDefault  ThemeName = "default"
+    ThemePaper    ThemeName = "paper"
+    ThemePhosphor ThemeName = "phosphor"
+    ThemeAmber    ThemeName = "amber"
+)
+
+func themeFromEnv() ThemeName {
+    switch os.Getenv("BUTTONS_THEME") {
+    case "paper":    return ThemePaper
+    case "phosphor": return ThemePhosphor
+    case "amber":    return ThemeAmber
+    default:         return ThemeDefault
+    }
+}
+```
+
+Extend `BuildStyles` to branch on theme *only for palette*, not for
+style structure. Every theme must define all the same styles — only
+the colors differ:
+
+```go
+func BuildStyles() Styles {
+    theme := themeFromEnv()
+
+    var primary, secondary, muted, indicator lipgloss.Color
+    switch theme {
+    case ThemePhosphor:
+        primary   = lipgloss.Color("#b8f3c3") // phosphor green
+        secondary = lipgloss.Color("#6c9e78")
+        muted     = lipgloss.Color("#2a4a32")
+        indicator = lipgloss.Color("#ff8a6c") // warm red for ACTIVE
+    case ThemeAmber:
+        primary   = lipgloss.Color("#f7c472")
+        secondary = lipgloss.Color("#a17a3c")
+        muted     = lipgloss.Color("#3a2a15")
+        indicator = lipgloss.Color("#ffbe5a")
+    case ThemePaper:
+        primary   = lipgloss.Color(hexInk)
+        secondary = lipgloss.Color(hexDust)
+        muted     = lipgloss.Color(hexAluminum)
+        indicator = lipgloss.Color(hexIndicator)
+    default:
+        hasDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+        ld := lipgloss.LightDark(hasDark)
+        primary   = ld(lipgloss.Color(hexInk), lipgloss.Color(hexPaper)).(lipgloss.Color)
+        secondary = ld(lipgloss.Color(hexDust), lipgloss.Color("#A8A8A0")).(lipgloss.Color)
+        muted     = ld(lipgloss.Color(hexAluminum), lipgloss.Color("#3A3A38")).(lipgloss.Color)
+        indicator = lipgloss.Color(hexIndicator)
+    }
+
+    // ... build Styles struct using these four colors
+}
+```
+
+**Rule:** Phosphor and amber use warmer indicators because orange
+against phosphor-green vibrates painfully. The indicator's *role*
+(ACTIVE only) is preserved — its *hex* changes per theme.
+
+---
+
+## Testing the TUI
+
+### Unit tests — pure functions first
+
+`Update` is pure, so you can drive it directly:
+
+```go
+func TestPressButtonFlipsStatus(t *testing.T) {
+    svc := newFakeService(t, button.Button{Name: "weather", Runtime: "http"})
+    m, _ := New(svc, "weather")
+
+    next, _ := m.Update(tea.KeyPressMsg{/* enter */})
+    nm := next.(Model)
+
+    if nm.status["weather"] != statusRunning {
+        t.Fatalf("want running, got %v", nm.status["weather"])
+    }
+}
+```
+
+### Snapshot tests — `View()` is a string
+
+```go
+func TestBoardIdleSnapshot(t *testing.T) {
+    m := newFixtureModel(t)
+    m.width, m.height = 80, 24
+    v := m.View()
+    snaps.MatchSnapshot(t, v.String())
+}
+```
+
+Strip ANSI with `ansi.Strip` if you want to diff plain text:
+
+```go
+import "charm.land/x/ansi"
+plain := ansi.Strip(v.String())
+```
+
+### Integration — `teatest` from `bubbletea/testing`
+
+```go
+tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+tm.Send(tea.KeyPressMsg{/* enter */})
+teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+    return bytes.Contains(b, []byte("ACTIVE"))
+})
+```
+
+### What to test
+
+- Cursor wrap (up at index 0 → last item).
+- Tab section-switch with and without a pinned row.
+- Press blocked while another press is running.
+- Required-arg bail renders a `StatusError` line.
+- `refreshMsg` trims `cursorList` when the list shrinks.
+- Click at a given `(x, y)` hits the right region per `computeLayout`.
+
+---
+
+## Anti-patterns we've rejected
+
+- **No tab bar on the logs view.** Five tabs (stream/stdout/stderr/env/history) is a dashboard, not a logs tail. If users need stderr-only, `grep` is right there.
+- **No progress bars in the board.** Spinners communicate "working", not "34% done". We don't know the percentage.
+- **No quit key in the footer legend.** The board is ambient. `ctrl+c` stays unadvertised as an escape hatch.
+- **No ticking when idle.** `tickCmd()` is re-armed only when `anyRunning()`. An open idle board should be 0% CPU.
+- **No mutating the model pointer.** `Update` returns a value-type copy. Mutating and returning the original silently drops updates.
+- **No indicator orange anywhere but ACTIVE.** Tempting on dividers, headers, empty-state accents. Every time: don't.
+- **No pixel-perfect CSS framework envy.** Four-frame `tea.Tick`-scheduled style swaps are plenty. Stop before you write an animation engine.
+
+---
+
+## Quick reference: adding a new screen
+
+1. Add a new state to a `section` enum (or a new top-level `Model.view` field).
+2. Write `renderX()` returning a string, composed of Styles-rendered pieces.
+3. Add its Y range to `layout` and update `computeLayout`.
+4. Add key handlers in `handleKey` — bind to a capital letter if a lowercase collides with a vim motion.
+5. Extend `handleLeftClick` for any clickable regions.
+6. Add a snapshot test for the new render.
+7. If it animates, use `tea.Tick` — never spawn goroutines that touch the model.
+
+The TUI fits in ~1000 lines of Go. Keep it that way.

--- a/context/plans/buttons-ui/Implementation guide.html
+++ b/context/plans/buttons-ui/Implementation guide.html
@@ -1,0 +1,447 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>buttons — implementation guide</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&family=Bowlby+One+SC&display=swap" rel="stylesheet">
+<style>
+:root{
+  --ink:#0A0A0A;
+  --indicator:#FF5A1F;
+  --paper:#F5F5F2;
+  --aluminum:#C5C5C0;
+  --dust:#6E6E68;
+
+  --term-bg:#0b0b0b;
+  --term-bg-2:#0f0f0f;
+  --term-fg:#e9e7df;
+  --term-dim:#8a8880;
+  --term-mute:#4a4844;
+  --term-line:#1f1e1a;
+
+  --case-bg:#1a1a18;
+  --case-edge:#2a2a27;
+
+  --mono:'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --disp:'Bowlby One SC', 'Space Grotesk', sans-serif;
+  --sans:'Space Grotesk', system-ui, sans-serif;
+}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:var(--sans);
+  background:radial-gradient(1200px 800px at 30% 10%, #262622 0%, #0e0e0d 60%, #050505 100%);
+  color:var(--paper);
+  min-height:100vh;
+  -webkit-font-smoothing:antialiased;
+}
+
+/* ── Top bar ─────────────────────────────────────────────── */
+.topbar{
+  max-width:1040px;
+  margin:0 auto;
+  padding:40px 32px 0;
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  gap:24px;
+  border-bottom:1px solid var(--case-edge);
+  padding-bottom:20px;
+}
+.wordmark{
+  font-family:var(--disp);
+  font-size:38px;
+  letter-spacing:.02em;
+  line-height:.95;
+}
+.wordmark span{color:var(--indicator)}
+.topbar .sub{
+  font-family:var(--mono);
+  color:var(--aluminum);
+  font-size:11px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  text-align:right;
+}
+.topbar .sub .pill{
+  display:inline-block;
+  border:1px solid var(--indicator);
+  color:var(--indicator);
+  padding:2px 8px;
+  margin-left:6px;
+}
+
+/* ── Layout ─────────────────────────────────────────────── */
+.shell{
+  max-width:1040px;
+  margin:0 auto;
+  display:grid;
+  grid-template-columns:240px 1fr;
+  gap:40px;
+  padding:32px;
+}
+nav.toc{
+  position:sticky;
+  top:24px;
+  align-self:start;
+  font-family:var(--mono);
+  font-size:12px;
+  max-height:calc(100vh - 48px);
+  overflow:auto;
+  border:1px solid var(--case-edge);
+  padding:18px 14px;
+  background:linear-gradient(180deg, rgba(26,26,24,.8), rgba(14,14,13,.8));
+}
+nav.toc h5{
+  font-family:var(--mono);
+  font-size:10px;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  color:var(--dust);
+  margin:0 0 10px;
+  font-weight:500;
+}
+nav.toc ol{margin:0; padding:0; list-style:none; counter-reset:toc;}
+nav.toc li{counter-increment:toc; margin:4px 0;}
+nav.toc li::before{
+  content:counter(toc, decimal-leading-zero);
+  color:var(--dust);
+  margin-right:10px;
+  font-variant-numeric:tabular-nums;
+}
+nav.toc a{
+  color:var(--aluminum);
+  text-decoration:none;
+  transition:color 120ms;
+}
+nav.toc a:hover{color:var(--indicator)}
+
+article{
+  min-width:0;
+  line-height:1.65;
+  color:var(--aluminum);
+  font-size:15px;
+}
+article h1{
+  font-family:var(--disp);
+  font-size:42px;
+  letter-spacing:.01em;
+  color:var(--paper);
+  margin:0 0 14px;
+  line-height:1;
+}
+article h1 + blockquote{
+  margin-top:0;
+}
+article h2{
+  font-family:var(--disp);
+  font-size:24px;
+  color:var(--paper);
+  margin:56px 0 14px;
+  letter-spacing:.01em;
+  padding-top:20px;
+  border-top:1px solid var(--case-edge);
+  position:relative;
+}
+article h2::before{
+  position:absolute;
+  right:0; top:20px;
+  font-family:var(--mono);
+  font-size:10px;
+  letter-spacing:.24em;
+  color:var(--dust);
+  text-transform:uppercase;
+  content:"§ " attr(data-idx);
+}
+article h3{
+  font-family:var(--sans);
+  font-size:17px;
+  color:var(--paper);
+  margin:28px 0 8px;
+  letter-spacing:.01em;
+  font-weight:700;
+}
+article h4{
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--indicator);
+  margin:20px 0 6px;
+}
+article p{margin:12px 0}
+article a{color:var(--indicator); text-decoration:underline; text-decoration-color:rgba(255,90,31,.4); text-underline-offset:3px;}
+article a:hover{text-decoration-color:var(--indicator)}
+article strong{color:var(--paper)}
+article em{color:var(--paper); font-style:normal; border-bottom:1px dotted var(--dust); padding-bottom:1px;}
+
+article ul, article ol{padding-left:22px; margin:12px 0}
+article li{margin:6px 0}
+article li::marker{color:var(--indicator)}
+
+article blockquote{
+  border-left:2px solid var(--indicator);
+  margin:16px 0;
+  padding:4px 18px;
+  color:var(--aluminum);
+  background:linear-gradient(90deg, rgba(255,90,31,.06), transparent 80%);
+  font-style:normal;
+}
+article blockquote p{margin:6px 0}
+
+article hr{
+  border:none;
+  border-top:1px solid var(--case-edge);
+  margin:48px 0;
+  position:relative;
+}
+article hr::after{
+  content:"•";
+  position:absolute;
+  left:50%; top:-12px;
+  transform:translateX(-50%);
+  background:#0b0b0b;
+  padding:0 14px;
+  color:var(--dust);
+  font-size:16px;
+}
+
+/* ── Inline code ─────────────────────────────────────────── */
+article code{
+  font-family:var(--mono);
+  font-size:.85em;
+  background:var(--term-line);
+  color:var(--paper);
+  padding:1px 6px;
+  border:1px solid var(--case-edge);
+}
+
+/* ── Code blocks — full terminal treatment ───────────────── */
+article pre{
+  position:relative;
+  background:linear-gradient(180deg, var(--term-bg-2), var(--term-bg));
+  border:1px solid var(--case-edge);
+  padding:22px 20px 18px;
+  margin:18px 0;
+  overflow-x:auto;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.03),
+    inset 0 -1px 0 rgba(0,0,0,.4),
+    0 10px 30px rgba(0,0,0,.35);
+}
+article pre::before{
+  content:"";
+  position:absolute;
+  top:8px; left:10px;
+  width:9px; height:9px;
+  background:var(--indicator);
+  border-radius:50%;
+  box-shadow:
+    14px 0 0 #444,
+    28px 0 0 #444;
+  opacity:.8;
+}
+article pre code{
+  background:transparent;
+  border:none;
+  padding:0;
+  font-size:12.5px;
+  line-height:1.55;
+  color:var(--term-fg);
+  font-family:var(--mono);
+}
+
+/* Go syntax highlighting — via regex in JS after render */
+.tok-k{color:#f0c060; font-weight:500}         /* keywords */
+.tok-s{color:#b9c28e}                           /* strings */
+.tok-c{color:var(--dust); font-style:italic}    /* comments */
+.tok-f{color:#e9e7df}                           /* identifiers after func/type */
+.tok-n{color:#8aaaff}                           /* numbers */
+.tok-p{color:var(--indicator)}                  /* punctuation accents */
+.tok-h{color:var(--indicator)}                  /* shell prompts / highlights */
+
+/* ── Tables ─────────────────────────────────────────────── */
+article table{
+  border-collapse:collapse;
+  width:100%;
+  margin:18px 0;
+  font-size:14px;
+}
+article th, article td{
+  border-bottom:1px solid var(--case-edge);
+  padding:10px 12px;
+  text-align:left;
+  vertical-align:top;
+}
+article th{
+  color:var(--dust);
+  font-family:var(--mono);
+  font-size:10px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  font-weight:500;
+  background:rgba(255,255,255,.02);
+}
+article td code{font-size:.8em}
+
+/* ── Anchor links on headings ─────────────────────────── */
+article h2 a.anchor,
+article h3 a.anchor{
+  opacity:0; transition:opacity 120ms;
+  color:var(--indicator);
+  margin-left:10px;
+  text-decoration:none;
+  font-family:var(--mono);
+  font-size:.6em;
+}
+article h2:hover a.anchor,
+article h3:hover a.anchor{opacity:.8}
+
+/* ── Footer ─────────────────────────────────────────── */
+footer{
+  max-width:1040px;
+  margin:0 auto;
+  padding:32px 32px 64px;
+  color:var(--dust);
+  font-family:var(--mono);
+  font-size:11px;
+  letter-spacing:.2em;
+  text-transform:uppercase;
+  border-top:1px solid var(--case-edge);
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+}
+
+/* ── Scrollbar polish ─────────────────────────────────── */
+::-webkit-scrollbar{width:10px; height:10px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:var(--case-edge); border:2px solid #0b0b0b}
+::-webkit-scrollbar-thumb:hover{background:var(--term-mute)}
+
+/* ── Responsive ───────────────────────────────────────── */
+@media (max-width: 900px){
+  .shell{grid-template-columns:1fr; padding:24px}
+  nav.toc{position:static; max-height:none}
+  article h1{font-size:32px}
+  article h2{font-size:20px}
+  .topbar{padding:24px 24px 0}
+  .topbar .sub{display:none}
+}
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="wordmark">buttons<span>.</span></div>
+  <div class="sub">
+    implementation guide<br>
+    v1 · 2026.04 <span class="pill">● draft</span>
+  </div>
+</div>
+
+<div class="shell">
+  <nav class="toc" aria-label="Table of contents">
+    <h5>Contents</h5>
+    <ol>
+      <li><a href="#architecture">Architecture in 30 seconds</a></li>
+      <li><a href="#identity">The identity rule, encoded</a></li>
+      <li><a href="#styles">Lip Gloss style system</a></li>
+      <li><a href="#model">The Bubble Tea model</a></li>
+      <li><a href="#input">Input &amp; hit-testing</a></li>
+      <li><a href="#press">Pressing buttons</a></li>
+      <li><a href="#mechanical">Mechanical press choreography</a></li>
+      <li><a href="#logs">The logs view</a></li>
+      <li><a href="#themes">Themes</a></li>
+      <li><a href="#testing">Testing</a></li>
+      <li><a href="#anti">Anti-patterns rejected</a></li>
+      <li><a href="#quickref">Quick reference</a></li>
+    </ol>
+  </nav>
+
+  <article id="doc">
+    <!-- rendered from IMPLEMENTATION.md at load -->
+    <p style="font-family:var(--mono); color:var(--dust)">loading&hellip;</p>
+  </article>
+</div>
+
+<footer>
+  <span>autonoco / buttons</span>
+  <span>bubble tea v2 · lip gloss v2 · go 1.22+</span>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script>
+/* Load the canonical IMPLEMENTATION.md and render it here. Keeps the
+   markdown as the source of truth for the repo — this page is a view. */
+(async function(){
+  const res = await fetch('IMPLEMENTATION.md');
+  const md  = await res.text();
+
+  marked.setOptions({ gfm:true, breaks:false });
+  const html = marked.parse(md);
+  const art = document.getElementById('doc');
+  art.innerHTML = html;
+
+  // Drop the embedded TOC in the markdown — our sidebar replaces it.
+  const firstH2 = art.querySelector('h2');
+  if (firstH2 && /contents/i.test(firstH2.textContent)) {
+    let node = firstH2;
+    const toRemove = [];
+    while (node && !(node.tagName === 'HR')) {
+      toRemove.push(node);
+      node = node.nextElementSibling;
+    }
+    toRemove.forEach(n=>n.remove());
+    if (node) node.remove();
+  }
+
+  // Number every h2 and stamp data-idx for the side margin glyph.
+  let idx = 1;
+  art.querySelectorAll('h2').forEach(h=>{
+    h.setAttribute('data-idx', String(idx).padStart(2,'0'));
+    idx++;
+    // Give sidebar anchors something to hit. Map by heading text.
+    const slug = h.textContent.toLowerCase()
+      .replace(/[^a-z0-9\s]/g,'')
+      .trim()
+      .replace(/\s+/g,'-');
+    h.id = slug;
+    const a = document.createElement('a');
+    a.href = '#' + slug;
+    a.className = 'anchor';
+    a.textContent = '#';
+    h.appendChild(a);
+  });
+
+  // Rewrite sidebar anchors to match first N headings by order.
+  const heads = art.querySelectorAll('h2');
+  document.querySelectorAll('nav.toc a').forEach((a, i)=>{
+    if (heads[i]) a.href = '#' + heads[i].id;
+  });
+
+  // Lightweight Go syntax highlight.
+  const goKeywords = /\b(package|import|type|struct|interface|func|return|if|else|for|range|switch|case|default|break|continue|go|defer|const|var|chan|select|map|nil|true|false)\b/g;
+  art.querySelectorAll('pre code').forEach(block=>{
+    let s = block.textContent;
+    // Escape for HTML first
+    s = s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    // Comments — // ... to end of line
+    s = s.replace(/(\/\/[^\n]*)/g, '<span class="tok-c">$1</span>');
+    // Strings — "..."
+    s = s.replace(/("(?:\\.|[^"\\])*")/g, '<span class="tok-s">$1</span>');
+    // Numbers
+    s = s.replace(/\b(\d+(?:\.\d+)?(?:ms|s|h)?)\b/g, '<span class="tok-n">$1</span>');
+    // Keywords — but not inside already-wrapped spans
+    s = s.replace(goKeywords, '<span class="tok-k">$1</span>');
+    block.innerHTML = s;
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/context/plans/buttons-ui/PLAN.md
+++ b/context/plans/buttons-ui/PLAN.md
@@ -1,0 +1,128 @@
+# UI update plan — board → full spec
+
+> Staged plan to bring `internal/tui/` up to the [IMPLEMENTATION.md](./IMPLEMENTATION.md) spec.
+> Six groups, eight PRs, ordered by dependency + user value.
+
+## Current state vs spec
+
+**Shipped (✅):** board layout, pinned + list, empty-state hero, `L` logs pane
+(5-row peek), spinner, auto-refresh, ambient no-quit footer, session ✓/✗ glyphs,
+click handling for pinned cards / list rows / footer press pill, batteries
+injection at press-time.
+
+**Spec but missing (❌):**
+
+1. Mechanical press choreography (4-frame pulse via `tea.Tick`)
+2. Elapsed timer on active cards (`● active · 3.2s`)
+3. Press-with-args inline form — today we bail to the CLI
+4. Detail view as a TUI page — today we print to stderr from `cmd/detail.go`
+5. Full-screen `buttons logs <name>` with follow / top / end keys
+6. `engine.Execute` line-channel streaming (pre-req for #5)
+7. Themes via `BUTTONS_THEME` (paper / phosphor / amber / default)
+8. `StatusWarn` style and warn severity in the log stream
+9. Snapshot + `teatest` integration tests
+
+---
+
+## Groups
+
+### Group A · Board polish (3 small PRs, parallelizable)
+
+| PR  | Scope                                                                                                                                                                                                         | Files |
+|-----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| A1  | **Mechanical press choreography.** `pressPulse` model field + `pressFireMsg` + `pressReleaseMsg`, 40 / 80 / 180 ms `tea.Tick` schedule. Reuses existing styles (Normal → Thick → Indicator → Active). No new colors. | `internal/tui/board.go`, `internal/tui/styles.go` |
+| A2  | **Elapsed timer on active cards.** Track `pressStartedAt map[name]time.Time`. On running state, render `· <elapsed>s` on pinned card + list row. Driven by the existing spinner tick — no new ticker.          | `internal/tui/board.go` |
+| A3  | **`StatusWarn` style.** Add warn color (`#F0C060`) to `Styles`. No consumer yet — reserved for the log-severity plumbing in Group C. Pure style addition.                                                     | `internal/tui/styles.go` |
+
+### Group B · Themes (depends on A3)
+
+| PR  | Scope | Files |
+|-----|---|---|
+| B1  | **`BUTTONS_THEME` env var (paper / phosphor / amber / default).** Extend `BuildStyles` with `themeFromEnv()`, branch on palette only — style graph stays identical. Amber / phosphor shift the indicator warm so orange doesn't vibrate on green. | `internal/tui/styles.go` |
+
+### Group C · Live logs (biggest slice — do after A + B)
+
+| PR  | Scope | Files |
+|-----|---|---|
+| C1  | **Engine line-channel streaming.** `engine.Execute` gains a `LineSink chan<- LogLine` parameter. Shell / HTTP / prompt executors write line-by-line alongside the `Stdout` / `Stderr` buffer. No JSON contract change. Unit test asserts interleaved delivery with severity tags. | `internal/engine/execute.go`, new `internal/engine/stream.go`, all callers (pass `nil` to keep behavior) |
+| C2  | **`buttons logs <name>` TUI + `internal/tui/logs.go`.** New `LogsModel`. Subscribes to line channel via `streamLogs` `tea.Cmd`. Keys: `f` follow, `g` / `G` top/end, `esc` / `q` back, `ctrl+c` cancel press. Header (button · press id · elapsed) + stream + footer (cancel pill + hint line). Wire an invocation path from board `↵` on an active row. | new `internal/tui/logs.go`, new `cmd/logs.go` |
+
+### Group D · Inline press form
+
+| PR  | Scope | Files |
+|-----|---|---|
+| D1  | **Press-with-args form.** Replace the `requires --arg X; press from CLI` bail with a `huh`-powered inline form: one field per required arg, Tab cycles, ↵ runs, ⎋ cancels. `will run:` preview line shows the CLI equivalent. On submit, same code path as the CLI press. | new `internal/tui/argform.go`, `internal/tui/board.go` |
+
+### Group E · Detail-as-TUI-page
+
+| PR  | Scope | Files |
+|-----|---|---|
+| E1  | **TUI detail page reached via `e` from board / `buttons <name>`.** Replace ad-hoc stderr printing in `cmd/detail.go` with a Bubble Tea page: runtime / method / URL / timeout / max-resp / args / last run. `↵ press`, `e edit`, `h history`, `⎋ back` keybinds. CLI `--json` path untouched. | new `internal/tui/detail.go`, `cmd/detail.go` |
+
+### Group F · Testing foundation (parallel with anything)
+
+| PR  | Scope | Files |
+|-----|---|---|
+| F1  | **Snapshot + `teatest` harness.** Add `charm.land/x/ansi` for ANSI stripping, a snapshot helper, and a `teatest` helper. Seed snapshots for: idle board, populated board with cursor, empty hero, logs pane open, active press, fail state. Every new render going forward gets a snapshot. | new `internal/tui/snapshot_test.go`, `internal/tui/testdata/*.golden` |
+
+---
+
+## Dependencies + merge order
+
+```
+A1 ─┐
+A2 ─┼── merge in any order
+A3 ─┘
+       │
+       ▼
+       B1            depends on A3 (warn color contract)
+       │
+       ▼
+       C1            pre-req for C2 (engine surface area)
+       │
+       ▼
+       C2
+       │
+       ▼
+D1, E1, F1           parallel, each ships on its own
+```
+
+---
+
+## Rough scope
+
+| Group | PRs | LOC  | Risk                                                  |
+|-------|----:|-----:|-------------------------------------------------------|
+| A     | 3   | ~250 | Low — model fields + render branches                  |
+| B     | 1   | ~120 | Low — color table                                     |
+| C     | 2   | ~600 | **High** — engine surface change + new TUI program    |
+| D     | 1   | ~200 | Medium — form UX, validation UX                       |
+| E     | 1   | ~180 | Low-medium — detail is already modeled                |
+| F     | 1   | ~150 | Low — golden files                                    |
+
+---
+
+## Gaps vs spec to settle before starting each group
+
+1. **Engine streaming contract (C1)** — spec says "line channel" but not:
+   severity classification (info / stdout / stderr / warn — how is warn
+   detected? keyword match? explicit tag?), timestamp source (child stdout
+   receive time vs. parent monotonic clock), back-pressure (drop if TUI can't
+   drain vs. block). Short design note lands with C1.
+2. **Detail view `e edit` (E1)** — does "edit" mean open `$EDITOR` on the code
+   path, or launch `buttons update`? Default: `$EDITOR` on the code file —
+   `update` is flag-driven and wrong for a TUI.
+3. **Theme discoverability (B1)** — `BUTTONS_THEME` env works for power users
+   but is invisible to new ones. Extend the settings store added in #69:
+   `buttons config set theme paper`. Env var wins when set, settings next,
+   default-detected third.
+
+---
+
+## Anti-goals (stay out of these)
+
+- Progress bars in the board — per spec, we don't know the percent.
+- A tab bar on logs view — `grep` exists; we're a tail, not a dashboard.
+- A quit key in the footer legend — `ctrl+c` stays unadvertised.
+- Per-frame animation engines — four `tea.Tick` scheduled swaps are plenty.
+- Hardware bezel in the TUI — marketing chrome only. Stop at the screen.


### PR DESCRIPTION
Drops the design context + rollout plan into the repo so every future TUI PR has a reference.

```
context/plans/buttons-ui/
├── Buttons CLI.html          10-station design mockup
├── Implementation guide.html cover
├── IMPLEMENTATION.md         ~1000-line working guide mapping
│                             every concept to an internal/tui/ symbol
└── PLAN.md                   6-group / 8-PR staged rollout
```

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)