### PR TITLE
feat(config): persist theme via `buttons config set theme NAME`

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,13 +23,19 @@ specifically).
 Known keys:
   default-timeout   seconds used when 'buttons create' is run without
                     an explicit --timeout flag (fallback: 300)
+  theme             board TUI theme: default | paper | phosphor | amber
+                    (fallback: default — adapts to terminal background)
 
 Running ` + "`buttons config`" + ` with no subcommand prints the current values.
+
+Resolution order for theme at TUI startup: $BUTTONS_THEME env var wins,
+then settings, then default. Env override keeps A/B comparison easy.
 
 Examples:
   buttons config
   buttons config set default-timeout 600
-  buttons config unset default-timeout`,
+  buttons config set theme amber
+  buttons config unset theme`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return showConfig()
 	},
@@ -93,6 +99,9 @@ func showConfig() error {
 		if v, ok := st.DefaultTimeout(); ok {
 			payload[settings.KeyDefaultTimeout] = v
 		}
+		if v, ok := st.Theme(); ok {
+			payload[settings.KeyTheme] = v
+		}
 		return config.WriteJSON(payload)
 	}
 
@@ -107,6 +116,11 @@ func showConfig() error {
 		render(settings.KeyDefaultTimeout, v, "")
 	} else {
 		render(settings.KeyDefaultTimeout, nil, "300s")
+	}
+	if v, ok := st.Theme(); ok {
+		render(settings.KeyTheme, v, "")
+	} else {
+		render(settings.KeyTheme, nil, "default (adaptive)")
 	}
 	return nil
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -33,7 +33,8 @@ type Settings struct {
 // zero-valued keys — we never want to apply a 0-second timeout
 // silently because someone set the key and then blanked the value.
 type Defaults struct {
-	TimeoutSeconds *int `json:"timeout_seconds,omitempty"`
+	TimeoutSeconds *int    `json:"timeout_seconds,omitempty"`
+	Theme          *string `json:"theme,omitempty"`
 }
 
 // Service is the file-backed settings store. One file, one instance.
@@ -72,7 +73,19 @@ var ErrUnknownKey = errors.New("unknown settings key")
 // on what exists.
 const (
 	KeyDefaultTimeout = "default-timeout"
+	KeyTheme          = "theme"
 )
+
+// validThemes lists accepted theme names. Kept in settings (not tui)
+// so config validation doesn't depend on the TUI build — the set of
+// valid strings is intentionally small and shouldn't change per-theme
+// implementation detail.
+var validThemes = map[string]bool{
+	"default":  true,
+	"paper":    true,
+	"phosphor": true,
+	"amber":    true,
+}
 
 // Load reads the settings file. A missing file returns a zero-value
 // Settings (with schema_version set) so callers don't have to
@@ -131,6 +144,12 @@ func (s *Service) Set(key, value string) error {
 			return fmt.Errorf("%s must be > 0, got %d", key, n)
 		}
 		st.Defaults.TimeoutSeconds = &n
+	case KeyTheme:
+		if !validThemes[value] {
+			return fmt.Errorf("%s must be one of default, paper, phosphor, amber; got %q", key, value)
+		}
+		v := value
+		st.Defaults.Theme = &v
 	default:
 		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
 	}
@@ -146,6 +165,8 @@ func (s *Service) Unset(key string) error {
 	switch key {
 	case KeyDefaultTimeout:
 		st.Defaults.TimeoutSeconds = nil
+	case KeyTheme:
+		st.Defaults.Theme = nil
 	default:
 		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
 	}
@@ -160,4 +181,14 @@ func (st *Settings) DefaultTimeout() (int, bool) {
 		return 0, false
 	}
 	return *st.Defaults.TimeoutSeconds, true
+}
+
+// Theme returns the user's persisted theme choice, if any. Callers
+// should treat an unset value as "no preference — fall back to env
+// var, then default-detect" (the TUI does this).
+func (st *Settings) Theme() (string, bool) {
+	if st == nil || st.Defaults.Theme == nil {
+		return "", false
+	}
+	return *st.Defaults.Theme, true
 }

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -50,6 +50,40 @@ func TestService_Set_InvalidTimeout(t *testing.T) {
 	}
 }
 
+func TestService_Set_Theme(t *testing.T) {
+	svc := NewService(t.TempDir())
+
+	if err := svc.Set(KeyTheme, "amber"); err != nil {
+		t.Fatalf("set amber: %v", err)
+	}
+	st, err := svc.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := st.Theme()
+	if !ok || v != "amber" {
+		t.Errorf("theme = %q/%v, want amber/true", v, ok)
+	}
+
+	if err := svc.Set(KeyTheme, "unknown-theme"); err == nil {
+		t.Error("set unknown theme should fail")
+	}
+}
+
+func TestService_Unset_Theme(t *testing.T) {
+	svc := NewService(t.TempDir())
+	if err := svc.Set(KeyTheme, "phosphor"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Unset(KeyTheme); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	st, _ := svc.Load()
+	if _, ok := st.Theme(); ok {
+		t.Error("theme should be unset")
+	}
+}
+
 func TestService_Unset(t *testing.T) {
 	svc := NewService(t.TempDir())
 	if err := svc.Set(KeyDefaultTimeout, "600"); err != nil {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -27,6 +27,8 @@ import (
 	"os"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/autonoco/buttons/internal/settings"
 )
 
 // Brand palette. Exact hex values from the identity spec.
@@ -54,20 +56,52 @@ type themeColors struct {
 	chipBg      color.Color
 }
 
-// resolveTheme inspects $BUTTONS_THEME and returns the palette to use.
-// Unknown / unset values fall through to the adaptive default, so a
-// typo can't suddenly make the board illegible.
+// resolveTheme picks a palette by precedence:
+//
+//  1. $BUTTONS_THEME env var — wins, always. Same pattern as batteries
+//     and default-timeout: an explicit env override beats saved
+//     preference so flipping themes for A/B comparison stays easy.
+//  2. `theme` key in ~/.buttons/settings.json — the persistent choice
+//     the user made via `buttons config set theme NAME`.
+//  3. Default adaptive palette (ld(ink/paper)).
+//
+// Unknown values at any level fall through to the next step; a typo
+// can't make the board illegible.
 func resolveTheme() themeColors {
-	switch os.Getenv("BUTTONS_THEME") {
-	case "paper":
-		return paperTheme()
-	case "phosphor":
-		return phosphorTheme()
-	case "amber":
-		return amberTheme()
-	default:
-		return defaultTheme()
+	if t := os.Getenv("BUTTONS_THEME"); t != "" {
+		if colors, ok := themeByName(t); ok {
+			return colors
+		}
 	}
+	// Settings lookup. Errors fall through silently — a garbled
+	// settings file should never block the TUI.
+	if svc, err := settings.NewServiceFromEnv(); err == nil {
+		if st, err := svc.Load(); err == nil {
+			if name, ok := st.Theme(); ok {
+				if colors, ok := themeByName(name); ok {
+					return colors
+				}
+			}
+		}
+	}
+	return defaultTheme()
+}
+
+// themeByName maps a theme name to its palette. Returns (_, false) for
+// unknown names so the resolver can fall to the next step in its
+// precedence chain.
+func themeByName(name string) (themeColors, bool) {
+	switch name {
+	case "paper":
+		return paperTheme(), true
+	case "phosphor":
+		return phosphorTheme(), true
+	case "amber":
+		return amberTheme(), true
+	case "default":
+		return defaultTheme(), true
+	}
+	return themeColors{}, false
 }
 
 // defaultTheme preserves the pre-theming behavior: ink on paper, or


### PR DESCRIPTION
Themes landed as an env var in #93 but had no persistence — you had to edit your shell rc to make `BUTTONS_THEME=amber` stick. Now:

```bash
buttons config set theme amber       # stored in ~/.buttons/settings.json
buttons config set theme default
buttons config unset theme
```

## Resolution order at TUI startup
1. `$BUTTONS_THEME` env var — wins, always (keeps A/B comparison easy)
2. `theme` key in `~/.buttons/settings.json`
3. Default adaptive palette

Unknown values at any step fall through to the next — a typo can't blank the board.

## What changed

### `internal/settings`
- `Defaults.Theme *string`, `KeyTheme` constant, `Theme()` accessor
- `Set` validates against `{default, paper, phosphor, amber}`; invalid names surface as `VALIDATION_ERROR` rather than being written
- `Unset` clears the key
- Tests: valid set + load roundtrip, rejection of unknown names, unset

### `internal/tui/styles.go`
- `resolveTheme()` grows a settings lookup between the env check and the default fallback
- `themeByName` extracted so env and settings paths share one name→palette mapper
- Settings read errors fall through silently — bad settings should never block the TUI

### `cmd/config.go`
- Help text lists `theme` as a known key with the four valid values
- `buttons config` shows theme alongside `default-timeout` with an `(unset — using default (adaptive))` hint when the user hasn't picked one

## Smoke test
```
$ buttons config set theme amber
{ "ok": true, "data": { "key": "theme", "value": "amber" } }

$ buttons config
  default-timeout     (unset — using 300s)
  theme               amber

$ buttons config set theme bogus
{ "ok": false, "error": { "code": "VALIDATION_ERROR", "message": "theme must be one of default, paper, phosphor, amber; got \"bogus\"" } }
```

## Test plan
- [x] Unit tests for set/unset/validation
- [x] Full `go test ./...` + `gosec ./...` clean (0 issues)
- [x] End-to-end smoke: set → show → invalid-name-rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)