### PR TITLE
feat(tui): inline press-with-args form (D1)

### DIFF
--- a/internal/tui/argform.go
+++ b/internal/tui/argform.go
@@ -1,0 +1,222 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+// argForm is the inline press-with-args form that the board opens
+// when a button with required args is invoked. Hand-rolled rather
+// than huh-embedded so the board owns its keyboard dispatch without
+// juggling two tea.Models.
+//
+// Behavior:
+//
+//   - One field per declared arg (both required and optional). Users
+//     land on the first required field. Tab / shift+tab navigate.
+//   - Typing characters appends; backspace drops the last rune.
+//   - Enter submits IF every required field has a non-empty value;
+//     otherwise the cursor jumps to the first missing required field.
+//   - Esc cancels — the board returns to its normal view with no
+//     press dispatched.
+//
+// The form is intentionally untyped at the UI level: int and bool
+// fields accept free text (users type "42" / "true") and validation
+// happens when the submitted values run through button.ParsePressArgs
+// — the same code path the CLI uses. One validator, one error shape.
+type argForm struct {
+	btnName string
+	fields  []argField
+	cursor  int
+	// lastErr surfaces validation errors from ParsePressArgs after
+	// the user presses Enter — rendered below the fields so the form
+	// doesn't dismiss on a typo.
+	lastErr string
+}
+
+// argField is one editable row. Value is the current buffer; the
+// cursor glyph is appended at render time only on the focused row.
+type argField struct {
+	name     string
+	typ      string
+	required bool
+	value    string
+}
+
+// newArgForm builds a form from a button's ArgDefs. Returns nil when
+// the button has no args — callers should skip the form in that case
+// and press directly.
+func newArgForm(btn *button.Button) *argForm {
+	if len(btn.Args) == 0 {
+		return nil
+	}
+	fields := make([]argField, len(btn.Args))
+	for i, a := range btn.Args {
+		fields[i] = argField{name: a.Name, typ: a.Type, required: a.Required}
+	}
+	f := &argForm{btnName: btn.Name, fields: fields}
+	f.cursor = f.firstRequiredIndex()
+	return f
+}
+
+// firstRequiredIndex returns the index of the first required field
+// that's still empty — the natural landing spot on open, and where
+// we bounce the cursor on a premature submit.
+func (f *argForm) firstRequiredIndex() int {
+	for i, fld := range f.fields {
+		if fld.required && fld.value == "" {
+			return i
+		}
+	}
+	return 0
+}
+
+// argFormResult is what handleKey returns to the board — exactly one
+// of submit / cancel / nothing.
+type argFormResult int
+
+const (
+	argFormPending argFormResult = iota
+	argFormSubmit
+	argFormCancel
+)
+
+// handleKey processes one key press. Returns (result, values) where
+// values is populated only when result == argFormSubmit. The board
+// is responsible for running ParsePressArgs and dispatching the press.
+func (f *argForm) handleKey(msg tea.KeyPressMsg) (argFormResult, map[string]string) {
+	key := msg.String()
+	switch key {
+	case "esc":
+		return argFormCancel, nil
+
+	case "enter":
+		// Bounce to the first missing required field rather than
+		// submitting an incomplete form — users type Enter reflexively
+		// and silently rejecting would feel broken.
+		if idx := f.firstRequiredIndex(); idx >= 0 && f.fields[idx].value == "" {
+			f.cursor = idx
+			f.lastErr = fmt.Sprintf("%s is required", f.fields[idx].name)
+			return argFormPending, nil
+		}
+		return argFormSubmit, f.values()
+
+	case "tab", "down":
+		f.cursor = (f.cursor + 1) % len(f.fields)
+		f.lastErr = ""
+		return argFormPending, nil
+
+	case "shift+tab", "up":
+		f.cursor = (f.cursor - 1 + len(f.fields)) % len(f.fields)
+		f.lastErr = ""
+		return argFormPending, nil
+
+	case "backspace":
+		v := f.fields[f.cursor].value
+		if len(v) > 0 {
+			// Rune-safe: strip the last complete rune, not just byte.
+			runes := []rune(v)
+			f.fields[f.cursor].value = string(runes[:len(runes)-1])
+		}
+		f.lastErr = ""
+		return argFormPending, nil
+	}
+
+	// Printable input — append every rune of the Text (handles
+	// multi-rune keys on non-Latin layouts without special-casing).
+	if text := msg.Text; text != "" {
+		f.fields[f.cursor].value += text
+		f.lastErr = ""
+	}
+	return argFormPending, nil
+}
+
+// values returns the raw key→value map for ParsePressArgs. Empty
+// optional fields are omitted (ParsePressArgs would reject an empty
+// string for a typed optional anyway).
+func (f *argForm) values() map[string]string {
+	out := make(map[string]string, len(f.fields))
+	for _, fld := range f.fields {
+		if fld.value == "" && !fld.required {
+			continue
+		}
+		out[fld.name] = fld.value
+	}
+	return out
+}
+
+// render paints the form as a single block that replaces the board's
+// content area. Styled to read as a focused prompt: header ("press
+// NAME · N required args"), a row per field, and an inline error /
+// preview line. The board's header + footer render around this.
+func (f *argForm) render(styles Styles, width int) string {
+	if width <= 0 {
+		width = 80
+	}
+
+	reqCount := 0
+	for _, fld := range f.fields {
+		if fld.required {
+			reqCount++
+		}
+	}
+
+	title := styles.HeroTitle.Render("press " + f.btnName)
+	subtitle := styles.Muted.Render(fmt.Sprintf("  ·  %d arg", len(f.fields)))
+	if len(f.fields) != 1 {
+		subtitle = styles.Muted.Render(fmt.Sprintf("  ·  %d args · %d required", len(f.fields), reqCount))
+	}
+
+	lines := []string{
+		title + subtitle,
+		"",
+	}
+	for i, fld := range f.fields {
+		lines = append(lines, f.renderField(styles, i, fld))
+	}
+	if f.lastErr != "" {
+		lines = append(lines, "", styles.StatusError.Render("!  "+f.lastErr))
+	} else {
+		lines = append(lines, "", styles.Muted.Render("↵ run · ⇥ next field · ⎋ cancel"))
+	}
+
+	return indentBlock(strings.Join(lines, "\n"), leftPad*2)
+}
+
+// renderField formats one row: name, type tag, required/optional tag,
+// then the current value with a caret on the focused row.
+func (f *argForm) renderField(styles Styles, idx int, fld argField) string {
+	focused := idx == f.cursor
+
+	var name string
+	if focused {
+		name = styles.ButtonNameSelected.Render("› " + fld.name)
+	} else {
+		name = styles.ButtonName.Render("  " + fld.name)
+	}
+
+	typTag := styles.Muted.Render(fmt.Sprintf("%s · %s", fld.typ, optionalityLabel(fld.required)))
+
+	var value string
+	if focused {
+		// Block cursor at the end of the buffer.
+		value = styles.HeroCode.Render(fld.value + "▎")
+	} else if fld.value != "" {
+		value = styles.HeroCode.Render(fld.value)
+	} else {
+		value = styles.Muted.Render("—")
+	}
+
+	return fmt.Sprintf("%-22s  %-20s  %s", name, typTag, value)
+}
+
+func optionalityLabel(required bool) string {
+	if required {
+		return "required"
+	}
+	return "optional"
+}

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -65,6 +65,12 @@ type Model struct {
 	// footer. Pane shows recent run history for the focused button.
 	logsOpen bool
 
+	// argForm, when non-nil, is the inline press-with-args prompt
+	// replacing the board's content area. Opened automatically when
+	// the user presses a button with required args; dismissed on
+	// submit (press fires) or esc (no press).
+	argForm *argForm
+
 	// pressPulse is the name of the button currently showing the
 	// keydown / fire frames of the mechanical-press animation. Empty
 	// when no press is mid-choreography. Distinct from status because
@@ -228,6 +234,16 @@ func refreshCmd() tea.Cmd {
 }
 
 func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// When the arg form is open, every non-emergency key is its
+	// property. Ctrl+C keeps its board-level meaning (quit) so there's
+	// always an escape hatch even from inside a modal state.
+	if m.argForm != nil {
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+		return m.handleArgFormKey(msg)
+	}
+
 	switch msg.String() {
 	// Ctrl+C is kept as an unadvertised emergency escape so the user
 	// is never truly stuck if something goes wrong — but the board
@@ -284,6 +300,58 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// handleArgFormKey dispatches a key to the inline form and, on
+// submit, validates through button.ParsePressArgs and fires the
+// press using the CLI's exact validation path. On cancel, the form
+// clears and the board returns to normal.
+func (m Model) handleArgFormKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	res, values := m.argForm.handleKey(msg)
+	switch res {
+	case argFormCancel:
+		m.argForm = nil
+		return m, nil
+
+	case argFormSubmit:
+		target := m.argForm.btnName
+		// Find the button (it might have been deleted between form
+		// open and submit — unlikely, but an auto-refresh in another
+		// terminal is possible).
+		var btn *button.Button
+		for i := range m.buttons {
+			if m.buttons[i].Name == target {
+				btn = &m.buttons[i]
+				break
+			}
+		}
+		if btn == nil {
+			m.argForm = nil
+			m.lastErr = fmt.Sprintf("%s is no longer available", target)
+			return m, nil
+		}
+		parsed, err := button.ParsePressArgs(toArgList(values), btn.Args)
+		if err != nil {
+			// Stay on the form; surface the validation error inline.
+			m.argForm.lastErr = err.Error()
+			return m, nil
+		}
+		// Dismiss the form, fire the press with the typed args.
+		m.argForm = nil
+		return m.pressButtonWithArgs(target, parsed)
+	}
+	return m, nil
+}
+
+// toArgList flattens map[name]value into the key=value slice shape
+// button.ParsePressArgs expects — letting us reuse the same
+// validator the CLI uses.
+func toArgList(values map[string]string) []string {
+	out := make([]string, 0, len(values))
+	for k, v := range values {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+	return out
 }
 
 func (m Model) moveCursor(delta int) tea.Model {
@@ -379,12 +447,47 @@ func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Any required args without values → open the inline form and
+	// return to let the user fill them in. The press fires when the
+	// form submits (see handlePressFormSubmit).
+	hasRequired := false
 	for _, a := range btn.Args {
 		if a.Required {
-			m.lastErr = fmt.Sprintf("%s requires --arg %s; press from the CLI for now", name, a.Name)
-			m.lastOK = ""
+			hasRequired = true
+			break
+		}
+	}
+	if hasRequired {
+		m.argForm = newArgForm(btn)
+		m.lastErr = ""
+		m.lastOK = ""
+		return m, nil
+	}
+
+	return m.pressButtonWithArgs(name, nil)
+}
+
+// pressButtonWithArgs dispatches a press with pre-resolved args (or
+// nil for "no args"). Callers are expected to have already verified
+// required-arg validation — either because there are none, or because
+// the form just finished collecting values.
+func (m Model) pressButtonWithArgs(name string, args map[string]string) (tea.Model, tea.Cmd) {
+	// Repeat the running-check here so direct calls are safe too.
+	for _, s := range m.status {
+		if s == statusRunning {
 			return m, nil
 		}
+	}
+
+	var btn *button.Button
+	for i := range m.buttons {
+		if m.buttons[i].Name == name {
+			btn = &m.buttons[i]
+			break
+		}
+	}
+	if btn == nil {
+		return m, nil
 	}
 
 	m.lastErr = ""
@@ -406,7 +509,7 @@ func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	pressCmd := runPress(btn, codePath, batteries)
+	pressCmd := runPress(btn, codePath, batteries, args)
 
 	// Four-frame choreography: rest → keydown (now) → fire (+40ms) →
 	// release (+180ms). pressPulse is set synchronously so the very
@@ -424,7 +527,7 @@ func (m Model) pressButton(name string) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(pressCmd, fireCmd, releaseCmd)
 }
 
-func runPress(btn *button.Button, codePath string, batteries map[string]string) tea.Cmd {
+func runPress(btn *button.Button, codePath string, batteries, args map[string]string) tea.Cmd {
 	name := btn.Name
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(btn.TimeoutSeconds)*time.Second)
@@ -432,7 +535,7 @@ func runPress(btn *button.Button, codePath string, batteries map[string]string) 
 
 		// Board presses don't stream yet — the dedicated `buttons logs`
 		// viewer (C2) will pass a sink for live tailing.
-		result := engine.Execute(ctx, btn, nil, batteries, nil, codePath)
+		result := engine.Execute(ctx, btn, args, batteries, nil, codePath)
 		return pressDoneMsg{name: name, result: result}
 	}
 }
@@ -549,7 +652,12 @@ func (m Model) View() tea.View {
 	parts = append(parts, m.renderDivider())
 	parts = append(parts, "") // blank before content
 
-	if len(m.buttons) == 0 {
+	if m.argForm != nil {
+		// Modal-ish content: form replaces the list / hero block but
+		// the board's header + divider + footer scaffold stays so the
+		// user never loses their visual orientation.
+		parts = append(parts, m.argForm.render(m.styles, m.width))
+	} else if len(m.buttons) == 0 {
 		parts = append(parts, m.renderEmptyHero())
 	} else {
 		if m.hasPinned() {
@@ -561,7 +669,7 @@ func (m Model) View() tea.View {
 		parts = append(parts, m.renderList())
 	}
 
-	if m.logsOpen && len(m.buttons) > 0 {
+	if m.argForm == nil && m.logsOpen && len(m.buttons) > 0 {
 		parts = append(parts, "")
 		parts = append(parts, m.renderDivider())
 		parts = append(parts, "")


### PR DESCRIPTION
Spec station 04. Buttons with required args no longer bail the user to the CLI — the board opens an inline form, collects values, and fires the press through the same ParsePressArgs validation as CLI.

`internal/tui/argform.go` (new, ~200 LOC) + board integration.

Keys: Tab / ↓ next · Shift+Tab / ↑ prev · Enter submit · Esc cancel · Backspace edit.

## Scope
- All fields are free-text input (matches CLI `--arg key=value`). Validation via `button.ParsePressArgs` on submit — same code path as CLI, same error messages.
- Form replaces list/hero block; board header + footer scaffold stays visible so users don't lose orientation.
- Logs pane is suppressed while form is open (can't coexist in one vertical column).

## Deferred
- "will run:" preview line (station 04 shows one)
- Enum-type dropdown fields — separate PR, touches `button.ArgDef` + create command + form

## Tests
Existing TUI tests pass. Argform unit tests (form keys, submit guard, validation error retention) come with F1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)