### PR TITLE
feat(args): enum arg type — closed-set value validation (D2)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -46,19 +46,29 @@ inline script, --file to copy an existing script, --url for an HTTP
 endpoint, or --prompt for a standalone instruction.
 
 Arguments are defined with --arg in name:type:required|optional format.
-Supported types: string, int, bool. Args are injected as env vars for
-scripts or substituted into URL templates for API buttons.
+Supported types: string, int, bool, enum.
+
+Enum args accept a 4th pipe-separated segment listing the allowed
+values — the TUI press form renders them as a horizontal choice row,
+and the CLI validates the supplied value is in the set:
+
+  --arg env:enum:required:staging|prod|canary
+
+Args are injected as env vars for scripts or substituted into URL
+templates for API buttons.
 
 Common flags:
   -f, --file PATH       copy an existing script file as this button's code
       --code STRING     inline script body (shortcut for one-liners)
       --url URL         turn this into an HTTP button
-      --arg SPEC        define an arg (name:type:required|optional, repeatable)
+      --arg SPEC        define an arg (name:type:required|optional,
+                        or name:enum:required:a|b|c; repeatable)
       --timeout SECS    execution timeout (default: 300)
   -d, --description S   human-readable description for 'buttons list'
       --runtime NAME    shell | python | node  (default: shell)
 
 Examples:
+  buttons create deploy --arg env:enum:required:staging|prod|canary   # enum arg
   buttons create deploy                                  # scaffold, then edit main.sh
   buttons create etl --runtime python                    # scaffold, then edit main.py
   buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required

--- a/internal/button/args.go
+++ b/internal/button/args.go
@@ -10,14 +10,26 @@ var allowedTypes = map[string]bool{
 	"string": true,
 	"int":    true,
 	"bool":   true,
+	"enum":   true,
 }
 
+// ParseArgDef parses a single --arg spec. Accepted shapes:
+//
+//	name:type:required|optional                      (string, int, bool)
+//	name:enum:required|optional:value1|value2|value3  (enum with choices)
+//
+// The enum form uses the same outer colon separator as the simple
+// types but adds a fourth segment: a pipe-separated list of allowed
+// values. Examples:
+//
+//	env:enum:required:staging|prod|canary
+//	log-level:enum:optional:debug|info|warn|error
 func ParseArgDef(raw string) (ArgDef, error) {
 	parts := strings.Split(raw, ":")
-	if len(parts) != 3 {
+	if len(parts) != 3 && len(parts) != 4 {
 		return ArgDef{}, &ServiceError{
 			Code:    "VALIDATION_ERROR",
-			Message: fmt.Sprintf("arg %q must have format name:type:required|optional", raw),
+			Message: fmt.Sprintf("arg %q must have format name:type:required|optional (enum adds a 4th :value1|value2 segment)", raw),
 		}
 	}
 
@@ -35,7 +47,7 @@ func ParseArgDef(raw string) (ArgDef, error) {
 	if typ == "" || !allowedTypes[typ] {
 		return ArgDef{}, &ServiceError{
 			Code:    "VALIDATION_ERROR",
-			Message: fmt.Sprintf("arg %q has invalid type %q (allowed: string, int, bool)", raw, typ),
+			Message: fmt.Sprintf("arg %q has invalid type %q (allowed: string, int, bool, enum)", raw, typ),
 		}
 	}
 
@@ -52,7 +64,53 @@ func ParseArgDef(raw string) (ArgDef, error) {
 		}
 	}
 
-	return ArgDef{Name: name, Type: typ, Required: required}, nil
+	// Enum-only: 4th segment required and must list ≥ 2 values.
+	// One-value enum is technically legal but useless — we reject it
+	// early so a typo like `env:enum:required:staging` (missing pipe)
+	// surfaces as a clear error instead of a degenerate enum.
+	var values []string
+	if typ == "enum" {
+		if len(parts) != 4 {
+			return ArgDef{}, &ServiceError{
+				Code:    "VALIDATION_ERROR",
+				Message: fmt.Sprintf("arg %q: enum type requires a 4th segment with pipe-separated values (e.g. name:enum:required:a|b|c)", raw),
+			}
+		}
+		rawValues := strings.Split(parts[3], "|")
+		seen := make(map[string]bool, len(rawValues))
+		for _, v := range rawValues {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				return ArgDef{}, &ServiceError{
+					Code:    "VALIDATION_ERROR",
+					Message: fmt.Sprintf("arg %q: enum value set has empty entry", raw),
+				}
+			}
+			if seen[v] {
+				return ArgDef{}, &ServiceError{
+					Code:    "VALIDATION_ERROR",
+					Message: fmt.Sprintf("arg %q: duplicate enum value %q", raw, v),
+				}
+			}
+			seen[v] = true
+			values = append(values, v)
+		}
+		if len(values) < 2 {
+			return ArgDef{}, &ServiceError{
+				Code:    "VALIDATION_ERROR",
+				Message: fmt.Sprintf("arg %q: enum needs at least 2 values, got %d", raw, len(values)),
+			}
+		}
+	} else if len(parts) == 4 {
+		// Non-enum type with a 4th segment is almost certainly a
+		// mistake (typo'd :enum, or mis-copied example). Reject.
+		return ArgDef{}, &ServiceError{
+			Code:    "VALIDATION_ERROR",
+			Message: fmt.Sprintf("arg %q: only enum types accept a 4th :value1|value2 segment", raw),
+		}
+	}
+
+	return ArgDef{Name: name, Type: typ, Required: required, Values: values}, nil
 }
 
 // ParsePressArgs parses key=value pairs and validates them against the button's arg definitions.
@@ -100,7 +158,7 @@ func ParsePressArgs(raws []string, defs []ArgDef) (map[string]string, error) {
 			}
 			continue
 		}
-		if err := validateArgType(d.Name, d.Type, val); err != nil {
+		if err := validateArgValue(d, val); err != nil {
 			return nil, err
 		}
 	}
@@ -108,13 +166,16 @@ func ParsePressArgs(raws []string, defs []ArgDef) (map[string]string, error) {
 	return supplied, nil
 }
 
-func validateArgType(name, typ, value string) error {
-	switch typ {
+// validateArgValue checks a supplied press-time value against a
+// declared ArgDef. Dispatches on Type; enum also checks membership in
+// the Values set.
+func validateArgValue(d ArgDef, value string) error {
+	switch d.Type {
 	case "int":
 		if _, err := strconv.Atoi(value); err != nil {
 			return &ServiceError{
 				Code:    "VALIDATION_ERROR",
-				Message: fmt.Sprintf("arg '%s' expects int, got %q", name, value),
+				Message: fmt.Sprintf("arg '%s' expects int, got %q", d.Name, value),
 			}
 		}
 	case "bool":
@@ -123,8 +184,18 @@ func validateArgType(name, typ, value string) error {
 		default:
 			return &ServiceError{
 				Code:    "VALIDATION_ERROR",
-				Message: fmt.Sprintf("arg '%s' expects bool (true/false/1/0), got %q", name, value),
+				Message: fmt.Sprintf("arg '%s' expects bool (true/false/1/0), got %q", d.Name, value),
 			}
+		}
+	case "enum":
+		for _, v := range d.Values {
+			if v == value {
+				return nil
+			}
+		}
+		return &ServiceError{
+			Code:    "VALIDATION_ERROR",
+			Message: fmt.Sprintf("arg '%s' must be one of %s; got %q", d.Name, strings.Join(d.Values, ", "), value),
 		}
 	}
 	return nil

--- a/internal/button/args_test.go
+++ b/internal/button/args_test.go
@@ -60,3 +60,67 @@ func TestParseArgDefs_Valid(t *testing.T) {
 		t.Fatalf("expected 2 defs, got %d", len(defs))
 	}
 }
+
+func TestParseArgDef_EnumValid(t *testing.T) {
+	def, err := ParseArgDef("env:enum:required:staging|prod|canary")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if def.Type != "enum" {
+		t.Errorf("type = %q, want enum", def.Type)
+	}
+	if !def.Required {
+		t.Error("required should be true")
+	}
+	if len(def.Values) != 3 {
+		t.Fatalf("values = %v, want 3 entries", def.Values)
+	}
+	for i, want := range []string{"staging", "prod", "canary"} {
+		if def.Values[i] != want {
+			t.Errorf("values[%d] = %q, want %q", i, def.Values[i], want)
+		}
+	}
+}
+
+func TestParseArgDef_EnumRejectsBadShapes(t *testing.T) {
+	cases := []struct {
+		raw    string
+		reason string
+	}{
+		{"env:enum:required", "missing values segment"},
+		{"env:enum:required:only-one", "single-value enum is useless"},
+		{"env:enum:required:a||b", "empty entry in the list"},
+		{"env:enum:required:a|a", "duplicate enum value"},
+		{"name:string:required:a|b", "non-enum types don't accept a 4th segment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			if _, err := ParseArgDef(tc.raw); err == nil {
+				t.Errorf("ParseArgDef(%q) should fail: %s", tc.raw, tc.reason)
+			}
+		})
+	}
+}
+
+func TestParsePressArgs_EnumMembership(t *testing.T) {
+	defs := []ArgDef{{
+		Name:     "env",
+		Type:     "enum",
+		Required: true,
+		Values:   []string{"staging", "prod", "canary"},
+	}}
+
+	// Valid value — passes.
+	out, err := ParsePressArgs([]string{"env=staging"}, defs)
+	if err != nil {
+		t.Fatalf("staging should be accepted: %v", err)
+	}
+	if out["env"] != "staging" {
+		t.Errorf("value = %q, want staging", out["env"])
+	}
+
+	// Invalid value — rejected with a helpful message listing the set.
+	if _, err := ParsePressArgs([]string{"env=dev"}, defs); err == nil {
+		t.Error("dev should be rejected (not in enum)")
+	}
+}

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -29,6 +29,11 @@ type ArgDef struct {
 	Name     string `json:"name"`
 	Type     string `json:"type"`
 	Required bool   `json:"required"`
+
+	// Values is the allowed value set for Type == "enum". Empty for
+	// other types. Stored in JSON as `values` (omitempty so existing
+	// non-enum buttons don't grow a noisy empty-array field).
+	Values []string `json:"values,omitempty"`
 }
 
 // ExtForRuntime returns the code file extension for a given runtime.

--- a/internal/tui/argform.go
+++ b/internal/tui/argform.go
@@ -38,13 +38,20 @@ type argForm struct {
 	lastErr string
 }
 
-// argField is one editable row. Value is the current buffer; the
-// cursor glyph is appended at render time only on the focused row.
+// argField is one editable row. For text-style types (string / int /
+// bool), `value` is the current input buffer. For `enum`, `values`
+// holds the declared choices and `selectedIdx` is the currently-
+// highlighted one — `value` is derived from `values[selectedIdx]` on
+// every selection move so submit and render agree.
 type argField struct {
 	name     string
 	typ      string
 	required bool
 	value    string
+
+	// Enum-only.
+	values      []string
+	selectedIdx int
 }
 
 // newArgForm builds a form from a button's ArgDefs. Returns nil when
@@ -56,7 +63,16 @@ func newArgForm(btn *button.Button) *argForm {
 	}
 	fields := make([]argField, len(btn.Args))
 	for i, a := range btn.Args {
-		fields[i] = argField{name: a.Name, typ: a.Type, required: a.Required}
+		f := argField{name: a.Name, typ: a.Type, required: a.Required}
+		// Enum: pre-select the first value so Enter can submit
+		// immediately without additional input. Any pre-selected
+		// value is valid by definition.
+		if a.Type == "enum" && len(a.Values) > 0 {
+			f.values = a.Values
+			f.selectedIdx = 0
+			f.value = a.Values[0]
+		}
+		fields[i] = f
 	}
 	f := &argForm{btnName: btn.Name, fields: fields}
 	f.cursor = f.firstRequiredIndex()
@@ -115,7 +131,25 @@ func (f *argForm) handleKey(msg tea.KeyPressMsg) (argFormResult, map[string]stri
 		f.lastErr = ""
 		return argFormPending, nil
 
+	case "left":
+		// Only meaningful on enum fields — moves the selection back.
+		// No-op on text fields so users don't feel like they broke
+		// anything by pressing it.
+		f.moveEnumSelection(-1)
+		f.lastErr = ""
+		return argFormPending, nil
+
+	case "right":
+		f.moveEnumSelection(+1)
+		f.lastErr = ""
+		return argFormPending, nil
+
 	case "backspace":
+		// Enum values aren't edited character-by-character — ignore
+		// backspace so users don't clear a radio pick by reflex.
+		if f.fields[f.cursor].typ == "enum" {
+			return argFormPending, nil
+		}
 		v := f.fields[f.cursor].value
 		if len(v) > 0 {
 			// Rune-safe: strip the last complete rune, not just byte.
@@ -128,11 +162,28 @@ func (f *argForm) handleKey(msg tea.KeyPressMsg) (argFormResult, map[string]stri
 
 	// Printable input — append every rune of the Text (handles
 	// multi-rune keys on non-Latin layouts without special-casing).
+	// Enum fields don't accept text input; the user moves between
+	// choices with left/right.
+	if f.fields[f.cursor].typ == "enum" {
+		return argFormPending, nil
+	}
 	if text := msg.Text; text != "" {
 		f.fields[f.cursor].value += text
 		f.lastErr = ""
 	}
 	return argFormPending, nil
+}
+
+// moveEnumSelection advances the current field's enum selection by
+// delta (wrapping). No-op if the current field isn't an enum.
+func (f *argForm) moveEnumSelection(delta int) {
+	fld := &f.fields[f.cursor]
+	if fld.typ != "enum" || len(fld.values) == 0 {
+		return
+	}
+	n := len(fld.values)
+	fld.selectedIdx = (fld.selectedIdx + delta + n) % n
+	fld.value = fld.values[fld.selectedIdx]
 }
 
 // values returns the raw key→value map for ParsePressArgs. Empty
@@ -202,7 +253,9 @@ func (f *argForm) renderField(styles Styles, idx int, fld argField) string {
 	typTag := styles.Muted.Render(fmt.Sprintf("%s · %s", fld.typ, optionalityLabel(fld.required)))
 
 	var value string
-	if focused {
+	if fld.typ == "enum" {
+		value = f.renderEnumValue(styles, fld, focused)
+	} else if focused {
 		// Block cursor at the end of the buffer.
 		value = styles.HeroCode.Render(fld.value + "▎")
 	} else if fld.value != "" {
@@ -212,6 +265,30 @@ func (f *argForm) renderField(styles Styles, idx int, fld argField) string {
 	}
 
 	return fmt.Sprintf("%-22s  %-20s  %s", name, typTag, value)
+}
+
+// renderEnumValue draws a horizontal choice strip for an enum field.
+// Unselected values render muted; the selected value renders in
+// HeroCode (the "inline code" chip style). When the row is focused,
+// arrow glyphs flank the set so the left/right navigation affordance
+// is visible without reading the help line.
+func (f *argForm) renderEnumValue(styles Styles, fld argField, focused bool) string {
+	if len(fld.values) == 0 {
+		return styles.Muted.Render("(no choices)")
+	}
+	parts := make([]string, 0, len(fld.values))
+	for i, v := range fld.values {
+		if i == fld.selectedIdx {
+			parts = append(parts, styles.HeroCode.Render(v))
+		} else {
+			parts = append(parts, styles.Muted.Render(v))
+		}
+	}
+	body := strings.Join(parts, styles.Muted.Render("  "))
+	if focused {
+		return styles.Muted.Render("‹ ") + body + styles.Muted.Render(" ›")
+	}
+	return "  " + body + "  "
 }
 
 func optionalityLabel(required bool) string {


### PR DESCRIPTION
Extends the button arg system with a fourth type — `enum` — with a closed set of valid values. Covers common cases: environments (staging/prod/canary), log levels, regions, tiers. Collapses script-level `case $1 in ... \*) exit 1 ;; esac` boilerplate into the button spec itself.

## Syntax
```bash
buttons create deploy \
  --arg env:enum:required:staging|prod|canary \
  --arg level:enum:optional:debug|info|warn|error
```

## What changes

**`internal/button`** — `ArgDef` gains `Values []string` (JSON `values,omitempty`). `ParseArgDef` accepts the 4-segment form. `ParsePressArgs` validates membership with a helpful error (`must be one of staging, prod, canary; got "dev"`).

**`cmd/create`** — help / examples document the syntax. No flag parsing change.

**`internal/tui/argform`** — enum fields render as a horizontal choice strip (`‹ staging  prod  canary ›`). Arrow keys cycle selection. First value pre-selected so Enter submits immediately.

## Backwards compatibility
- `schema_version` stays 2 — `Values` is an optional field
- Existing buttons without `Values` continue to work unchanged
- `omitempty` keeps old button.json files byte-identical

## Tests
- 3 unit tests in `internal/button/args_test.go`: enum parse, five bad-shape rejections, membership validation
- Full `go test ./...` + `gosec ./...` clean (0 issues)
- End-to-end: create → button.json has values → press valid → press invalid, all shapes verified

## Plan status
Next after this: E (detail as TUI page) and F (snapshot tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)