### PR TITLE
feat(drawer): on_error handler + kind=wait

### DIFF
--- a/cmd/drawer.go
+++ b/cmd/drawer.go
@@ -46,6 +46,7 @@ Usage:
   buttons drawer NAME add BUTTON [BUTTON ...]         append button step(s)
   buttons drawer NAME add drawer/OTHER                append a sub-drawer step
   buttons drawer NAME add for_each:BUTTON             append a per-item loop wrapping BUTTON
+  buttons drawer NAME add wait:DURATION               append a time-based pause (e.g. wait:30s)
   buttons drawer NAME connect A to B                  auto-match output → args by name+type
   buttons drawer NAME connect A.output.x to B.args.y  explicit field path
   buttons drawer NAME set STEP.args.FIELD=value       literal or ${ref} into a step arg

--- a/docs/cli/buttons_drawer.md
+++ b/docs/cli/buttons_drawer.md
@@ -18,6 +18,7 @@ Usage:
   buttons drawer NAME add BUTTON [BUTTON ...]         append button step(s)
   buttons drawer NAME add drawer/OTHER                append a sub-drawer step
   buttons drawer NAME add for_each:BUTTON             append a per-item loop wrapping BUTTON
+  buttons drawer NAME add wait:DURATION               append a time-based pause (e.g. wait:30s)
   buttons drawer NAME connect A to B                  auto-match output → args by name+type
   buttons drawer NAME connect A.output.x to B.args.y  explicit field path
   buttons drawer NAME set STEP.args.FIELD=value       literal or ${ref} into a step arg

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -166,6 +166,10 @@
           "description": "Drawer name to invoke (kind=drawer only)",
           "type": "string"
         },
+        "duration": {
+          "description": "Go duration like '30s' (kind=wait)",
+          "type": "string"
+        },
         "from": {
           "description": "CEL expression producing the input array (kind=aggregate)",
           "type": "string"
@@ -217,6 +221,10 @@
         },
         "timeout_seconds": {
           "type": "integer"
+        },
+        "until": {
+          "description": "RFC3339 timestamp or CEL expression producing one (kind=wait)",
+          "type": "string"
         }
       },
       "required": [

--- a/internal/drawer/entity.go
+++ b/internal/drawer/entity.go
@@ -148,6 +148,18 @@ type Step struct {
 	// the result is collected into an output array.
 	From  string `json:"from,omitempty" jsonschema:"description=CEL expression producing the input array (kind=aggregate)"`
 	Pluck string `json:"pluck,omitempty" jsonschema:"description=CEL expression evaluated per item; 'item' is bound to the current entry (kind=aggregate)"`
+
+	// --- Fields below apply only to Kind == "wait" ---
+	//
+	// Duration is a Go-style duration string ("5s", "2m30s", "1h").
+	// Mutually exclusive with Until. If both are set, Duration wins
+	// and a warning surfaces at validate time.
+	Duration string `json:"duration,omitempty" jsonschema:"description=Go duration like '30s' (kind=wait)"`
+
+	// Until is an RFC3339 timestamp OR a CEL expression producing
+	// one. The runtime sleeps until that wall-clock instant, honoring
+	// ctx cancellation so presses cleanly abort on Ctrl-C.
+	Until string `json:"until,omitempty" jsonschema:"description=RFC3339 timestamp or CEL expression producing one (kind=wait)"`
 }
 
 // Case is one branch of a kind=switch step. When is a CEL predicate;

--- a/internal/drawer/executor.go
+++ b/internal/drawer/executor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -147,6 +148,9 @@ func (e *Executor) runStep(ctx context.Context, d *Drawer, step *Step, ctxMap Co
 	}
 	if kind == "aggregate" {
 		return e.runAggregateStep(step, ctxMap)
+	}
+	if kind == "wait" {
+		return e.runWaitStep(ctx, step, ctxMap)
 	}
 	if kind != "button" {
 		sr.Status = "failed"
@@ -683,6 +687,102 @@ func (e *Executor) runAggregateStep(step *Step, ctxMap Context) (StepRun, error)
 	return sr, nil
 }
 
+// runWaitStep handles kind=wait — pauses for Duration or until the
+// Until timestamp. Honors context cancellation so presses abort
+// cleanly on Ctrl-C. No output; the step just consumes wall time.
+//
+// Common uses: cool-off between API calls, delay retries, hold a
+// pipeline until a scheduled deploy window opens. Webhook-triggered
+// resumes ("wait for external signal") are deferred to when we
+// have a REST API — today this is purely a time-based pause.
+func (e *Executor) runWaitStep(ctx context.Context, step *Step, ctxMap Context) (StepRun, error) {
+	sr := StepRun{ID: step.ID}
+
+	if step.Duration == "" && step.Until == "" {
+		sr.Status = "failed"
+		sr.Error = &StepError{
+			Code:        "VALIDATION_ERROR",
+			Message:     "wait step needs either 'duration' or 'until'",
+			Remediation: "set step.duration='30s' or step.until='<RFC3339>' / ${ref}",
+		}
+		return sr, fmt.Errorf("wait without duration or until")
+	}
+
+	start := time.Now()
+	var target time.Time
+	switch {
+	case step.Duration != "":
+		// Resolve ${...} refs first so inputs.delay type flows work.
+		resolved, err := Resolve(step.Duration, ctxMap)
+		if err != nil {
+			sr.Status = "failed"
+			sr.Error = &StepError{Code: "RESOLVE_ERROR", Message: err.Error()}
+			return sr, err
+		}
+		durStr, ok := resolved.(string)
+		if !ok {
+			durStr = fmt.Sprintf("%v", resolved)
+		}
+		d, err := time.ParseDuration(durStr)
+		if err != nil {
+			sr.Status = "failed"
+			sr.Error = &StepError{
+				Code:        "VALIDATION_ERROR",
+				Message:     fmt.Sprintf("invalid duration %q: %v", durStr, err),
+				Remediation: "use Go duration syntax like '30s', '2m', '1h30m'",
+			}
+			return sr, err
+		}
+		target = start.Add(d)
+	default: // step.Until
+		resolved, err := Resolve(step.Until, ctxMap)
+		if err != nil {
+			sr.Status = "failed"
+			sr.Error = &StepError{Code: "RESOLVE_ERROR", Message: err.Error()}
+			return sr, err
+		}
+		untilStr, ok := resolved.(string)
+		if !ok {
+			untilStr = fmt.Sprintf("%v", resolved)
+		}
+		t, err := time.Parse(time.RFC3339, untilStr)
+		if err != nil {
+			sr.Status = "failed"
+			sr.Error = &StepError{
+				Code:        "VALIDATION_ERROR",
+				Message:     fmt.Sprintf("invalid RFC3339 timestamp %q: %v", untilStr, err),
+				Remediation: "use 2026-04-20T15:00:00Z format",
+			}
+			return sr, err
+		}
+		target = t
+	}
+
+	wait := time.Until(target)
+	if wait > 0 {
+		select {
+		case <-ctx.Done():
+			sr.Status = "failed"
+			sr.Error = &StepError{
+				Code:        "CANCELLED",
+				Message:     "wait cancelled before target time",
+				Remediation: "press was interrupted before the wait completed",
+			}
+			sr.DurationMs = time.Since(start).Milliseconds()
+			return sr, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+
+	sr.Status = "ok"
+	sr.DurationMs = time.Since(start).Milliseconds()
+	sr.Output = map[string]any{
+		"waited_ms": sr.DurationMs,
+		"until":     target.UTC().Format(time.RFC3339),
+	}
+	return sr, nil
+}
+
 // computeReturn evaluates a drawer's Return block against its
 // completed run's step outputs, producing the map that flows into
 // the parent drawer's context as this step's .output. Returns an
@@ -727,11 +827,69 @@ func (e *Executor) finalize(res *ExecuteResult, d *Drawer) {
 		ErrorType:  errorCode(res.Error),
 	})
 
-	// Failures are already captured in the drawer's own pressed/
-	// history (RecordRun above). Agents triage via `buttons summary`
-	// (cross-target recent_failures) or `buttons drawer NAME` for
-	// the per-drawer view that surfaces recent_runs including the
-	// last failure and its remediation.
+	// Drawer-level on_error handler. When the drawer fails AND has
+	// an on_error pointer, invoke the handler drawer with a standard
+	// error payload so an agent's cleanup / alert drawer runs
+	// automatically. Handler failures are swallowed — we log but
+	// don't promote them to primary failures (the original error is
+	// still what matters).
+	if res.Status != "ok" && d.OnError != nil && d.OnError.Drawer != "" {
+		e.invokeErrorHandler(d, res, redacted)
+	}
+}
+
+// invokeErrorHandler runs the on_error handler drawer with a
+// standardized payload:
+//
+//	drawer       — the failing drawer's name
+//	run_id       — the failing run's id (cross-links history)
+//	failed_step  — id of the step that tripped the failure
+//	error        — { code, message, remediation }
+//	inputs       — the failing drawer's (redacted) inputs
+//
+// Handler-supplied With{} keys override these defaults, so agents
+// can inject literal config like severity/team/channel.
+func (e *Executor) invokeErrorHandler(parent *Drawer, res *ExecuteResult, redactedInputs map[string]any) {
+	handlerName := parent.OnError.Drawer
+	handler, err := e.DrawerSvc.Get(handlerName)
+	if err != nil {
+		// Missing handler is a misconfiguration, not a runtime
+		// failure. Surface to stderr and move on — the primary
+		// failure is already recorded.
+		fmt.Fprintf(os.Stderr, "drawer %s: on_error handler %q not found (%v)\n", parent.Name, handlerName, err)
+		return
+	}
+
+	errPayload := map[string]any{
+		"code": errorCode(res.Error),
+	}
+	if res.Error != nil {
+		errPayload["message"] = res.Error.Message
+		errPayload["remediation"] = res.Error.Remediation
+	}
+	inputs := map[string]any{
+		"drawer":      parent.Name,
+		"run_id":      res.RunID,
+		"failed_step": res.FailedStep,
+		"error":       errPayload,
+		"inputs":      redactedInputs,
+	}
+	// User-supplied With{} wins over defaults so agents can inject
+	// team / severity / channel literals without us having to model
+	// every possible enrichment field.
+	for k, v := range parent.OnError.With {
+		inputs[k] = v
+	}
+
+	// Fresh context for the handler — don't inherit the parent's
+	// cancellation state since the parent is done.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+
+	handlerRes, herr := e.Execute(ctx, handler, inputs)
+	if herr != nil || (handlerRes != nil && handlerRes.Status != "ok") {
+		fmt.Fprintf(os.Stderr, "drawer %s: on_error handler %q failed (non-fatal)\n", parent.Name, handlerName)
+	}
 }
 
 // computeBackoff turns a retry policy + attempt number into a wait

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -166,6 +166,10 @@
           "description": "Drawer name to invoke (kind=drawer only)",
           "type": "string"
         },
+        "duration": {
+          "description": "Go duration like '30s' (kind=wait)",
+          "type": "string"
+        },
         "from": {
           "description": "CEL expression producing the input array (kind=aggregate)",
           "type": "string"
@@ -217,6 +221,10 @@
         },
         "timeout_seconds": {
           "type": "integer"
+        },
+        "until": {
+          "description": "RFC3339 timestamp or CEL expression producing one (kind=wait)",
+          "type": "string"
         }
       },
       "required": [

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -168,6 +168,29 @@ func (s *Service) AddSteps(drawerName string, targets []string) (*Drawer, error)
 	}
 
 	for _, t := range targets {
+		// `wait:DURATION` → kind=wait step with the given duration.
+		// Most common shape; for `until`-form, use `add wait` then
+		// `set wait.until=<RFC3339>`.
+		if strings.HasPrefix(t, "wait:") {
+			dur := strings.TrimPrefix(t, "wait:")
+			if dur == "" {
+				return nil, &ServiceError{
+					Code:    "VALIDATION_ERROR",
+					Message: "wait:DURATION requires a duration (e.g. wait:30s)",
+				}
+			}
+			id := "wait"
+			for n := 2; taken[id]; n++ {
+				id = fmt.Sprintf("wait-%d", n)
+			}
+			taken[id] = true
+			d.Steps = append(d.Steps, Step{
+				ID:       id,
+				Kind:     "wait",
+				Duration: dur,
+			})
+			continue
+		}
 		// `for_each:BUTTON` → kind=for_each step wrapping one nested
 		// button step. Minimal shorthand so agents can author simple
 		// per-item loops without patching drawer.json directly.
@@ -324,10 +347,14 @@ func (s *Service) SetField(drawerName, stepID, field, value string) (*Drawer, er
 		d.Steps[idx].Button = value
 	case "drawer":
 		d.Steps[idx].Drawer = value
+	case "duration":
+		d.Steps[idx].Duration = value
+	case "until":
+		d.Steps[idx].Until = value
 	default:
 		return nil, &ServiceError{
 			Code:    "STEP_FIELD_UNKNOWN",
-			Message: fmt.Sprintf("unknown step field %q — allowed: over, as, on_item_failure, from, pluck, button, drawer", field),
+			Message: fmt.Sprintf("unknown step field %q — allowed: over, as, on_item_failure, from, pluck, button, drawer, duration, until", field),
 		}
 	}
 	d.UpdatedAt = time.Now().UTC()

--- a/internal/drawer/validate.go
+++ b/internal/drawer/validate.go
@@ -178,6 +178,23 @@ func Validate(d *Drawer, btnSvc *button.Service) ValidationReport {
 			}
 			continue
 		}
+		if kind == "wait" {
+			if st.Duration == "" && st.Until == "" {
+				report.Errors = append(report.Errors, ValidationIssue{
+					Severity: "error", StepID: st.ID,
+					Message:     "wait step needs either 'duration' or 'until'",
+					Remediation: "set step.duration='30s' or step.until='<RFC3339>'",
+				})
+			}
+			if st.Duration != "" && st.Until != "" {
+				report.Warnings = append(report.Warnings, ValidationIssue{
+					Severity: "warning", StepID: st.ID,
+					Message:     "wait step sets both 'duration' and 'until' — duration wins",
+					Remediation: "keep only one",
+				})
+			}
+			continue
+		}
 		if kind != "button" {
 			// Future kinds are reserved but not runnable; the executor
 			// errors with KIND_NOT_IMPLEMENTED. Warn so the validator

--- a/test/integration/onerror_wait_test.go
+++ b/test/integration/onerror_wait_test.go
@@ -1,0 +1,178 @@
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOnError_HandlerDrawerRuns verifies that when a drawer fails,
+// the on_error handler drawer is invoked automatically with a
+// standard error payload. Uses a sentinel file as the side effect
+// so we can detect the handler ran without mocking the runtime.
+func TestOnError_HandlerDrawerRuns(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Flaky button — always fails.
+	env.run("create", "always-fail",
+		"--runtime", "shell",
+		"--code", "echo 'kaboom' >&2; exit 7",
+		"--json",
+	)
+	// Recorder button — appends "handler-ran" + the error code
+	// it received to a sentinel file. Uses drawer inputs (which
+	// map to button args by name-match) so the error's code field
+	// flows through.
+	sentinel := filepath.Join(env.home, "handler.log")
+	env.run("create", "record-error",
+		"--runtime", "shell",
+		"--code", `echo "handler-ran $BUTTONS_ARG_CODE" >> "`+sentinel+`"; echo '{"ok":true}'`,
+		"--arg", "code:string:required",
+		"--json",
+	)
+	env.run("drawer", "create", "notify-failures", "--json")
+	env.run("drawer", "notify-failures", "add", "record-error", "--json")
+
+	// Primary drawer: calls always-fail. Patch drawer.json to add
+	// on_error pointing at notify-failures (CLI doesn't have a
+	// dedicated verb for this yet).
+	env.run("drawer", "create", "main-flow", "--json")
+	env.run("drawer", "main-flow", "add", "always-fail", "--json")
+	drawerPath := filepath.Join(env.home, "drawers", "main-flow", "drawer.json")
+	data, _ := os.ReadFile(drawerPath) // #nosec G304 — test scope
+	var d map[string]any
+	_ = json.Unmarshal(data, &d)
+	d["on_error"] = map[string]any{
+		"drawer": "notify-failures",
+	}
+	// notify-failures's record-error button takes a `code` arg,
+	// filled from the handler's `error.code` field via the
+	// standard payload passed by the on_error invocation. The
+	// drawer's own inputs route through to the button by
+	// name-match, so we need the notify-failures drawer to accept
+	// a `code` input mapped into record-error.args.code.
+	out, _ := json.MarshalIndent(d, "", "  ")
+	_ = os.WriteFile(drawerPath, out, 0o600)
+
+	// Patch notify-failures so its record-error step pulls `code`
+	// out of the standard error payload (inputs.error.code). No
+	// top-level inputs declaration — the handler receives the
+	// whole error envelope and references into it directly.
+	handlerPath := filepath.Join(env.home, "drawers", "notify-failures", "drawer.json")
+	data, _ = os.ReadFile(handlerPath) // #nosec G304 — test scope
+	var handler map[string]any
+	_ = json.Unmarshal(data, &handler)
+	steps := handler["steps"].([]any)
+	for _, s := range steps {
+		step := s.(map[string]any)
+		if step["id"] == "record-error" {
+			step["args"] = map[string]any{
+				"code": "${inputs.error.code}",
+			}
+		}
+	}
+	handler["steps"] = steps
+	hout, _ := json.MarshalIndent(handler, "", "  ")
+	_ = os.WriteFile(handlerPath, hout, 0o600)
+
+	// Press the main drawer. Expect failure, and expect the
+	// handler to have written to the sentinel.
+	r := env.run("drawer", "main-flow", "press", "--json")
+	if r.ExitCode == 0 {
+		t.Fatalf("expected main-flow failure, got success: %s", r.Stdout)
+	}
+
+	// Give the handler a moment in case of timing — should be
+	// synchronous so this is belt-and-suspenders.
+	raw, err := os.ReadFile(sentinel) // #nosec G304 — test scope
+	if err != nil {
+		t.Fatalf("sentinel not written: %v", err)
+	}
+	if !strings.Contains(string(raw), "handler-ran") {
+		t.Errorf("handler didn't run: sentinel = %q", string(raw))
+	}
+	// error.code from a shell-button failure is SCRIPT_ERROR.
+	if !strings.Contains(string(raw), "SCRIPT_ERROR") {
+		t.Errorf("handler didn't receive error.code: sentinel = %q", string(raw))
+	}
+}
+
+// TestWait_Duration verifies kind=wait pauses for the requested
+// duration and reports the actual wait in output.waited_ms.
+func TestWait_Duration(t *testing.T) {
+	env := newTestEnv(t)
+	env.run("drawer", "create", "pause-demo", "--json")
+
+	// Use the shorthand to add a wait:200ms step.
+	r := env.run("drawer", "pause-demo", "add", "wait:200ms", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("add wait: exit %d, stderr=%s", r.ExitCode, r.Stderr)
+	}
+
+	r = env.run("drawer", "pause-demo", "press", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("press: exit %d, stderr=%s, stdout=%s", r.ExitCode, r.Stderr, r.Stdout)
+	}
+
+	var resp struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Status string `json:"status"`
+			Steps  []struct {
+				ID         string         `json:"id"`
+				Status     string         `json:"status"`
+				DurationMs int64          `json:"duration_ms"`
+				Output     map[string]any `json:"output"`
+			} `json:"steps"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &resp); err != nil {
+		t.Fatalf("parse: %v\nraw=%s", err, r.Stdout)
+	}
+	if !resp.OK || resp.Data.Status != "ok" {
+		t.Fatalf("wait drawer not ok: %s", r.Stdout)
+	}
+	if len(resp.Data.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(resp.Data.Steps))
+	}
+	step := resp.Data.Steps[0]
+	if step.Status != "ok" {
+		t.Errorf("wait status = %q, want ok", step.Status)
+	}
+	if step.DurationMs < 150 {
+		// Allow some slack below 200ms in case the system clock is
+		// slightly off. If it's < 150ms the wait didn't actually fire.
+		t.Errorf("wait duration_ms = %d, expected ≥150", step.DurationMs)
+	}
+}
+
+// TestWait_MissingDurationAndUntilFails verifies the validator /
+// executor catches a wait step that has neither duration nor until.
+func TestWait_MissingDurationAndUntilFails(t *testing.T) {
+	env := newTestEnv(t)
+	env.run("drawer", "create", "bad-wait", "--json")
+
+	drawerPath := filepath.Join(env.home, "drawers", "bad-wait", "drawer.json")
+	data, _ := os.ReadFile(drawerPath) // #nosec G304 — test scope
+	var d map[string]any
+	_ = json.Unmarshal(data, &d)
+	d["steps"] = []any{
+		map[string]any{
+			"id":   "broken",
+			"kind": "wait",
+			// neither duration nor until set
+		},
+	}
+	out, _ := json.MarshalIndent(d, "", "  ")
+	_ = os.WriteFile(drawerPath, out, 0o600)
+
+	r := env.run("drawer", "bad-wait", "press", "--json")
+	if r.ExitCode == 0 {
+		t.Fatal("expected failure on wait without duration/until")
+	}
+	if !strings.Contains(r.Stdout, "duration") && !strings.Contains(r.Stdout, "until") {
+		t.Errorf("expected missing-duration error, got: %s", r.Stdout)
+	}
+}


### PR DESCRIPTION
Two small, operationally high-value additions rounding out Stage 3's control-flow surface.

## Drawer-level \`on_error\` handler

When any step fails unhandled, the executor auto-invokes a designated \"cleanup/alert\" drawer with a standard error payload (\`drawer\`, \`run_id\`, \`failed_step\`, \`error\`, \`inputs\`). Handler-supplied \`with\` keys override defaults so agents can layer literal config (severity, team, channel).

\`\`\`json
{
  "on_error": {
    "drawer": "notify-failures",
    "with": { "severity": "high" }
  }
}
\`\`\`

Handler runs in a fresh context (parent is done) with a 300s timeout; handler failures are logged but don't promote — the original error is still the primary signal. Every serious automation needs \"if anything breaks, run this\" and the drawer-pointer shape keeps the mental model uniform (no special trigger nodes).

## \`kind: wait\` — time-based pause

\`\`\`bash
buttons drawer X add wait:30s                    # shorthand
\`\`\`

Or manually in drawer.json:

\`\`\`json
{ "id": "cool-off", "kind": "wait", "duration": "30s" }
{ "id": "tomorrow", "kind": "wait", "until": "\${inputs.scheduled_at}" }
\`\`\`

\`duration\` accepts any Go duration. \`until\` accepts RFC3339 timestamps or CEL refs producing them. Honors ctx cancellation so Ctrl-C aborts cleanly.

## \`set\` extended

Two new fields addressable by \`buttons drawer X set\`:
- \`STEP.duration=DUR\` — kind=wait duration
- \`STEP.until=<RFC3339>\` — kind=wait absolute target

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all green
- [x] 3 new integration tests pass
- [x] Schema regenerated, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)