### PR TITLE
feat(engine): LineSink streams every line from the child in real time (C1)

### DIFF
--- a/cmd/press.go
+++ b/cmd/press.go
@@ -114,7 +114,10 @@ Examples:
 			return handleServiceError(err)
 		}
 
-		result := engine.Execute(ctx, btn, parsedArgs, batteries, codePath)
+		// No streaming sink for CLI presses — the final Result is the
+		// only thing the caller needs. The TUI log viewer (C2) passes
+		// a real sink to see lines as they happen.
+		result := engine.Execute(ctx, btn, parsedArgs, batteries, nil, codePath)
 
 		// Attach prompt if AGENT.md has custom content (not the default template)
 		if promptMD := readPrompt(btn.Name); promptMD != "" {

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -23,7 +23,11 @@ const sigTermGrace = 5 * time.Second
 // batteries is the caller-provided map of battery KEY → VALUE; each entry is
 // injected into the child process as BUTTONS_BAT_<KEY> so shell / code buttons
 // can read secrets without baking them into the script file. Pass nil to skip.
-func Execute(ctx context.Context, btn *button.Button, args, batteries map[string]string, codePath string) *Result {
+// sink, when non-nil, receives every line the child writes to stdout / stderr
+// in real time as LogLine values — used by the TUI log viewer. The buffered
+// Result.Stdout / Result.Stderr remain authoritative; the sink is best-effort
+// (see stream.go for the back-pressure policy).
+func Execute(ctx context.Context, btn *button.Button, args, batteries map[string]string, sink LineSink, codePath string) *Result {
 	start := time.Now()
 	result := &Result{
 		Button:    btn.Name,
@@ -91,9 +95,15 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 	}
 	cmd.Env = env
 
+	// Capture everything into buffers (authoritative for Result) and,
+	// if a sink was provided, tee every completed line to it tagged
+	// with the right severity. Partial trailing lines are emitted on
+	// Flush after the child exits.
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdoutTee := newLineTee(&stdout, sink, SeverityStdout)
+	stderrTee := newLineTee(&stderr, sink, SeverityStderr)
+	cmd.Stdout = stdoutTee
+	cmd.Stderr = stderrTee
 
 	if err := cmd.Start(); err != nil {
 		result.Status = "error"
@@ -112,6 +122,12 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 	select {
 	case err := <-done:
 		result.DurationMs = time.Since(start).Milliseconds()
+		// Emit any trailing partial lines before the consumer sees the
+		// final Result — ensures the last message on a script that
+		// didn't terminate its output with \n still appears in the
+		// stream.
+		stdoutTee.Flush()
+		stderrTee.Flush()
 		result.Stdout = stdout.String()
 		result.Stderr = stderr.String()
 
@@ -137,6 +153,8 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 	case <-ctx.Done():
 		killProcessGroup(cmd, done)
 		result.DurationMs = time.Since(start).Milliseconds()
+		stdoutTee.Flush()
+		stderrTee.Flush()
 		result.Stdout = stdout.String()
 		result.Stderr = stderr.String()
 		result.Status = "timeout"

--- a/internal/engine/execute_test.go
+++ b/internal/engine/execute_test.go
@@ -34,7 +34,7 @@ func TestExecute_BatteriesInjectedAsEnv(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, nil, map[string]string{"APIFY_TOKEN": "secret123"}, codePath)
+	result := Execute(ctx, btn, nil, map[string]string{"APIFY_TOKEN": "secret123"}, nil, codePath)
 
 	if result.Status != "ok" {
 		t.Fatalf("status=%q stderr=%q", result.Status, result.Stderr)
@@ -42,6 +42,74 @@ func TestExecute_BatteriesInjectedAsEnv(t *testing.T) {
 	if result.Stdout != "secret123" {
 		t.Errorf("stdout = %q, want secret123", result.Stdout)
 	}
+}
+
+// TestExecute_SinkReceivesStreamedLines verifies the caller-provided
+// LineSink gets every line the child writes in real time, tagged with
+// the right severity, while the final Result.Stdout/Stderr still
+// contain the complete buffered output. This is the C1 contract.
+func TestExecute_SinkReceivesStreamedLines(t *testing.T) {
+	dir := t.TempDir()
+	codePath := filepath.Join(dir, "main.sh")
+	script := "#!/bin/sh\necho first\necho second\necho oops >&2\nprintf trailing\n"
+	if err := os.WriteFile(codePath, []byte(script), 0o700); err != nil { // #nosec G306
+		t.Fatal(err)
+	}
+
+	btn := &button.Button{
+		Name:           "stream-test",
+		Runtime:        "shell",
+		TimeoutSeconds: 5,
+	}
+
+	sink := make(chan LogLine, 16)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result := Execute(ctx, btn, nil, nil, sink, codePath)
+	close(sink)
+
+	if result.Status != "ok" {
+		t.Fatalf("status=%q stderr=%q", result.Status, result.Stderr)
+	}
+
+	var stdoutLines, stderrLines []string
+	for l := range sink {
+		switch l.Sev {
+		case SeverityStdout:
+			stdoutLines = append(stdoutLines, l.Text)
+		case SeverityStderr:
+			stderrLines = append(stderrLines, l.Text)
+		}
+	}
+
+	wantStdout := []string{"first", "second", "trailing"}
+	if !equalStringSlices(stdoutLines, wantStdout) {
+		t.Errorf("stdout lines = %v, want %v", stdoutLines, wantStdout)
+	}
+	if !equalStringSlices(stderrLines, []string{"oops"}) {
+		t.Errorf("stderr lines = %v, want [oops]", stderrLines)
+	}
+
+	// Primary capture must be complete including trailing partial.
+	if result.Stdout != "first\nsecond\ntrailing" {
+		t.Errorf("Result.Stdout = %q", result.Stdout)
+	}
+	if result.Stderr != "oops\n" {
+		t.Errorf("Result.Stderr = %q", result.Stderr)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // streamingServer returns an httptest server that streams `total`
@@ -90,7 +158,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Default(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, nil, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
@@ -125,7 +193,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Custom(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := Execute(ctx, btn, map[string]string{}, nil, "")
+		result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 		if result.Status != "ok" {
 			t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
 		}
@@ -152,7 +220,7 @@ func TestExecuteHTTP_ResponseBodyLimit_Custom(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := Execute(ctx, btn, map[string]string{}, nil, "")
+		result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 		if result.Status != "ok" {
 			t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)
 		}
@@ -189,7 +257,7 @@ func TestExecuteHTTP_SSRFBlocksLocalhostByDefault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, nil, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 
 	if result.Status != "error" {
 		t.Fatalf("expected status 'error' for SSRF-blocked request, got %q", result.Status)
@@ -224,7 +292,7 @@ func TestExecuteHTTP_SSRFPerButtonOverride(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, nil, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("expected status 'ok' with per-button override, got %q; stderr=%q", result.Status, result.Stderr)
@@ -257,7 +325,7 @@ func TestExecuteHTTP_SSRFEnvVarOverride(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, nil, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("expected status 'ok' with env var override, got %q; stderr=%q", result.Status, result.Stderr)
@@ -287,7 +355,7 @@ func TestExecuteHTTP_SmallResponseUnaffected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result := Execute(ctx, btn, map[string]string{}, nil, "")
+	result := Execute(ctx, btn, map[string]string{}, nil, nil, "")
 
 	if result.Status != "ok" {
 		t.Fatalf("unexpected status %q; stderr=%q", result.Status, result.Stderr)

--- a/internal/engine/stream.go
+++ b/internal/engine/stream.go
@@ -1,0 +1,145 @@
+// Stream support for Execute.
+//
+// A caller that wants to watch a press as it runs — notably the
+// forthcoming `buttons logs <name>` TUI — passes a LineSink to
+// Execute. Every line the child process writes to stdout / stderr
+// arrives on the channel tagged with a Severity and a wall-clock
+// timestamp. The sink is optional: passing nil keeps the pre-streaming
+// behavior intact (buffered Stdout / Stderr on Result, no channel).
+//
+// Back-pressure policy
+//
+// The tee emits to the sink via a non-blocking select. If the consumer
+// can't keep up, lines are dropped — the buffered `Result.Stdout` /
+// `Result.Stderr` remain authoritative (that's where history.Record
+// pulls from). Dropping a preview line is the right trade versus
+// blocking the press itself on a slow UI. Use a wide channel (buf >=
+// 64) if you want to see every line.
+package engine
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+)
+
+// Severity classifies a log line's source. Consumers (TUI log viewer,
+// future log filters) colorize and group by this.
+type Severity int
+
+const (
+	// SeverityInfo is emitted by the engine itself, not the child —
+	// used for "starting press X" / "exit Y" wrapping. Reserved for
+	// future wrapping lines; the shell path doesn't emit any today.
+	SeverityInfo Severity = iota
+	// SeverityStdout is anything the child wrote to its stdout.
+	SeverityStdout
+	// SeverityStderr is anything the child wrote to its stderr.
+	SeverityStderr
+	// SeverityWarn is reserved for future heuristic or explicit warn
+	// tagging (e.g. lines starting with `warn:` or matching a warn
+	// pattern). Not emitted automatically in this version.
+	SeverityWarn
+)
+
+// String returns a stable lowercase name — handy for logging and for
+// JSON serialization if we ever expose a stream endpoint.
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityStdout:
+		return "stdout"
+	case SeverityStderr:
+		return "stderr"
+	case SeverityWarn:
+		return "warn"
+	default:
+		return "unknown"
+	}
+}
+
+// LogLine is one classified chunk of output. Text never includes the
+// trailing newline — consumers shouldn't have to strip.
+type LogLine struct {
+	Ts   time.Time
+	Sev  Severity
+	Text string
+}
+
+// LineSink is the channel type Execute's caller provides. Send-only
+// from the engine's perspective so a caller can't accidentally receive
+// on their own sink.
+type LineSink = chan<- LogLine
+
+// lineTee wraps an underlying io.Writer (the primary capture buffer)
+// and, as a side effect, splits incoming bytes on newline and emits
+// each completed line to a LineSink tagged with a fixed severity.
+// Partial lines are accumulated across Write calls until a Flush or
+// the next newline-terminated chunk.
+type lineTee struct {
+	w    io.Writer // primary capture — source of truth for Result.Stdout/Stderr
+	sink LineSink  // optional streaming consumer
+	sev  Severity
+
+	mu  sync.Mutex
+	buf []byte // in-flight partial line
+}
+
+// newLineTee returns a tee writer. If sink is nil, the tee only writes
+// to w — zero overhead on the streaming side.
+func newLineTee(w io.Writer, sink LineSink, sev Severity) *lineTee {
+	return &lineTee{w: w, sink: sink, sev: sev}
+}
+
+// Write captures to the primary buffer first (so Result.Stdout is
+// always complete regardless of what happens to the sink), then splits
+// into lines and emits each to the sink.
+func (t *lineTee) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if t.sink == nil {
+		return n, err
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p[:n]...)
+	for {
+		i := bytes.IndexByte(t.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(t.buf[:i])
+		t.buf = t.buf[i+1:]
+		t.emit(line)
+	}
+	return n, err
+}
+
+// Flush emits any trailing partial line (no newline terminator) still
+// sitting in the buffer. Call when the child process exits to catch
+// the last log message that scripts without a trailing newline would
+// otherwise drop.
+func (t *lineTee) Flush() {
+	if t.sink == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.buf) > 0 {
+		t.emit(string(t.buf))
+		t.buf = t.buf[:0]
+	}
+}
+
+// emit sends a line to the sink. Non-blocking: if the channel is full
+// the line is dropped. The primary buffer still holds it, so Result
+// and history are unaffected; only the real-time stream loses it.
+func (t *lineTee) emit(text string) {
+	line := LogLine{Ts: time.Now(), Sev: t.sev, Text: text}
+	select {
+	case t.sink <- line:
+	default:
+		// Dropped; see back-pressure policy in the package comment.
+	}
+}

--- a/internal/engine/stream_test.go
+++ b/internal/engine/stream_test.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func collect(sink chan LogLine) []LogLine {
+	var out []LogLine
+	for l := range sink {
+		out = append(out, l)
+	}
+	return out
+}
+
+func TestLineTee_SplitsOnNewline(t *testing.T) {
+	var buf bytes.Buffer
+	sink := make(chan LogLine, 10)
+	tee := newLineTee(&buf, sink, SeverityStdout)
+
+	if _, err := tee.Write([]byte("one\ntwo\nthree\n")); err != nil {
+		t.Fatal(err)
+	}
+	close(sink)
+
+	lines := collect(sink)
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3: %+v", len(lines), lines)
+	}
+	for i, want := range []string{"one", "two", "three"} {
+		if lines[i].Text != want {
+			t.Errorf("line[%d] = %q, want %q", i, lines[i].Text, want)
+		}
+		if lines[i].Sev != SeverityStdout {
+			t.Errorf("line[%d] severity = %v, want stdout", i, lines[i].Sev)
+		}
+	}
+	// Primary capture must be verbatim, including newlines.
+	if got := buf.String(); got != "one\ntwo\nthree\n" {
+		t.Errorf("primary buf = %q", got)
+	}
+}
+
+func TestLineTee_PartialLineHeldUntilFlush(t *testing.T) {
+	var buf bytes.Buffer
+	sink := make(chan LogLine, 10)
+	tee := newLineTee(&buf, sink, SeverityStderr)
+
+	if _, err := tee.Write([]byte("hello, ")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tee.Write([]byte("world")); err != nil {
+		t.Fatal(err)
+	}
+	// No newline yet — nothing emitted.
+	select {
+	case l := <-sink:
+		t.Fatalf("unexpected emit before newline/flush: %+v", l)
+	default:
+	}
+	tee.Flush()
+	close(sink)
+
+	lines := collect(sink)
+	if len(lines) != 1 || lines[0].Text != "hello, world" {
+		t.Fatalf("want one line 'hello, world'; got %+v", lines)
+	}
+	if lines[0].Sev != SeverityStderr {
+		t.Errorf("severity = %v, want stderr", lines[0].Sev)
+	}
+}
+
+func TestLineTee_SplitAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	sink := make(chan LogLine, 10)
+	tee := newLineTee(&buf, sink, SeverityStdout)
+
+	// Split a logical line across two writes.
+	if _, err := tee.Write([]byte("first-")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tee.Write([]byte("half\nsecond\n")); err != nil {
+		t.Fatal(err)
+	}
+	close(sink)
+
+	lines := collect(sink)
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if lines[0].Text != "first-half" {
+		t.Errorf("line[0] = %q, want first-half", lines[0].Text)
+	}
+	if lines[1].Text != "second" {
+		t.Errorf("line[1] = %q, want second", lines[1].Text)
+	}
+}
+
+func TestLineTee_NilSinkIsPassthrough(t *testing.T) {
+	var buf bytes.Buffer
+	tee := newLineTee(&buf, nil, SeverityStdout)
+
+	if _, err := tee.Write([]byte("hello\n")); err != nil {
+		t.Fatal(err)
+	}
+	tee.Flush() // should not panic
+	if got := buf.String(); got != "hello\n" {
+		t.Errorf("primary buf = %q", got)
+	}
+}
+
+func TestLineTee_DropsWhenSinkFull(t *testing.T) {
+	var buf bytes.Buffer
+	// Unbuffered sink that nobody's reading → every emit should drop.
+	sink := make(chan LogLine)
+	tee := newLineTee(&buf, sink, SeverityStdout)
+
+	payload := strings.Repeat("line\n", 50)
+	if _, err := tee.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	// Primary capture is still complete. Sink receives nothing because
+	// drops are the policy when back-pressured.
+	if got := buf.String(); got != payload {
+		t.Errorf("primary buf lost bytes: %d written, %d captured", len(payload), len(got))
+	}
+	select {
+	case l := <-sink:
+		t.Fatalf("unexpected emit on stalled sink: %+v", l)
+	default:
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	cases := map[Severity]string{
+		SeverityInfo:   "info",
+		SeverityStdout: "stdout",
+		SeverityStderr: "stderr",
+		SeverityWarn:   "warn",
+		Severity(99):   "unknown",
+	}
+	for sev, want := range cases {
+		if got := sev.String(); got != want {
+			t.Errorf("Severity(%d).String() = %q, want %q", sev, got, want)
+		}
+	}
+}

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -430,7 +430,9 @@ func runPress(btn *button.Button, codePath string, batteries map[string]string) 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(btn.TimeoutSeconds)*time.Second)
 		defer cancel()
 
-		result := engine.Execute(ctx, btn, nil, batteries, codePath)
+		// Board presses don't stream yet — the dedicated `buttons logs`
+		// viewer (C2) will pass a sink for live tailing.
+		result := engine.Execute(ctx, btn, nil, batteries, nil, codePath)
 		return pressDoneMsg{name: name, result: result}
 	}
 }


### PR DESCRIPTION
Pre-req for the full-screen `buttons logs <name>` TUI (Group C2). The existing `Result.Stdout` / `Result.Stderr` buffers stay authoritative — they're what `history.Record` persists — but callers that want a live view now pass a `LineSink` channel and see every line as the child writes it, tagged with severity and timestamp.

## What's new

### `internal/engine/stream.go`
- `Severity` (info / stdout / stderr / warn) + `String()` for stable lowercase names
- `LogLine { Ts, Sev, Text }` — text never includes the trailing newline
- `LineSink = chan<- LogLine` (type alias, send-only from engine perspective)
- `lineTee` wraps an `io.Writer`, captures normally, and tees every completed line to the sink. Partial lines held across Writes until `Flush` or next `\n`

### Back-pressure policy
Emits are **non-blocking**: if the channel is full, the line is dropped. Result stays complete, only the real-time view loses it. Dropping a preview line is the right trade vs blocking the press on a slow UI.

### `execute.go`
- Signature grows `sink LineSink` between `batteries` and `codePath`
- `nil` is zero-overhead: `lineTee` short-circuits the emit branch
- Shell / code executor's stdout and stderr both wrap in tees — one pass, no extra goroutine per pipe
- `Flush` called after Wait (and in timeout branch) so trailing partial lines reach the sink

### Scope boundaries
HTTP and prompt executors are **not** streamed. They're request/response or file reads, not long-running processes.

## Callers
- `cmd/press`: `nil` — CLI wants the final Result
- `internal/tui/board`: `nil` — board shows status, not per-line output; C2 will pass a real sink

## Tests
- `stream_test.go` — six targeted tests (split on \n, partial held until Flush, split across writes, nil-sink pass-through, drop on stalled sink, Severity.String)
- `execute_test.go` — `TestExecute_SinkReceivesStreamedLines` drives a real shell script with interleaved stdout/stderr/trailing-no-newline output, asserts both the channel and the final Result match with severity tagging

## Test plan
- [x] `go build / vet / test / gosec` clean (0 gosec issues)
- [x] Unit tests pass
- [ ] C2 (logs TUI) integration — next PR

## Related
Part of the [UI update plan](../blob/main/context/plans/buttons-ui/PLAN.md), Group C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)