### PR TITLE
feat(tui): active pinned card + divider contrast (item 1 of #118 remainder)

### DIFF
--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -771,15 +771,26 @@ func (m Model) renderPinnedCard(btn button.Button, selected bool) string {
 	if len(label) < 10 {
 		label = fmt.Sprintf("%-10s", label)
 	}
-	// While running, render a second line inside the card showing a
-	// live elapsed counter ("● active · 3.2s"). Lip Gloss handles
-	// multi-line content inside a bordered box; the card grows by one
-	// row only while active, so idle-state layout is unchanged.
-	if m.status[btn.Name] == statusRunning {
-		sub := "● active · " + formatElapsed(m.elapsedFor(btn.Name))
-		return style.Render(label + "\n" + sub)
+	// Idle cards: single-line label inside the bordered box.
+	if m.status[btn.Name] != statusRunning {
+		return style.Render(label)
 	}
-	return style.Render(label)
+
+	// Active cards: two-line interior (label + elapsed toast) and a
+	// right-aligned "↵ TAIL" badge pinned to the line ABOVE the card's
+	// top border — matches spec station 02 where a running pinned card
+	// gets the badge floating just outside its top-right corner, hinting
+	// that pressing ↵ on the selected row opens the live log stream.
+	sub := m.styles.Indicator.Render("● ACTIVE") + m.styles.Muted.Render(" · "+formatElapsed(m.elapsedFor(btn.Name)))
+	card := style.Render(label + "\n" + sub)
+
+	cardWidth := lipgloss.Width(card)
+	badge := m.styles.BadgeActive.Render("↵ TAIL")
+	badgeOffset := cardWidth - lipgloss.Width(badge)
+	if badgeOffset < 0 {
+		badgeOffset = 0
+	}
+	return strings.Repeat(" ", badgeOffset) + badge + "\n" + card
 }
 
 func (m Model) renderList() string {

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -113,6 +113,22 @@ func TestSnapshot_BoardLogsOpen(t *testing.T) {
 	assertSnapshot(t, "board_logs_pane_empty", m.View().Content)
 }
 
+func TestSnapshot_BoardPinnedActive(t *testing.T) {
+	// Pinned button mid-press: spec shows thick orange border, two-line
+	// interior (name + "● ACTIVE · <elapsed>"), and a "↵ TAIL" badge
+	// floating above the card's top-right corner.
+	m := fixtureModel([]button.Button{
+		{Name: "deploy", Runtime: "shell", TimeoutSeconds: 300, Pinned: true},
+		{Name: "weather", Runtime: "http", URL: "https://wttr.in/NYC", TimeoutSeconds: 60},
+	})
+	m.section = sectionPinned
+	m.cursorPinned = 0
+	m.status["deploy"] = statusRunning
+	// Freeze elapsed at a known instant so the golden is deterministic.
+	m.pressStartedAt["deploy"] = time.Now().Add(-3*time.Second - 200*time.Millisecond)
+	assertSnapshot(t, "board_pinned_active", m.View().Content)
+}
+
 func TestSnapshot_BoardArgFormOpen(t *testing.T) {
 	btn := button.Button{
 		Name:           "deploy",

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -113,7 +113,12 @@ func defaultTheme() themeColors {
 	return themeColors{
 		primary:     ld(lipgloss.Color(hexInk), lipgloss.Color(hexPaper)),
 		secondary:   ld(lipgloss.Color(hexDust), lipgloss.Color("#A8A8A0")),
-		muted:       ld(lipgloss.Color(hexAluminum), lipgloss.Color("#3A3A38")),
+		// Muted (divider + border foreground) needs to stay visible
+		// on dark terminals. The previous #3A3A38 was near-black on
+		// a typical dark terminal bg and dividers rendered almost
+		// invisible. #555550 gives a readable grey without competing
+		// with primary text.
+		muted:       ld(lipgloss.Color(hexAluminum), lipgloss.Color("#555550")),
 		indicator:   lipgloss.Color(hexIndicator),
 		onIndicator: lipgloss.Color(hexPaper),
 		warn:        lipgloss.Color("#F0C060"),

--- a/internal/tui/testdata/board_pinned_active.golden
+++ b/internal/tui/testdata/board_pinned_active.golden
@@ -1,0 +1,23 @@
+  ● buttons                                                     btn—02 · board
+────────────────────────────────────────────────────────────────────────────────
+
+                ↵ TAIL 
+  ┏━━━━━━━━━━━━━━━━━━━┓
+  ┃    deploy         ┃
+  ┃  ● ACTIVE · 3.2s  ┃
+  ┗━━━━━━━━━━━━━━━━━━━┛
+
+────────────────────────────────────────────────────────────────────────────────
+
+  ⠋   deploy                                      shell · 300s  3.2s   ACTIVE 
+  □   weather                                     http · 60s · GET wttr.in/NYC
+
+────────────────────────────────────────────────────────────────────────────────
+
+  ┌─────────┐                                                                 
+  │  press  │                  ↑↓  nav  ·   ↵  press  ·   L  logs  ·   ?  help
+  └─────────┘                                                                 
+
+  ● deploy running… stdout streaming to ~/.buttons/buttons/deploy/pressed/
+
+  TTY 1 · UTF-8 · 256-COLOR                                  ● ACTIVE · deploy


### PR DESCRIPTION
First of three sequential PRs (pinned card → detail chrome → logs chrome) addressing the remaining #118 items.

## What changed

### Active pinned card (spec station 02)

When a pinned button is running, the card now renders:
- Thick orange border (already there)
- Two-line interior: bold name on top, `● ACTIVE · 3.2s` below
- **New:** `↵ TAIL` badge on the line directly above the card's top-right corner, hinting "↵ on the selected row opens live logs"

Measured by computing card width and prepending a right-aligned badge line. Card grows by 2 rows during an active press.

### Divider contrast bump

Dividers were rendering nearly invisible on dark terminals. Muted-on-dark was `#3A3A38` — basically indistinguishable from the typical terminal bg. Bumped to `#555550`. Light theme unchanged.

The screenshot Bobak shared showed dividers essentially vanishing; they're now legible.

## Tests

- New `board_pinned_active` golden captures the full active-state rendering (including `↵ TAIL` badge + running toast + `● ACTIVE · deploy` chrome badge)
- Existing 5 goldens regenerated for the new divider color — same text content, different ANSI escapes

## Sequence
Next up: detail-page bottom chrome, then logs-view bottom chrome + `● follow` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)