### PR TITLE
feat(tui): detail page bottom chrome strip (item 2 of #118 remainder)

### DIFF
--- a/internal/tui/detail_view.go
+++ b/internal/tui/detail_view.go
@@ -49,9 +49,66 @@ func (m DetailModel) View() tea.View {
 	parts = append(parts, "")
 	parts = append(parts, m.renderDetailFooter())
 
+	// Bottom chrome strip — runtime / capacity / network for HTTP
+	// buttons, just the runtime label otherwise. Mirrors the board's
+	// chrome pattern so the two views share visual vocabulary.
+	parts = append(parts, "")
+	parts = append(parts, m.renderDetailChrome())
+
 	v := tea.NewView(strings.Join(parts, "\n"))
 	v.AltScreen = true
 	return v
+}
+
+// renderDetailChrome paints the bottom status strip for the detail
+// page. Surfaces the runtime-shaped facts at a glance:
+//
+//	HTTP button    HTTP <method> · <max-resp> · NET PUBLIC|PRIVATE
+//	shell/python   <RUNTIME> · <timeout>s
+//	prompt         PROMPT · <timeout>s
+//
+// Left side is always the brand identity line the board uses. Right
+// side flips on button type.
+func (m DetailModel) renderDetailChrome() string {
+	left := strings.Join([]string{"TTY 1", "UTF-8", "256-COLOR"}, m.styles.Muted.Render(" · "))
+	left = m.styles.Chrome.Render(left)
+
+	var rightParts []string
+	switch {
+	case m.btn.URL != "":
+		method := m.btn.Method
+		if method == "" {
+			method = "GET"
+		}
+		rightParts = append(rightParts, "HTTP "+method)
+		rightParts = append(rightParts, button.FormatSize(button.ResolveMaxResponseBytes(m.btn.MaxResponseBytes)))
+		if m.btn.AllowPrivateNetworks {
+			rightParts = append(rightParts, "NET PRIVATE")
+		} else {
+			rightParts = append(rightParts, "NET PUBLIC")
+		}
+	case m.btn.Runtime == "prompt":
+		rightParts = append(rightParts, "PROMPT")
+		rightParts = append(rightParts, fmt.Sprintf("%ds", m.btn.TimeoutSeconds))
+	default:
+		rt := strings.ToUpper(m.btn.Runtime)
+		if rt == "" {
+			rt = "SHELL"
+		}
+		rightParts = append(rightParts, rt)
+		rightParts = append(rightParts, fmt.Sprintf("%ds", m.btn.TimeoutSeconds))
+	}
+	right := m.styles.Chrome.Render(strings.Join(rightParts, " · "))
+
+	w := m.width
+	if w <= 0 {
+		w = 80
+	}
+	gap := w - lipgloss.Width(left) - lipgloss.Width(right) - leftPad*2
+	if gap < 2 {
+		gap = 2
+	}
+	return strings.Repeat(" ", leftPad) + left + strings.Repeat(" ", gap) + right
 }
 
 // renderDetailHeader is the name + optional description line.

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -129,6 +129,46 @@ func TestSnapshot_BoardPinnedActive(t *testing.T) {
 	assertSnapshot(t, "board_pinned_active", m.View().Content)
 }
 
+func TestSnapshot_DetailHTTP(t *testing.T) {
+	// Detail view for an HTTP button — chrome surfaces method, max
+	// response cap, and network access scope.
+	btn := &button.Button{
+		Name:                 "weather",
+		Description:          "get current weather for a city via wttr.in JSON API",
+		Runtime:              "http",
+		URL:                  "https://wttr.in/{{city}}?format=j1",
+		Method:               "GET",
+		TimeoutSeconds:       60,
+		AllowPrivateNetworks: false,
+		Args: []button.ArgDef{
+			{Name: "city", Type: "string", Required: true},
+		},
+	}
+	m := NewDetail(btn, nil, "", "")
+	m.width = 100
+	m.height = 40
+	assertSnapshot(t, "detail_http", m.View().Content)
+}
+
+func TestSnapshot_DetailShell(t *testing.T) {
+	// Detail view for a shell button with a code path — chrome shows
+	// runtime + timeout; the `e edit` hint is present.
+	btn := &button.Button{
+		Name:           "deploy",
+		Description:    "ship a release to a target env",
+		Runtime:        "shell",
+		TimeoutSeconds: 300,
+		Args: []button.ArgDef{
+			{Name: "env", Type: "string", Required: true},
+			{Name: "verbose", Type: "bool", Required: false},
+		},
+	}
+	m := NewDetail(btn, nil, "", "/tmp/deploy/main.sh")
+	m.width = 100
+	m.height = 40
+	assertSnapshot(t, "detail_shell", m.View().Content)
+}
+
 func TestSnapshot_BoardArgFormOpen(t *testing.T) {
 	btn := button.Button{
 		Name:           "deploy",

--- a/internal/tui/testdata/detail_http.golden
+++ b/internal/tui/testdata/detail_http.golden
@@ -1,0 +1,24 @@
+  weather  — get current weather for a city via wttr.in JSON API                            detail
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    runtime       http
+    method        GET
+    url           https://wttr.in/{{city}}?format=j1
+    max resp      10.0 MB
+    private net   blocked
+    timeout       60s
+
+    args
+    
+    city  string · required
+
+    usage
+    
+    buttons press weather --arg city=<string>
+    buttons press weather --arg city=<string> --json
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+   ↵  back
+
+  TTY 1 · UTF-8 · 256-COLOR                                        HTTP GET · 10.0 MB · NET PUBLIC

--- a/internal/tui/testdata/detail_shell.golden
+++ b/internal/tui/testdata/detail_shell.golden
@@ -1,0 +1,21 @@
+  deploy  — ship a release to a target env                                                  detail
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    runtime       shell
+    timeout       300s
+
+    args
+    
+    env  string · required
+    verbose  bool · optional
+
+    usage
+    
+    buttons press deploy --arg env=<string>
+    buttons press deploy --arg env=<string> --json
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+   e  edit  ·   ↵  back
+
+  TTY 1 · UTF-8 · 256-COLOR                                                           SHELL · 300s


### PR DESCRIPTION
Second of the three remaining #118 items. The detail page now ends with the chrome strip the board uses:

```
TTY 1 · UTF-8 · 256-COLOR    HTTP GET · 10.0 MB · NET PUBLIC    (HTTP button)
TTY 1 · UTF-8 · 256-COLOR                        SHELL · 300s   (shell button)
TTY 1 · UTF-8 · 256-COLOR                       PROMPT · 60s    (prompt button)
```

Runtime-shaped badges on the right so the detail page's mode-line reads differently per button type. Matches the board's chrome pattern so both views share visual vocabulary.

## New goldens
- `detail_http.golden` — HTTP button with `{{city}}` template var + required arg
- `detail_shell.golden` — shell button with code path + 2 args

Both capture full rendering so any future tweak shows up as a plain-text diff.

## Sequence
Last item: logs-view bottom chrome + `● follow` header indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)