### PR TITLE
feat(press): --follow streams live output during a press

### DIFF
--- a/.agents/skills/buttons/SKILL.md
+++ b/.agents/skills/buttons/SKILL.md
@@ -273,6 +273,7 @@ buttons press [flags]
 |------|------|-------------|
 | `--arg` | stringArray | argument as key=value |
 | `--dry-run` | bool | show what would execute without running |
+| `-f, --follow` | bool | stream stdout/stderr to stderr as the press runs (final Result still goes to stdout) |
 | `--idempotency-key` | string | reuse the cached result for this key if present (cross-run dedup) |
 | `--idempotency-ttl` | duration | how long idempotency entries stay valid (e.g. 1h, 24h) |
 | `--timeout` | int | override timeout in seconds |

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -22,6 +22,7 @@ var pressTimeout int
 var pressDryRun bool
 var pressIdempotencyKey string
 var pressIdempotencyTTL time.Duration
+var pressFollow bool
 
 var pressCmd = &cobra.Command{
 	Use:   "press [name]",
@@ -165,10 +166,35 @@ Examples:
 			defer queueLock.Release()
 		}
 
-		// No streaming sink for CLI presses — the final Result is the
-		// only thing the caller needs. The TUI log viewer (C2) passes
-		// a real sink to see lines as they happen.
-		result := engine.Execute(ctx, btn, parsedArgs, batteries, nil, codePath)
+		// If --follow is set, tee child stdout/stderr to our stderr
+		// as lines arrive. Pure-text stream: stdout lines prefixed
+		// with nothing, stderr lines prefixed with `! `. The final
+		// structured Result still goes to stdout at the end so
+		// agents can parse `buttons press --follow --json | jq .`
+		// cleanly — live feed on stderr, result on stdout.
+		var sink chan engine.LogLine
+		var sinkDone chan struct{}
+		if pressFollow {
+			sink = make(chan engine.LogLine, 128)
+			sinkDone = make(chan struct{})
+			go func() {
+				for line := range sink {
+					prefix := ""
+					if line.Sev == engine.SeverityStderr {
+						prefix = "! "
+					}
+					fmt.Fprintf(os.Stderr, "%s%s\n", prefix, line.Text)
+				}
+				close(sinkDone)
+			}()
+		}
+
+		result := engine.Execute(ctx, btn, parsedArgs, batteries, sink, codePath)
+
+		if pressFollow {
+			close(sink)
+			<-sinkDone // drain the channel before emitting the final Result
+		}
 
 		// Attach prompt if AGENT.md has custom content (not the default template)
 		if promptMD := readPrompt(btn.Name); promptMD != "" {
@@ -309,5 +335,6 @@ func init() {
 	pressCmd.Flags().BoolVar(&pressDryRun, "dry-run", false, "show what would execute without running")
 	pressCmd.Flags().StringVar(&pressIdempotencyKey, "idempotency-key", "", "reuse the cached result for this key if present (cross-run dedup)")
 	pressCmd.Flags().DurationVar(&pressIdempotencyTTL, "idempotency-ttl", 24*time.Hour, "how long idempotency entries stay valid (e.g. 1h, 24h)")
+	pressCmd.Flags().BoolVarP(&pressFollow, "follow", "f", false, "stream stdout/stderr to stderr as the press runs (final Result still goes to stdout)")
 	rootCmd.AddCommand(pressCmd)
 }

--- a/docs/cli/buttons_press.md
+++ b/docs/cli/buttons_press.md
@@ -39,6 +39,7 @@ buttons press [name] [flags]
 ```
       --arg stringArray            argument as key=value
       --dry-run                    show what would execute without running
+  -f, --follow                     stream stdout/stderr to stderr as the press runs (final Result still goes to stdout)
   -h, --help                       help for press
       --idempotency-key string     reuse the cached result for this key if present (cross-run dedup)
       --idempotency-ttl duration   how long idempotency entries stay valid (e.g. 1h, 24h) (default 24h0m0s)


### PR DESCRIPTION
One new command flag. Tiny PR.

\`buttons press NAME --follow\` tees child stdout/stderr to the CLI's stderr as each line arrives. Stdout lines print as-is; stderr lines are prefixed with \`! \`. The final structured Result still goes to stdout at the end — agents parse the same JSON they always did.

## Why
Answers "how do I press a button and follow the logs at the same time?" in a single command. Before this, you had to background the press and \`buttons tail -f\` separately. Now:

\`\`\`
buttons press X --follow --json 2> live-feed.log | jq .
#                                      │                  └─ final Result (stdout)
#                                      └─ live output lines (stderr)
\`\`\`

## What this is NOT
- Not a TUI — pure text stream. The TUI lives on \`buttons board\`.
- Not a replacement for \`buttons tail\` — \`tail\` follows the progress JSONL that scripts write to \`\$BUTTONS_PROGRESS_PATH\`; this one tails child stdout/stderr. Different streams, both useful.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./...\` all green
- [x] Smoke tested: stdout gets final JSON, stderr gets live feed, both separable

🤖 Generated with [Claude Code](https://claude.com/claude-code)