### PR TITLE
feat(webhook): drawers triggered by Cloudflare-tunneled webhooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,19 @@ Drawers are workflow chains of buttons. Spec stored at `~/.buttons/drawers/<name
 References between steps use `${step_id.output.field}` (dotted-path) or `$ENV{VAR_NAME}` for secrets. Stage 2 swaps the dotted-path resolver for CEL while keeping the `${...}` wire format stable.
 
 ### `buttons summary` and `--summary`
-Workspace introspection: `buttons summary [--json]` dumps buttons, drawers, recent runs, and failures in one response so agents orient themselves in a single tool call. Bare `buttons` invokes the same.
+Workspace introspection: `buttons summary [--json]` dumps buttons, drawers, recent runs, failures, and webhook listener state in one response so agents orient themselves in a single tool call. Bare `buttons` invokes the same.
 
 `--summary` is a universal flag: applied to any mutating command (`press`, `drawer press`, `drawer add`, `drawer connect`, etc.) it returns a read-only plan instead of executing. Never mutates, never touches the network, never side-effects.
+
+### Webhook-triggered drawers
+Drawers can be invoked automatically by incoming HTTP POSTs. Architecture: `cloudflared` tunnel → local listener → dispatch by path → press drawer with request body/headers/query as `${inputs.webhook.*}`.
+
+- **Setup:** `buttons webhook setup` — one-time Cloudflare login + pick hostname. Quick-tunnel mode (no config) works for ephemeral URLs; named mode for stable hostnames.
+- **Register:** `buttons drawer <name> trigger webhook [PATH] [--secret TOKEN]` — default path `/<drawer-name>`. Secret, when set, is verified via `X-Buttons-Token` header or `?token=`.
+- **Listen:** `buttons webhook listen` — foreground dispatcher. Responds `202 Accepted` immediately; drawer presses asynchronously.
+- **Input shape:** `${inputs.webhook.body}` (+ `body.<field>`, `headers.<Name>`, `query.<param>`, `method`, `path`, `received_at`).
+- **Cross-drawer refs:** `${webhooks.<drawer-name>}` → that drawer's full public URL. Use when one drawer configures an upstream with another drawer's webhook URL.
+- **Dry-run:** `buttons drawer <name> press --webhook-body '{...}'` or `--webhook-body @file.json` — simulates a POST locally without running the listener.
 
 ### Stage 2 plumbing (CEL, idempotency, queues, progress, DLQ)
 - **Expressions:** `${...}` wraps CEL (`google/cel-go`). Ternaries, string concat, arithmetic, `has()` for null-coalescing. Dotted-path refs still work — the shape agents learned in stage 1 is unchanged; CEL extends it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Workspace introspection: `buttons summary [--json]` dumps buttons, drawers, rece
 Drawers can be invoked automatically by incoming HTTP POSTs. Architecture: `cloudflared` tunnel → local listener → dispatch by path → press drawer with request body/headers/query as `${inputs.webhook.*}`.
 
 - **Setup:** `buttons webhook setup` — one-time Cloudflare login + pick hostname. Quick-tunnel mode (no config) works for ephemeral URLs; named mode for stable hostnames.
-- **Register:** `buttons drawer <name> trigger webhook [PATH] [--secret TOKEN]` — default path `/<drawer-name>`. Secret, when set, is verified via `X-Buttons-Token` header or `?token=`.
+- **Register:** `buttons drawer <name> trigger webhook [PATH] [--auth TYPE ...]` — default path `/<drawer-name>`. Auth types mirror n8n's four: `none` | `basic` (`--auth-user --auth-pass`) | `header` (`--auth-header-name --auth-header-value`) | `jwt` (`--jwt-secret [--jwt-algorithm HS256|HS384|HS512] [--jwt-issuer] [--jwt-audience]`). Any secret field accepts `$ENV{VAR}` resolved at match time. All comparisons are constant-time (`crypto/subtle`).
 - **Listen:** `buttons webhook listen` — foreground dispatcher. Responds `202 Accepted` immediately; drawer presses asynchronously.
 - **Input shape:** `${inputs.webhook.body}` (+ `body.<field>`, `headers.<Name>`, `query.<param>`, `method`, `path`, `received_at`).
 - **Cross-drawer refs:** `${webhooks.<drawer-name>}` → that drawer's full public URL. Use when one drawer configures an upstream with another drawer's webhook URL.

--- a/cmd/drawer.go
+++ b/cmd/drawer.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/webhook"
 )
 
 // drawer uses NAME-before-verb syntax for per-drawer operations:
@@ -116,6 +118,8 @@ Typical authoring flow:
 			return drawerConnect(name, vargs)
 		case "set":
 			return drawerSet(name, vargs)
+		case "trigger":
+			return drawerTrigger(name, vargs)
 		case "press":
 			return drawerPress(name, vargs)
 		case "remove", "rm":
@@ -184,7 +188,23 @@ func drawerList() error {
 		if desc == "" {
 			desc = "-"
 		}
-		fmt.Printf("%s\t%s\t%s\n", d.Name, desc, strings.Join(stepNames, " → "))
+		// Webhook-triggered drawers get a trailing tag so agents
+		// scanning the list see which ones are reachable via the
+		// listener. Quick-mode users see "webhook" with no URL; named
+		// mode shows the full URL.
+		wh := ""
+		for _, t := range d.Triggers {
+			if t.Kind == "webhook" && t.Path != "" {
+				cfg, _ := webhook.LoadConfig()
+				if cfg != nil && cfg.Mode == webhook.ModeNamed {
+					wh = "\twebhook=https://" + cfg.Hostname + t.Path
+				} else {
+					wh = "\twebhook=" + t.Path
+				}
+				break
+			}
+		}
+		fmt.Printf("%s\t%s\t%s%s\n", d.Name, desc, strings.Join(stepNames, " → "), wh)
 	}
 	return nil
 }
@@ -380,9 +400,34 @@ func drawerPress(name string, args []string) error {
 		return handleDrawerError(err)
 	}
 
+	// Split --webhook-body <value> out of args before parseKV sees it.
+	// Accepts three forms so agents can pick what's ergonomic:
+	//   --webhook-body '{"foo":1}'            inline JSON literal
+	//   --webhook-body @fixture.json          path to a JSON fixture
+	//   --webhook-body=<form-above>           = form
+	args, webhookBody, err := extractWebhookBody(args)
+	if err != nil {
+		return err
+	}
+
 	inputValues, err := parseKV(args)
 	if err != nil {
 		return err
+	}
+
+	// If --webhook-body was supplied, synthesize the same inputs.webhook
+	// shape that `buttons webhook listen` produces. Lets agents test a
+	// webhook-triggered drawer without starting the listener — iterate
+	// locally, curl for integration.
+	if webhookBody != nil {
+		inputValues["webhook"] = map[string]any{
+			"body":        webhookBody,
+			"headers":     map[string]string{},
+			"query":       map[string]string{},
+			"method":      "POST",
+			"path":        webhookTriggerPath(d),
+			"received_at": time.Now().UTC().Format(time.RFC3339),
+		}
 	}
 
 	exec := drawer.NewExecutor()
@@ -533,6 +578,192 @@ func drawerRemove(name string) error {
 	return nil
 }
 
+// drawerTrigger handles `buttons drawer NAME trigger webhook [--path /X] [--secret TOKEN]`.
+// Only kind=webhook is live today; other trigger kinds declared in the
+// schema return NOT_IMPLEMENTED.
+//
+// Positional parsing: `trigger webhook /apify` or `trigger webhook
+// --path /apify --secret TOK`. The positional path form is the
+// friendly agent-facing shortcut.
+func drawerTrigger(name string, vargs []string) error {
+	if len(vargs) < 1 {
+		return fmt.Errorf("usage: buttons drawer %s trigger webhook [PATH] [--secret TOKEN]\n  examples:\n    buttons drawer %s trigger webhook /apify-done\n    buttons drawer %s trigger webhook /gh --secret $GH_WEBHOOK_SECRET", name, name, name)
+	}
+	kind := vargs[0]
+	vargs = vargs[1:]
+
+	if kind != "webhook" {
+		return fmt.Errorf("trigger kind %q not implemented; only 'webhook' is available today", kind)
+	}
+
+	// Parse: first non-flag positional is the path; --path / --secret
+	// override. Simple loop beats pulling in pflag for three fields.
+	var path, secret string
+	for i := 0; i < len(vargs); i++ {
+		a := vargs[i]
+		switch {
+		case a == "--path":
+			if i+1 >= len(vargs) {
+				return fmt.Errorf("--path needs a value")
+			}
+			path = vargs[i+1]
+			i++
+		case strings.HasPrefix(a, "--path="):
+			path = strings.TrimPrefix(a, "--path=")
+		case a == "--secret":
+			if i+1 >= len(vargs) {
+				return fmt.Errorf("--secret needs a value")
+			}
+			secret = vargs[i+1]
+			i++
+		case strings.HasPrefix(a, "--secret="):
+			secret = strings.TrimPrefix(a, "--secret=")
+		case strings.HasPrefix(a, "-"):
+			return fmt.Errorf("unknown flag %q", a)
+		default:
+			if path == "" {
+				path = a
+			} else {
+				return fmt.Errorf("unexpected extra positional %q", a)
+			}
+		}
+	}
+	if path == "" {
+		// Default path: /<drawer-name>. Agents who don't care about URL
+		// design get a sensible default; the verb still accepts an
+		// explicit override.
+		path = "/" + name
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	svc := drawer.NewService()
+	d, err := svc.SetWebhookTrigger(name, path, secret)
+	if err != nil {
+		return handleDrawerError(err)
+	}
+
+	// Compose the public URL if webhook setup has been run so agents
+	// see the exact string they'd paste into the upstream service.
+	cfg, _ := webhook.LoadConfig()
+	var publicURL string
+	if cfg != nil && cfg.Mode == webhook.ModeNamed {
+		publicURL = "https://" + cfg.Hostname + path
+	}
+
+	inputShape := webhookInputShape()
+
+	if jsonOutput {
+		return config.WriteJSON(map[string]any{
+			"drawer":      d.Name,
+			"kind":        "webhook",
+			"path":        path,
+			"has_secret":  secret != "",
+			"public_url":  publicURL,
+			"input_shape": inputShape,
+		})
+	}
+	fmt.Fprintf(os.Stderr, "Registered webhook trigger on %s\n", d.Name)
+	fmt.Fprintf(os.Stderr, "  path:   %s\n", path)
+	if secret != "" {
+		fmt.Fprintf(os.Stderr, "  secret: configured (sent via X-Buttons-Token)\n")
+	}
+	if publicURL != "" {
+		fmt.Fprintf(os.Stderr, "  url:    %s\n", publicURL)
+	} else {
+		fmt.Fprintf(os.Stderr, "  (run `buttons webhook setup` to establish a stable public URL)\n")
+	}
+	fmt.Fprintf(os.Stderr, "\nAvailable inputs inside this drawer's steps:\n")
+	for _, line := range inputShape {
+		fmt.Fprintf(os.Stderr, "  %s\n", line)
+	}
+	fmt.Fprintf(os.Stderr, "\nCross-drawer reference (from another drawer's step args):\n")
+	fmt.Fprintf(os.Stderr, "  ${webhooks.%s}   — resolves to the full public URL above\n", d.Name)
+	printNextHint("buttons webhook listen   # start the dispatcher")
+	return nil
+}
+
+// extractWebhookBody scans args for the --webhook-body flag, pulls it
+// out, and parses the value into a JSON-ish shape. Returns the residual
+// args (for parseKV) and the parsed body (nil when flag absent). Three
+// forms accepted: --webhook-body '<json>', --webhook-body @file, and
+// --webhook-body=<either>.
+func extractWebhookBody(args []string) ([]string, any, error) {
+	rest := make([]string, 0, len(args))
+	var rawVal string
+	var seen bool
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--webhook-body":
+			if i+1 >= len(args) {
+				return nil, nil, fmt.Errorf("--webhook-body needs a value (inline JSON or @path)")
+			}
+			rawVal = args[i+1]
+			seen = true
+			i++
+		case strings.HasPrefix(a, "--webhook-body="):
+			rawVal = strings.TrimPrefix(a, "--webhook-body=")
+			seen = true
+		default:
+			rest = append(rest, a)
+		}
+	}
+	if !seen {
+		return rest, nil, nil
+	}
+	// @path form — read the file and parse.
+	if strings.HasPrefix(rawVal, "@") {
+		path := strings.TrimPrefix(rawVal, "@")
+		data, err := os.ReadFile(path) // #nosec G304 -- user-supplied path for dry-run fixture
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		rawVal = string(data)
+	}
+	var parsed any
+	if strings.TrimSpace(rawVal) == "" {
+		parsed = nil
+	} else if err := json.Unmarshal([]byte(rawVal), &parsed); err != nil {
+		// Not JSON — pass through as a string so the drawer can
+		// still observe the value.
+		parsed = rawVal
+	}
+	return rest, parsed, nil
+}
+
+// webhookTriggerPath returns the drawer's registered webhook path so
+// the dry-run ${inputs.webhook.path} matches what a real POST would
+// produce. Falls back to "/" + drawer name when no trigger is set (the
+// same default as `drawer NAME trigger webhook`).
+func webhookTriggerPath(d *drawer.Drawer) string {
+	for _, t := range d.Triggers {
+		if t.Kind == "webhook" && t.Path != "" {
+			return t.Path
+		}
+	}
+	return "/" + d.Name
+}
+
+// webhookInputShape lists the ${inputs.webhook.*} shape an incoming
+// webhook materializes inside a triggered drawer. Kept as data (not a
+// prose blob) so `--json` callers get a structured enumeration.
+//
+// Keep this in sync with serveHandler.ServeHTTP in cmd/serve.go — the
+// fields it writes into the webhookInput map must show up here.
+func webhookInputShape() []string {
+	return []string{
+		"${inputs.webhook.body}              — parsed JSON body (object | array | string | null)",
+		"${inputs.webhook.body.<field>}      — drill into the parsed body",
+		"${inputs.webhook.headers.<Header>}  — single-value request headers (e.g. X-Signature)",
+		"${inputs.webhook.query.<param>}     — query string params",
+		"${inputs.webhook.method}            — POST",
+		"${inputs.webhook.path}              — the trigger path (e.g. /apify)",
+		"${inputs.webhook.received_at}       — RFC3339 UTC timestamp",
+	}
+}
+
 func drawerSchema() error {
 	// Dump the embedded drawer JSON Schema. Use stdout so `buttons
 	// drawer schema | jq .` works cleanly.
@@ -603,6 +834,11 @@ func drawerShowSummary(name string) error {
 		topology = append(topology, s.ID)
 	}
 
+	// Webhook trigger surfacing: if this drawer has one, compute the
+	// full public URL so agents see exactly what to paste into the
+	// upstream service.
+	triggersOut := summarizeDrawerTriggers(d)
+
 	snapshot := map[string]any{
 		"name":        d.Name,
 		"description": d.Description,
@@ -611,6 +847,7 @@ func drawerShowSummary(name string) error {
 		"topology":    strings.Join(topology, " → "),
 		"validation":  report,
 		"recent_runs": summarizeDrawerRuns(runs),
+		"triggers":    triggersOut,
 	}
 
 	if jsonOutput {
@@ -621,6 +858,17 @@ func drawerShowSummary(name string) error {
 		fmt.Printf("  %s\n", d.Description)
 	}
 	fmt.Printf("  %s\n", strings.Join(topology, " → "))
+	for _, tg := range triggersOut {
+		if tg["kind"] == "webhook" {
+			url, _ := tg["url"].(string)
+			path, _ := tg["path"].(string)
+			if url != "" {
+				fmt.Printf("  webhook:    %s\n", url)
+			} else {
+				fmt.Printf("  webhook:    %s  (no public URL — run `buttons webhook setup`)\n", path)
+			}
+		}
+	}
 	if !report.OK {
 		fmt.Printf("  validation: %d error(s), %d warning(s)\n", len(report.Errors), len(report.Warnings))
 		for _, e := range report.Errors {
@@ -827,6 +1075,31 @@ func jsonToArgTypeCompatible(jsonType, argType string) bool {
 func mustJSON(v any) string {
 	b, _ := json.MarshalIndent(v, "", "  ")
 	return string(b)
+}
+
+// summarizeDrawerTriggers projects a drawer's declared triggers into
+// summary JSON, computing the public URL for each webhook trigger when
+// the named tunnel is configured. Quick-mode users see the path only;
+// the URL surfaces after `buttons webhook setup`.
+func summarizeDrawerTriggers(d *drawer.Drawer) []map[string]any {
+	cfg, _ := webhook.LoadConfig()
+	var host string
+	if cfg != nil && cfg.Mode == webhook.ModeNamed {
+		host = cfg.Hostname
+	}
+	out := make([]map[string]any, 0, len(d.Triggers))
+	for _, t := range d.Triggers {
+		entry := map[string]any{
+			"kind":       t.Kind,
+			"path":       t.Path,
+			"has_secret": t.Secret != "",
+		}
+		if t.Kind == "webhook" && host != "" {
+			entry["url"] = "https://" + host + t.Path
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func summarizeDrawerRuns(runs []drawer.Run) []map[string]any {

--- a/cmd/drawer.go
+++ b/cmd/drawer.go
@@ -717,13 +717,16 @@ func drawerTrigger(name string, vargs []string) error {
 	return nil
 }
 
-// extractJSONFlag scans args for --json / --json=true / --no-json and
-// sets the package-level jsonOutput bool accordingly. Returns the
-// residual args so the per-verb hand-parsers don't have to know about
-// the flag. Also strips --help so `buttons drawer NAME --help`
-// doesn't confuse our dispatch — Cobra's automatic help path is
-// intentional for `buttons drawer --help` (no subcommand) and handled
-// upstream by the RunE when args is empty.
+// extractJSONFlag scans args for the rootCmd persistent flags
+// (--json, --no-input, --summary) and sets the corresponding
+// package-level globals — drawerCmd.DisableFlagParsing prevents
+// Cobra from doing this for us. Returns the residual args for the
+// per-verb hand-parsers.
+//
+// Each flag supports three forms: bare (`--json`), `=form`
+// (`--json=true`), and the negation (`--no-json`). Verbs inside
+// drawerCmd don't use `--help` since the RunE emits its own usage
+// block; `--help` passes through and per-verb handlers error cleanly.
 func extractJSONFlag(args []string) []string {
 	out := make([]string, 0, len(args))
 	for _, a := range args {
@@ -732,6 +735,14 @@ func extractJSONFlag(args []string) []string {
 			jsonOutput = true
 		case "--json=false", "--no-json":
 			jsonOutput = false
+		case "--summary", "--summary=true":
+			summaryFlag = true
+		case "--summary=false":
+			summaryFlag = false
+		case "--no-input", "--no-input=true":
+			noInput = true
+		case "--no-input=false":
+			noInput = false
 		default:
 			out = append(out, a)
 		}

--- a/cmd/drawer.go
+++ b/cmd/drawer.go
@@ -73,7 +73,17 @@ Typical authoring flow:
 	Args:          cobra.ArbitraryArgs,
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	// Per-verb flags (e.g. `trigger webhook --auth basic --auth-user ...`)
+	// are hand-parsed by drawerTrigger / drawerSet / drawerPress so the
+	// surface varies per verb without registering every permutation on
+	// drawerCmd. DisableFlagParsing gives us the raw args intact; we
+	// still honor --json by scanning for it below (rootCmd's Persistent
+	// PreRunE also auto-sets jsonOutput when stdout is non-TTY).
+	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Manual --json handling because DisableFlagParsing took the
+		// usual cobra path out of the loop.
+		args = extractJSONFlag(args)
 		if len(args) == 0 {
 			return cmd.Help()
 		}
@@ -135,14 +145,9 @@ Typical authoring flow:
 }
 
 func init() {
-	// Register the logs flags on drawerCmd as well so
-	// `buttons drawer NAME logs --failed --limit 50` parses. The
-	// flag variables are package-level (declared in cmd/logs.go)
-	// so the drawerLogs handler sees the right values regardless
-	// of which command registered them.
-	drawerCmd.Flags().BoolVar(&logsFailed, "failed", false, "only return runs that failed (for `NAME logs`)")
-	drawerCmd.Flags().IntVar(&logsLimit, "limit", 20, "max runs to return (for `NAME logs`)")
-	drawerCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "stream live progress (for `NAME logs`)")
+	// drawerCmd has DisableFlagParsing = true so per-verb flags are
+	// hand-parsed inside drawerLogs / drawerTrigger / drawerPress /
+	// drawerSet. Nothing to register here.
 	rootCmd.AddCommand(drawerCmd)
 }
 
@@ -578,16 +583,26 @@ func drawerRemove(name string) error {
 	return nil
 }
 
-// drawerTrigger handles `buttons drawer NAME trigger webhook [--path /X] [--secret TOKEN]`.
+// drawerTrigger handles `buttons drawer NAME trigger webhook [PATH] [auth-flags]`.
 // Only kind=webhook is live today; other trigger kinds declared in the
 // schema return NOT_IMPLEMENTED.
 //
-// Positional parsing: `trigger webhook /apify` or `trigger webhook
-// --path /apify --secret TOK`. The positional path form is the
-// friendly agent-facing shortcut.
+// Auth flags mirror n8n's four webhook auth types:
+//
+//	--auth none                                            (default)
+//	--auth basic --auth-user <user> --auth-pass <pass>
+//	--auth header --auth-header-name X-Foo --auth-header-value <val>
+//	--auth jwt    --jwt-secret <secret>
+//	                [--jwt-algorithm HS256|HS384|HS512]
+//	                [--jwt-issuer <iss>] [--jwt-audience <aud>]
+//
+// Any *-value / *-secret / *-pass field accepts literal strings OR
+// the form '$ENV{VAR_NAME}' which the listener resolves against its
+// environment at match time — keeps committed drawer.json from
+// carrying raw secrets.
 func drawerTrigger(name string, vargs []string) error {
 	if len(vargs) < 1 {
-		return fmt.Errorf("usage: buttons drawer %s trigger webhook [PATH] [--secret TOKEN]\n  examples:\n    buttons drawer %s trigger webhook /apify-done\n    buttons drawer %s trigger webhook /gh --secret $GH_WEBHOOK_SECRET", name, name, name)
+		return fmt.Errorf("usage: buttons drawer %s trigger webhook [PATH] [--auth <type> ...]\n  examples:\n    buttons drawer %s trigger webhook /apify\n    buttons drawer %s trigger webhook /gh --auth header --auth-header-name X-Hub-Signature --auth-header-value '$ENV{GH_SECRET}'\n    buttons drawer %s trigger webhook /stripe --auth jwt --jwt-secret '$ENV{STRIPE_JWT_KEY}' --jwt-issuer stripe.com", name, name, name, name)
 	}
 	kind := vargs[0]
 	vargs = vargs[1:]
@@ -596,31 +611,44 @@ func drawerTrigger(name string, vargs []string) error {
 		return fmt.Errorf("trigger kind %q not implemented; only 'webhook' is available today", kind)
 	}
 
-	// Parse: first non-flag positional is the path; --path / --secret
-	// override. Simple loop beats pulling in pflag for three fields.
-	var path, secret string
+	// Scalar-flag loop keeps drawerTrigger pflag-free. Accepts both
+	// `--flag value` and `--flag=value` forms for every flag so agents
+	// can use whichever they prefer.
+	var path string
+	auth := &drawer.TriggerAuth{Type: "none"}
 	for i := 0; i < len(vargs); i++ {
 		a := vargs[i]
-		switch {
-		case a == "--path":
+		val := func() (string, error) {
 			if i+1 >= len(vargs) {
-				return fmt.Errorf("--path needs a value")
+				return "", fmt.Errorf("%s needs a value", a)
 			}
-			path = vargs[i+1]
+			v := vargs[i+1]
 			i++
-		case strings.HasPrefix(a, "--path="):
-			path = strings.TrimPrefix(a, "--path=")
-		case a == "--secret":
-			if i+1 >= len(vargs) {
-				return fmt.Errorf("--secret needs a value")
+			return v, nil
+		}
+		// =form handler factored out so the switch stays readable.
+		if eq := strings.Index(a, "="); eq > 0 && strings.HasPrefix(a, "--") {
+			key, v := a[:eq], a[eq+1:]
+			if err := applyTriggerFlag(key, v, &path, auth); err != nil {
+				return err
 			}
-			secret = vargs[i+1]
-			i++
-		case strings.HasPrefix(a, "--secret="):
-			secret = strings.TrimPrefix(a, "--secret=")
-		case strings.HasPrefix(a, "-"):
-			return fmt.Errorf("unknown flag %q", a)
+			continue
+		}
+		switch a {
+		case "--path", "--auth", "--auth-user", "--auth-pass",
+			"--auth-header-name", "--auth-header-value",
+			"--jwt-secret", "--jwt-algorithm", "--jwt-issuer", "--jwt-audience":
+			v, err := val()
+			if err != nil {
+				return err
+			}
+			if err := applyTriggerFlag(a, v, &path, auth); err != nil {
+				return err
+			}
 		default:
+			if strings.HasPrefix(a, "-") {
+				return fmt.Errorf("unknown flag %q", a)
+			}
 			if path == "" {
 				path = a
 			} else {
@@ -638,8 +666,14 @@ func drawerTrigger(name string, vargs []string) error {
 		path = "/" + path
 	}
 
+	// Collapse the zero-value "none" auth back to a nil so we don't
+	// write a useless block into drawer.json for the common case.
+	if auth.Type == "" || auth.Type == "none" {
+		auth = nil
+	}
+
 	svc := drawer.NewService()
-	d, err := svc.SetWebhookTrigger(name, path, secret)
+	d, err := svc.SetWebhookTrigger(name, path, auth)
 	if err != nil {
 		return handleDrawerError(err)
 	}
@@ -653,22 +687,21 @@ func drawerTrigger(name string, vargs []string) error {
 	}
 
 	inputShape := webhookInputShape()
+	authType := triggerAuthType(auth)
 
 	if jsonOutput {
 		return config.WriteJSON(map[string]any{
 			"drawer":      d.Name,
 			"kind":        "webhook",
 			"path":        path,
-			"has_secret":  secret != "",
+			"auth_type":   authType,
 			"public_url":  publicURL,
 			"input_shape": inputShape,
 		})
 	}
 	fmt.Fprintf(os.Stderr, "Registered webhook trigger on %s\n", d.Name)
 	fmt.Fprintf(os.Stderr, "  path:   %s\n", path)
-	if secret != "" {
-		fmt.Fprintf(os.Stderr, "  secret: configured (sent via X-Buttons-Token)\n")
-	}
+	fmt.Fprintf(os.Stderr, "  auth:   %s\n", authType)
 	if publicURL != "" {
 		fmt.Fprintf(os.Stderr, "  url:    %s\n", publicURL)
 	} else {
@@ -681,6 +714,64 @@ func drawerTrigger(name string, vargs []string) error {
 	fmt.Fprintf(os.Stderr, "\nCross-drawer reference (from another drawer's step args):\n")
 	fmt.Fprintf(os.Stderr, "  ${webhooks.%s}   — resolves to the full public URL above\n", d.Name)
 	printNextHint("buttons webhook listen   # start the dispatcher")
+	return nil
+}
+
+// extractJSONFlag scans args for --json / --json=true / --no-json and
+// sets the package-level jsonOutput bool accordingly. Returns the
+// residual args so the per-verb hand-parsers don't have to know about
+// the flag. Also strips --help so `buttons drawer NAME --help`
+// doesn't confuse our dispatch — Cobra's automatic help path is
+// intentional for `buttons drawer --help` (no subcommand) and handled
+// upstream by the RunE when args is empty.
+func extractJSONFlag(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		switch a {
+		case "--json", "--json=true":
+			jsonOutput = true
+		case "--json=false", "--no-json":
+			jsonOutput = false
+		default:
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// applyTriggerFlag routes a parsed --key=value onto the right field
+// of the TriggerAuth block (or onto path). Factored out so both the
+// `--flag value` and `--flag=value` paths share one code path.
+func applyTriggerFlag(key, value string, path *string, auth *drawer.TriggerAuth) error {
+	switch key {
+	case "--path":
+		*path = value
+	case "--auth":
+		switch value {
+		case "none", "basic", "header", "jwt":
+			auth.Type = value
+		default:
+			return fmt.Errorf("--auth must be one of none|basic|header|jwt (got %q)", value)
+		}
+	case "--auth-user":
+		auth.Username = value
+	case "--auth-pass":
+		auth.Password = value
+	case "--auth-header-name":
+		auth.HeaderName = value
+	case "--auth-header-value":
+		auth.HeaderValue = value
+	case "--jwt-secret":
+		auth.JWTSecret = value
+	case "--jwt-algorithm":
+		auth.JWTAlgorithm = value
+	case "--jwt-issuer":
+		auth.JWTIssuer = value
+	case "--jwt-audience":
+		auth.JWTAudience = value
+	default:
+		return fmt.Errorf("unknown flag %q", key)
+	}
 	return nil
 }
 
@@ -777,15 +868,46 @@ func drawerSchema() error {
 // are sequential orchestration and per-button `buttons NAME logs
 // --follow` covers the live-press case at the step level.
 func drawerLogs(name string, vargs []string) error {
-	n := logsLimit
-	if n <= 0 {
-		n = 20
+	// DisableFlagParsing on drawerCmd means cobra no longer fills the
+	// logsLimit/logsFailed/logsFollow globals; parse them here from
+	// vargs instead. Keeps the verb's surface unchanged.
+	failed := false
+	limit := 20
+	for i := 0; i < len(vargs); i++ {
+		a := vargs[i]
+		switch {
+		case a == "--failed":
+			failed = true
+		case a == "--limit":
+			if i+1 >= len(vargs) {
+				return fmt.Errorf("--limit needs a value")
+			}
+			if _, err := fmt.Sscanf(vargs[i+1], "%d", &limit); err != nil {
+				return fmt.Errorf("--limit needs an integer, got %q", vargs[i+1])
+			}
+			i++
+		case strings.HasPrefix(a, "--limit="):
+			if _, err := fmt.Sscanf(strings.TrimPrefix(a, "--limit="), "%d", &limit); err != nil {
+				return fmt.Errorf("--limit needs an integer, got %q", a)
+			}
+		case a == "-f", a == "--follow":
+			// Follow mode isn't implemented for drawers at the orchestrator
+			// level (see function comment). Accept the flag silently so
+			// agents that pass it get no surprise error; point them at
+			// button-level follow.
+			_ = a
+		default:
+			return fmt.Errorf("unknown flag %q", a)
+		}
 	}
-	runs, err := drawer.ListRuns(name, n)
+	if limit <= 0 {
+		limit = 20
+	}
+	runs, err := drawer.ListRuns(name, limit)
 	if err != nil {
 		return handleDrawerError(err)
 	}
-	if logsFailed {
+	if failed {
 		kept := runs[:0]
 		for _, r := range runs {
 			if r.Status != "ok" {
@@ -1090,9 +1212,9 @@ func summarizeDrawerTriggers(d *drawer.Drawer) []map[string]any {
 	out := make([]map[string]any, 0, len(d.Triggers))
 	for _, t := range d.Triggers {
 		entry := map[string]any{
-			"kind":       t.Kind,
-			"path":       t.Path,
-			"has_secret": t.Secret != "",
+			"kind":      t.Kind,
+			"path":      t.Path,
+			"auth_type": triggerAuthType(t.Auth),
 		}
 		if t.Kind == "webhook" && host != "" {
 			entry["url"] = "https://" + host + t.Path

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -152,12 +152,34 @@ func runListen(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// toAuthConfig adapts a drawer-layer TriggerAuth into the webhook
+// package's verifier struct. Kept as a thin copy so the verifier has
+// no dependency on the drawer package (avoids an import cycle if the
+// drawer ever grows webhook-aware validation logic).
+func toAuthConfig(a *drawer.TriggerAuth) *webhook.TriggerAuthConfig {
+	if a == nil {
+		return nil
+	}
+	return &webhook.TriggerAuthConfig{
+		Type:         a.Type,
+		Username:     a.Username,
+		Password:     a.Password,
+		HeaderName:   a.HeaderName,
+		HeaderValue:  a.HeaderValue,
+		JWTSecret:    a.JWTSecret,
+		JWTAlgorithm: a.JWTAlgorithm,
+		JWTIssuer:    a.JWTIssuer,
+		JWTAudience:  a.JWTAudience,
+	}
+}
+
 // route maps one webhook path to the drawer that owns it plus the
-// optional shared-token secret.
+// auth configuration. Auth is kept as a pointer so a nil route.auth
+// is the "open endpoint" case — matching the on-disk normalisation.
 type route struct {
 	path       string
 	drawerName string
-	secret     string
+	auth       *drawer.TriggerAuth
 }
 
 func collectWebhookRoutes(ds []drawer.Drawer) []route {
@@ -167,7 +189,7 @@ func collectWebhookRoutes(ds []drawer.Drawer) []route {
 			if t.Kind != "webhook" || t.Path == "" {
 				continue
 			}
-			out = append(out, route{path: t.Path, drawerName: d.Name, secret: t.Secret})
+			out = append(out, route{path: t.Path, drawerName: d.Name, auth: t.Auth})
 		}
 	}
 	return out
@@ -181,11 +203,15 @@ func printServeBanner(publicBase string, routes []route, tunnel *webhook.Tunnel)
 		}
 		rs := payload["routes"].([]map[string]any)
 		for _, r := range routes {
+			authType := "none"
+			if r.auth != nil && r.auth.Type != "" {
+				authType = r.auth.Type
+			}
 			rs = append(rs, map[string]any{
-				"path":       r.path,
-				"drawer":     r.drawerName,
-				"has_secret": r.secret != "",
-				"url":        publicBase + r.path,
+				"path":      r.path,
+				"drawer":    r.drawerName,
+				"auth_type": authType,
+				"url":       publicBase + r.path,
 			})
 		}
 		payload["routes"] = rs
@@ -200,11 +226,11 @@ func printServeBanner(publicBase string, routes []route, tunnel *webhook.Tunnel)
 	fmt.Fprintf(os.Stderr, "  listening at: %s\n", publicBase)
 	fmt.Fprintf(os.Stderr, "\nroutes:\n")
 	for _, r := range routes {
-		lock := ""
-		if r.secret != "" {
-			lock = "  (token-protected)"
+		authLabel := ""
+		if r.auth != nil && r.auth.Type != "" && r.auth.Type != "none" {
+			authLabel = "  (auth: " + r.auth.Type + ")"
 		}
-		fmt.Fprintf(os.Stderr, "  %s%s  →  %s%s\n", publicBase, r.path, r.drawerName, lock)
+		fmt.Fprintf(os.Stderr, "  %s%s  →  %s%s\n", publicBase, r.path, r.drawerName, authLabel)
 	}
 	fmt.Fprintf(os.Stderr, "\nCtrl-C to stop.\n\n")
 }
@@ -249,16 +275,25 @@ func (h *serveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Shared-token check. Either X-Buttons-Token header or ?token=.
-	if matched.secret != "" {
-		got := r.Header.Get("X-Buttons-Token")
-		if got == "" {
-			got = r.URL.Query().Get("token")
+	// Auth gate. Matches n8n's trigger-webhook auth types (none,
+	// basic, header, jwt). Every string compare inside VerifyAuth
+	// uses crypto/subtle.ConstantTimeCompare so timing side-channels
+	// don't leak the configured secret.
+	if res := webhook.VerifyAuth(toAuthConfig(matched.auth), r); !res.OK {
+		w.Header().Set("Content-Type", "application/json")
+		// WWW-Authenticate for Basic helps browsers/clients re-prompt;
+		// harmless to emit for other types but only strictly correct
+		// for basic.
+		if matched.auth != nil && matched.auth.Type == "basic" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="buttons webhook"`)
 		}
-		if got != matched.secret {
-			http.Error(w, `{"ok":false,"error":"invalid_token"}`, http.StatusUnauthorized)
-			return
-		}
+		w.WriteHeader(res.Status)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": res.Code,
+			"detail": res.Detail,
+		})
+		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20)) // 8 MiB cap

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,367 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/webhook"
+)
+
+// listenFlags collects the small set of knobs `buttons webhook listen`
+// exposes. Rare enough to not warrant global state in the package.
+var listenFlags struct {
+	noTunnel bool
+	port     int
+}
+
+// webhookListenCmd is registered under webhookCmd in cmd/webhook.go's
+// init(). Lives here because the handler + dispatcher implementation
+// wants its own file; the parent webhookCmd just binds it.
+var webhookListenCmd = &cobra.Command{
+	Use:   "listen",
+	Short: "Run the webhook listener — presses drawers when trigger paths are hit",
+	Long: `Runs a foreground HTTP listener exposed via Cloudflare tunnel so
+drawers with webhook triggers get invoked when third-party services
+POST to their paths.
+
+Prereq:
+  1. 'cloudflared' on PATH (brew install cloudflared)
+  2. 'buttons webhook setup' run once for a stable named tunnel
+     (quick-tunnel mode works too, but the URL changes each run — fine
+     for dev, not for services that register a fixed URL up front)
+
+Workflow:
+  1. Create a drawer:               buttons drawer create on-apify-done
+  2. Add steps that consume the webhook body via \${inputs.webhook.body.*}
+  3. Attach a webhook trigger:      buttons drawer on-apify-done trigger webhook /apify
+  4. Start the listener:            buttons webhook listen
+  5. Configure the third-party service to POST to the printed URL.
+
+When a POST arrives at a registered path:
+  - The request body, headers, query, and method are materialized as
+    \${inputs.webhook.body}, \${inputs.webhook.headers.*}, etc.
+  - The drawer is pressed asynchronously — the HTTP response returns
+    immediately with {ok, drawer} so the sender doesn't block on the
+    full workflow.
+  - If the drawer has a shared-token secret set, X-Buttons-Token (or
+    ?token= query param) must match or the request is rejected 401.
+
+The listener stays up until Ctrl-C. Run it in tmux, a separate pane,
+or under launchd/systemd for always-on setups.`,
+	Args: cobra.NoArgs,
+	RunE: runListen,
+}
+
+func init() {
+	webhookListenCmd.Flags().BoolVar(&listenFlags.noTunnel, "no-tunnel", false, "skip cloudflared; listen on 127.0.0.1 only (local testing)")
+	webhookListenCmd.Flags().IntVar(&listenFlags.port, "port", 0, "bind local listener on this port (0 = random)")
+}
+
+func runListen(cmd *cobra.Command, args []string) error {
+	dsvc := drawer.NewService()
+	all, err := dsvc.List()
+	if err != nil {
+		return handleDrawerError(err)
+	}
+	// Pre-filter: only drawers with webhook triggers. Keeps the routing
+	// table small and the status output focused.
+	routes := collectWebhookRoutes(all)
+	if len(routes) == 0 {
+		return fmt.Errorf("no drawers have a webhook trigger yet — run `buttons drawer NAME trigger webhook /path` first")
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", listenFlags.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("bind %s: %w", addr, err)
+	}
+	localURL := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	mux := http.NewServeMux()
+	h := &serveHandler{dsvc: dsvc, routes: routes}
+	mux.Handle("/", h)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Start tunnel (unless suppressed).
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	var tunnel *webhook.Tunnel
+	var publicBase string
+	if listenFlags.noTunnel {
+		publicBase = localURL
+	} else {
+		if err := webhook.CheckCloudflared(); err != nil {
+			_ = srv.Shutdown(context.Background())
+			return handleWebhookErr(err)
+		}
+		tunnelCtx, tunnelCancel := context.WithTimeout(ctx, 90*time.Second)
+		tunnel, err = webhook.StartTunnel(tunnelCtx, localURL)
+		tunnelCancel()
+		if err != nil {
+			_ = srv.Shutdown(context.Background())
+			return handleWebhookErr(err)
+		}
+		defer func() { _ = tunnel.Stop() }()
+		publicBase = tunnel.URL
+	}
+
+	printServeBanner(publicBase, routes, tunnel)
+
+	// Wait on signal or server error.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-sigCh:
+		fmt.Fprintln(os.Stderr, "\nshutting down…")
+	case err := <-serveErr:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	_ = srv.Shutdown(shutdownCtx)
+	return nil
+}
+
+// route maps one webhook path to the drawer that owns it plus the
+// optional shared-token secret.
+type route struct {
+	path       string
+	drawerName string
+	secret     string
+}
+
+func collectWebhookRoutes(ds []drawer.Drawer) []route {
+	out := make([]route, 0)
+	for _, d := range ds {
+		for _, t := range d.Triggers {
+			if t.Kind != "webhook" || t.Path == "" {
+				continue
+			}
+			out = append(out, route{path: t.Path, drawerName: d.Name, secret: t.Secret})
+		}
+	}
+	return out
+}
+
+func printServeBanner(publicBase string, routes []route, tunnel *webhook.Tunnel) {
+	if jsonOutput {
+		payload := map[string]any{
+			"public_base": publicBase,
+			"routes":      make([]map[string]any, 0, len(routes)),
+		}
+		rs := payload["routes"].([]map[string]any)
+		for _, r := range routes {
+			rs = append(rs, map[string]any{
+				"path":       r.path,
+				"drawer":     r.drawerName,
+				"has_secret": r.secret != "",
+				"url":        publicBase + r.path,
+			})
+		}
+		payload["routes"] = rs
+		_ = config.WriteJSON(payload)
+		return
+	}
+	mode := "local"
+	if tunnel != nil {
+		mode = string(tunnel.Mode) + " tunnel"
+	}
+	fmt.Fprintf(os.Stderr, "buttons webhook listen — %s\n", mode)
+	fmt.Fprintf(os.Stderr, "  listening at: %s\n", publicBase)
+	fmt.Fprintf(os.Stderr, "\nroutes:\n")
+	for _, r := range routes {
+		lock := ""
+		if r.secret != "" {
+			lock = "  (token-protected)"
+		}
+		fmt.Fprintf(os.Stderr, "  %s%s  →  %s%s\n", publicBase, r.path, r.drawerName, lock)
+	}
+	fmt.Fprintf(os.Stderr, "\nCtrl-C to stop.\n\n")
+}
+
+// serveHandler dispatches incoming POSTs to the drawer registered for
+// the request path. Holds a sync.Mutex around the in-flight count so a
+// graceful shutdown can wait for drawer presses rather than dropping
+// them mid-run.
+type serveHandler struct {
+	dsvc    *drawer.Service
+	routes  []route
+	mu      sync.Mutex
+	inFlight int
+}
+
+func (h *serveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Accept POST only. A GET on a webhook URL is almost always a human
+	// poking around; respond with a useful message instead of 405.
+	if r.Method == http.MethodGet {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"message":"buttons webhook endpoint — POST to trigger"}`))
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"ok":false,"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Find the matching route. Exact path match only — wildcards and
+	// path params aren't needed today and would complicate collision
+	// detection in SetWebhookTrigger.
+	var matched *route
+	for i := range h.routes {
+		if h.routes[i].path == r.URL.Path {
+			matched = &h.routes[i]
+			break
+		}
+	}
+	if matched == nil {
+		http.Error(w, `{"ok":false,"error":"no_drawer_registered_for_path"}`, http.StatusNotFound)
+		return
+	}
+
+	// Shared-token check. Either X-Buttons-Token header or ?token=.
+	if matched.secret != "" {
+		got := r.Header.Get("X-Buttons-Token")
+		if got == "" {
+			got = r.URL.Query().Get("token")
+		}
+		if got != matched.secret {
+			http.Error(w, `{"ok":false,"error":"invalid_token"}`, http.StatusUnauthorized)
+			return
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20)) // 8 MiB cap
+	if err != nil {
+		http.Error(w, `{"ok":false,"error":"body_read_failed"}`, http.StatusBadRequest)
+		return
+	}
+	_ = r.Body.Close()
+
+	// Parse body: JSON if possible, else raw string. Agents usually want
+	// navigable fields (${inputs.webhook.body.foo}) but non-JSON senders
+	// still deserve to be observable.
+	var parsedBody any
+	if len(body) == 0 {
+		parsedBody = nil
+	} else if json.Valid(body) {
+		if err := json.Unmarshal(body, &parsedBody); err != nil {
+			parsedBody = string(body)
+		}
+	} else {
+		parsedBody = string(body)
+	}
+
+	headers := map[string]string{}
+	for k, vs := range r.Header {
+		// First value is enough for the common case; Cookie, Set-Cookie,
+		// and a few others are multi-valued but drawer resolution
+		// doesn't care about those.
+		if len(vs) > 0 {
+			headers[k] = vs[0]
+		}
+	}
+	query := map[string]string{}
+	for k, vs := range r.URL.Query() {
+		if len(vs) > 0 {
+			query[k] = vs[0]
+		}
+	}
+
+	webhookInput := map[string]any{
+		"body":        parsedBody,
+		"headers":     headers,
+		"query":       query,
+		"method":      r.Method,
+		"path":        r.URL.Path,
+		"received_at": time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Load fresh so a newly-added or modified drawer picks up without
+	// a restart — listing is cheap.
+	d, err := h.dsvc.Get(matched.drawerName)
+	if err != nil {
+		http.Error(w, `{"ok":false,"error":"drawer_not_found"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Press asynchronously: respond to the webhook sender right away
+	// with a run id. Most services retry aggressively on slow webhook
+	// responses, and a long-running drawer would block them needlessly.
+	h.mu.Lock()
+	h.inFlight++
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			h.mu.Lock()
+			h.inFlight--
+			h.mu.Unlock()
+		}()
+		// Fresh context — not tied to the request (which is about to
+		// close). 1h cap so a hung drawer can't leak forever.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+		defer cancel()
+
+		exec := drawer.NewExecutor()
+		result, execErr := exec.Execute(ctx, d, map[string]any{"webhook": webhookInput})
+		if execErr != nil && result == nil {
+			fmt.Fprintf(os.Stderr, "[serve] drawer %s error: %v\n", d.Name, execErr)
+			return
+		}
+		if result != nil && result.Status != "ok" {
+			fmt.Fprintf(os.Stderr, "[serve] drawer %s failed: %s\n", d.Name, failedStepSummary(result))
+			return
+		}
+		fmt.Fprintf(os.Stderr, "[serve] drawer %s ok (%dms)\n", d.Name, result.DurationMs)
+	}()
+
+	// Response to the webhook sender.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":     true,
+		"drawer": matched.drawerName,
+	})
+}
+
+func failedStepSummary(r *drawer.ExecuteResult) string {
+	parts := []string{}
+	if r.FailedStep != "" {
+		parts = append(parts, "step="+r.FailedStep)
+	}
+	if r.Error != nil {
+		parts = append(parts, r.Error.Code+": "+r.Error.Message)
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -12,6 +12,7 @@ import (
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/drawer"
 	"github.com/autonoco/buttons/internal/history"
+	"github.com/autonoco/buttons/internal/webhook"
 )
 
 // summaryFlag is the universal --summary flag. When set on a mutating
@@ -107,6 +108,11 @@ func runSummary() error {
 		drawerEntries = append(drawerEntries, drawerSummaryEntry(d, recent))
 	}
 
+	// Webhook block: mode, hostname, and count of drawers routed.
+	// Keeps the agent aware of whether the listener needs to run and
+	// what URL prefix to expect.
+	webhookBlock := buildWebhookSummaryBlock(drawers)
+
 	resp := map[string]any{
 		"version":  version,
 		"data_dir": dataDir,
@@ -121,6 +127,7 @@ func runSummary() error {
 		"active_runs":      []any{}, // v1 executor is sync; nothing is ever active between commands
 		"recent_failures":  failures,
 		"schedules":        []any{}, // stage 3
+		"webhook":          webhookBlock,
 	}
 
 	if jsonOutput {
@@ -151,6 +158,50 @@ func buttonSummary(b button.Button, recent []history.Run) map[string]any {
 	return entry
 }
 
+// buildWebhookSummaryBlock rolls up webhook-listener state into the
+// workspace summary. Agents use this to answer "should I start the
+// listener?" and "what's my base URL?" without learning a second
+// command.
+func buildWebhookSummaryBlock(drawers []drawer.Drawer) map[string]any {
+	cfg, _ := webhook.LoadConfig()
+	mode := string(webhook.ModeQuick)
+	hostname := ""
+	if cfg != nil && cfg.Mode == webhook.ModeNamed {
+		mode = string(webhook.ModeNamed)
+		hostname = cfg.Hostname
+	}
+
+	routes := make([]map[string]any, 0)
+	for _, d := range drawers {
+		for _, t := range d.Triggers {
+			if t.Kind != "webhook" || t.Path == "" {
+				continue
+			}
+			entry := map[string]any{
+				"drawer":     d.Name,
+				"path":       t.Path,
+				"has_secret": t.Secret != "",
+			}
+			if hostname != "" {
+				entry["url"] = "https://" + hostname + t.Path
+			}
+			routes = append(routes, entry)
+		}
+	}
+
+	block := map[string]any{
+		"mode":         mode,
+		"routes":       routes,
+		"route_count":  len(routes),
+		"listen_hint":  "buttons webhook listen",
+	}
+	if hostname != "" {
+		block["hostname"] = hostname
+		block["base_url"] = "https://" + hostname
+	}
+	return block
+}
+
 func drawerSummaryEntry(d drawer.Drawer, recent []drawer.Run) map[string]any {
 	topology := make([]string, 0, len(d.Steps))
 	for _, s := range d.Steps {
@@ -164,6 +215,9 @@ func drawerSummaryEntry(d drawer.Drawer, recent []drawer.Run) map[string]any {
 	}
 	if summaryDeep {
 		entry["steps"] = d.Steps
+	}
+	if triggers := summarizeDrawerTriggers(&d); len(triggers) > 0 {
+		entry["triggers"] = triggers
 	}
 	entry["recent_runs"] = summarizeDrawerRuns(recent)
 	return entry

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -158,6 +158,17 @@ func buttonSummary(b button.Button, recent []history.Run) map[string]any {
 	return entry
 }
 
+// triggerAuthType returns the auth mechanism name ("none", "basic",
+// "header", "jwt") for summary rendering. Nil auth blocks are treated
+// as "none" — matches the on-disk normalisation done in
+// drawer.Service.SetWebhookTrigger.
+func triggerAuthType(a *drawer.TriggerAuth) string {
+	if a == nil || a.Type == "" {
+		return "none"
+	}
+	return a.Type
+}
+
 // buildWebhookSummaryBlock rolls up webhook-listener state into the
 // workspace summary. Agents use this to answer "should I start the
 // listener?" and "what's my base URL?" without learning a second
@@ -178,9 +189,9 @@ func buildWebhookSummaryBlock(drawers []drawer.Drawer) map[string]any {
 				continue
 			}
 			entry := map[string]any{
-				"drawer":     d.Name,
-				"path":       t.Path,
-				"has_secret": t.Secret != "",
+				"drawer":    d.Name,
+				"path":      t.Path,
+				"auth_type": triggerAuthType(t.Auth),
 			}
 			if hostname != "" {
 				entry["url"] = "https://" + hostname + t.Path

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -1,0 +1,367 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/webhook"
+)
+
+// webhookCmd groups the three verbs a user needs to get webhook
+// infrastructure working: `setup` (one-time CF login + named tunnel),
+// `status` (what mode are we in / what's the public URL), and `test`
+// (prove the loop works end-to-end).
+var webhookCmd = &cobra.Command{
+	Use:   "webhook",
+	Short: "Expose a local URL via Cloudflare to receive webhook callbacks",
+	Long: `Drawer steps occasionally need to register a public URL with a third-
+party service (Apify, GitHub, Stripe) and wait for it to post back. The
+webhook subsystem manages a Cloudflare tunnel to your local machine so
+that URL works without hosting anything yourself.
+
+Two modes:
+
+  quick   zero setup. Each webhook step spawns a fresh Quick Tunnel
+          (ephemeral *.trycloudflare.com URL). Good when the service
+          accepts a per-run webhook URL.
+
+  named   stable hostname on your own Cloudflare account. Set up once
+          via 'buttons webhook setup'. Required when a service wants a
+          fixed URL registered up front (e.g. GitHub webhooks).
+
+Prereq: 'cloudflared' binary on PATH. Install via 'brew install cloudflared'.
+
+Verbs:
+  buttons webhook setup    — one-time: Cloudflare login + pick a hostname
+  buttons webhook status   — show current mode + hostname
+  buttons webhook test     — end-to-end round-trip verify
+  buttons webhook listen   — run the dispatcher that presses triggered drawers
+  buttons webhook logout   — forget the named-tunnel config (quick mode again)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWebhookStatus()
+	},
+}
+
+var webhookSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "One-time Cloudflare login + named-tunnel config",
+	Args:  cobra.NoArgs,
+	RunE:  runWebhookSetup,
+}
+
+var webhookStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show current webhook mode and URL",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWebhookStatus()
+	},
+}
+
+var webhookTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Round-trip verify: spin up a tunnel, self-POST, observe delivery",
+	Args:  cobra.NoArgs,
+	RunE:  runWebhookTest,
+}
+
+var webhookLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Clear named-tunnel config (falls back to quick mode)",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := webhook.DeleteConfig(); err != nil {
+			return handleWebhookErr(err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"mode": string(webhook.ModeQuick)})
+		}
+		fmt.Fprintln(os.Stderr, "Cleared named-tunnel config. Falling back to quick mode.")
+		return nil
+	},
+}
+
+// webhookSetupHostname is the --hostname override for non-interactive
+// setup (CI, scripted installs). When empty the flow prompts.
+var webhookSetupHostname string
+var webhookSetupTunnelName string
+
+// runWebhookSetup walks the user through: binary check → cloudflared
+// login if needed → hostname prompt → create + route tunnel → persist.
+func runWebhookSetup(cmd *cobra.Command, args []string) error {
+	if err := webhook.CheckCloudflared(); err != nil {
+		return handleWebhookErr(err)
+	}
+
+	hostname := strings.TrimSpace(webhookSetupHostname)
+	tunnelName := strings.TrimSpace(webhookSetupTunnelName)
+	if tunnelName == "" {
+		tunnelName = webhook.DefaultTunnelName
+	}
+
+	if hostname == "" {
+		if jsonOutput || noInput || config.IsNonTTY() {
+			return handleWebhookErr(errors.New("--hostname is required in non-interactive mode (example: --hostname webhooks.yourdomain.com)"))
+		}
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Hostname to receive webhooks").
+					Description("Must be on a zone managed by the Cloudflare account you're about to log in to.\nExample: webhooks.yourdomain.com").
+					Placeholder("webhooks.yourdomain.com").
+					Value(&hostname).
+					Validate(func(s string) error {
+						s = strings.TrimSpace(s)
+						if s == "" {
+							return errors.New("hostname required")
+						}
+						if !strings.Contains(s, ".") {
+							return errors.New("looks like a bare word — need a full domain like webhooks.example.com")
+						}
+						return nil
+					}),
+			),
+		).Run(); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				return errSilent
+			}
+			return handleWebhookErr(err)
+		}
+		hostname = strings.TrimSpace(hostname)
+	}
+
+	// Login inherits the user's terminal so the browser prompt appears.
+	// SkipLogin piggybacks on cert.pem presence — the second run of
+	// setup (to change hostname) doesn't re-open the browser.
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	defer cancel()
+
+	if !jsonOutput {
+		if webhook.HasCloudflaredCert() {
+			fmt.Fprintln(os.Stderr, "  Using existing Cloudflare login (~/.cloudflared/cert.pem).")
+		} else {
+			fmt.Fprintln(os.Stderr, "  Opening browser for Cloudflare login…")
+		}
+	}
+
+	result, err := webhook.RunSetup(ctx, webhook.SetupOpts{
+		Hostname:   hostname,
+		TunnelName: tunnelName,
+	})
+	if err != nil {
+		return handleWebhookErr(err)
+	}
+
+	if jsonOutput {
+		return config.WriteJSON(map[string]any{
+			"mode":        string(webhook.ModeNamed),
+			"hostname":    result.Hostname,
+			"tunnel_name": result.TunnelName,
+			"tunnel_id":   result.TunnelID,
+		})
+	}
+	fmt.Fprintf(os.Stderr, "\nConnected.\n")
+	fmt.Fprintf(os.Stderr, "  Hostname:    https://%s\n", result.Hostname)
+	fmt.Fprintf(os.Stderr, "  Tunnel:      %s (%s)\n", result.TunnelName, result.TunnelID)
+	printNextHint("buttons webhook test")
+	return nil
+}
+
+func runWebhookStatus() error {
+	cfg, err := webhook.LoadConfig()
+	if err != nil {
+		return handleWebhookErr(err)
+	}
+	mode := webhook.ModeQuick
+	var hostname, tunnelName, tunnelID string
+	if cfg != nil && cfg.Mode == webhook.ModeNamed {
+		mode = webhook.ModeNamed
+		hostname = cfg.Hostname
+		tunnelName = cfg.TunnelName
+		tunnelID = cfg.TunnelID
+	}
+	binOK := webhook.CheckCloudflared() == nil
+
+	if jsonOutput {
+		return config.WriteJSON(map[string]any{
+			"mode":            string(mode),
+			"hostname":        hostname,
+			"tunnel_name":     tunnelName,
+			"tunnel_id":       tunnelID,
+			"cloudflared_ok":  binOK,
+		})
+	}
+	fmt.Fprintf(os.Stderr, "  mode:         %s\n", mode)
+	if mode == webhook.ModeNamed {
+		fmt.Fprintf(os.Stderr, "  hostname:     https://%s\n", hostname)
+		fmt.Fprintf(os.Stderr, "  tunnel:       %s (%s)\n", tunnelName, tunnelID)
+	} else {
+		fmt.Fprintf(os.Stderr, "  hostname:     (ephemeral trycloudflare.com per run)\n")
+	}
+	if binOK {
+		fmt.Fprintf(os.Stderr, "  cloudflared:  installed\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "  cloudflared:  MISSING — brew install cloudflared\n")
+	}
+	if mode == webhook.ModeQuick {
+		printNextHint("buttons webhook setup  — upgrade to a stable hostname")
+	}
+	return nil
+}
+
+// runWebhookTest proves the whole loop: listener → tunnel → public URL
+// → POST back → delivery observed. Takes a minute end-to-end because
+// cloudflared needs time to register a connection.
+func runWebhookTest(cmd *cobra.Command, args []string) error {
+	if err := webhook.CheckCloudflared(); err != nil {
+		return handleWebhookErr(err)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 90*time.Second)
+	defer cancel()
+
+	// Ctrl-C during test should tear down cleanly.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	srv, err := webhook.NewServer()
+	if err != nil {
+		return handleWebhookErr(err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	if !jsonOutput {
+		fmt.Fprintf(os.Stderr, "  Starting tunnel (this takes ~15s)…\n")
+	}
+	t, err := webhook.StartTunnel(ctx, srv.LocalURL())
+	if err != nil {
+		return handleWebhookErr(err)
+	}
+	defer func() { _ = t.Stop() }()
+
+	corr, err := webhook.NewCorrelationID()
+	if err != nil {
+		return handleWebhookErr(err)
+	}
+	postURL := fmt.Sprintf("%s/webhook/%s", t.URL, corr)
+
+	if !jsonOutput {
+		fmt.Fprintf(os.Stderr, "  Tunnel up: %s\n", t.URL)
+		fmt.Fprintf(os.Stderr, "  POSTing to %s …\n", postURL)
+	}
+
+	// Fire the test POST in the background; cloudflared sometimes
+	// needs a beat before the first edge request routes, so we retry
+	// with a short backoff.
+	delivery := make(chan error, 1)
+	go func() {
+		delivery <- selfPost(ctx, postURL)
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer waitCancel()
+	ev, waitErr := srv.Wait(waitCtx, corr)
+	if waitErr != nil {
+		postErr := <-delivery
+		return handleWebhookErr(fmt.Errorf("no webhook received within 60s (post err: %v, wait err: %w)", postErr, waitErr))
+	}
+	if postErr := <-delivery; postErr != nil {
+		// Unusual: server received the event but the POST goroutine
+		// reported an error. Surface it but don't fail the test —
+		// delivery won.
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "  (note: POST goroutine reported %v)\n", postErr)
+		}
+	}
+
+	if jsonOutput {
+		return config.WriteJSON(map[string]any{
+			"mode":         string(t.Mode),
+			"url":          t.URL,
+			"correlation":  corr,
+			"received_at":  ev.ReceivedAt,
+			"body":         ev.Body,
+		})
+	}
+	fmt.Fprintf(os.Stderr, "\nWebhook round-trip ok (%s mode).\n", t.Mode)
+	fmt.Fprintf(os.Stderr, "  received: %s\n", ev.ReceivedAt.Format(time.RFC3339))
+	return nil
+}
+
+// selfPost fires one test request at the public URL. The tunnel
+// manager already waited for /healthz to respond before handing us the
+// URL, so a single POST is sufficient — retries here would only mask a
+// real problem.
+func selfPost(ctx context.Context, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{"hello":"from buttons webhook test"}`))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d from test POST", resp.StatusCode)
+	}
+	return nil
+}
+
+// handleWebhookErr renders cloudflared-missing errors cleanly and
+// everything else via the standard JSON/stderr split.
+func handleWebhookErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var missing webhook.CloudflaredMissingError
+	if errors.As(err, &missing) {
+		if jsonOutput {
+			_ = config.WriteJSONError("CLOUDFLARED_MISSING", err.Error())
+			return errSilent
+		}
+		fmt.Fprintln(os.Stderr, err.Error())
+		return errSilent
+	}
+	if jsonOutput {
+		_ = config.WriteJSONError("WEBHOOK_ERROR", err.Error())
+		return errSilent
+	}
+	fmt.Fprintln(os.Stderr, "webhook:", err.Error())
+	return errSilent
+}
+
+func init() {
+	rootCmd.AddCommand(webhookCmd)
+	webhookCmd.AddCommand(webhookSetupCmd)
+	webhookCmd.AddCommand(webhookStatusCmd)
+	webhookCmd.AddCommand(webhookTestCmd)
+	webhookCmd.AddCommand(webhookLogoutCmd)
+	webhookCmd.AddCommand(webhookListenCmd)
+
+	webhookSetupCmd.Flags().StringVar(&webhookSetupHostname, "hostname", "", "hostname for webhooks (e.g. webhooks.yourdomain.com)")
+	webhookSetupCmd.Flags().StringVar(&webhookSetupTunnelName, "tunnel", webhook.DefaultTunnelName, "Cloudflare tunnel name")
+}

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -239,6 +239,10 @@
     "Trigger": {
       "additionalProperties": false,
       "properties": {
+        "auth": {
+          "$ref": "#/$defs/TriggerAuth",
+          "description": "Authentication for incoming webhooks"
+        },
         "kind": {
           "description": "Trigger source",
           "enum": [
@@ -252,14 +256,66 @@
         "path": {
           "description": "URL path on the webhook listener (kind=webhook only); e.g. /apify",
           "type": "string"
-        },
-        "secret": {
-          "description": "Shared token; if set",
-          "type": "string"
         }
       },
       "required": [
         "kind"
+      ],
+      "type": "object"
+    },
+    "TriggerAuth": {
+      "additionalProperties": false,
+      "properties": {
+        "header_name": {
+          "description": "Header name to check (type=header); e.g. X-Buttons-Token",
+          "type": "string"
+        },
+        "header_value": {
+          "description": "Expected header value (type=header); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "jwt_algorithm": {
+          "description": "JWT signing algorithm (default: HS256)",
+          "enum": [
+            "HS256",
+            "HS384",
+            "HS512"
+          ],
+          "type": "string"
+        },
+        "jwt_audience": {
+          "description": "Expected aud claim (type=jwt); optional",
+          "type": "string"
+        },
+        "jwt_issuer": {
+          "description": "Expected iss claim (type=jwt); optional",
+          "type": "string"
+        },
+        "jwt_secret": {
+          "description": "HS-family signing secret (type=jwt); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "password": {
+          "description": "HTTP Basic password (type=basic); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "type": {
+          "description": "Auth mechanism",
+          "enum": [
+            "none",
+            "basic",
+            "header",
+            "jwt"
+          ],
+          "type": "string"
+        },
+        "username": {
+          "description": "HTTP Basic username (type=basic); $ENV{VAR} supported",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
       ],
       "type": "object"
     }

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -235,6 +235,33 @@
         "id"
       ],
       "type": "object"
+    },
+    "Trigger": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "description": "Trigger source",
+          "enum": [
+            "webhook",
+            "cron",
+            "file",
+            "mcp"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "description": "URL path on the webhook listener (kind=webhook only); e.g. /apify",
+          "type": "string"
+        },
+        "secret": {
+          "description": "Shared token; if set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://buttons.sh/schemas/drawer.schema.json",
@@ -285,6 +312,13 @@
       "description": "Ordered list of steps (depth-first execution)",
       "items": {
         "$ref": "#/$defs/Step"
+      },
+      "type": "array"
+    },
+    "triggers": {
+      "description": "Ways this drawer gets invoked automatically (webhook",
+      "items": {
+        "$ref": "#/$defs/Trigger"
       },
       "type": "array"
     },

--- a/internal/agentskill/agentskill.go
+++ b/internal/agentskill/agentskill.go
@@ -127,6 +127,25 @@ Common commands:
 - ` + "`buttons press <name> --arg key=value`" + ` — with args
 - ` + "`buttons create <name>`" + ` — scaffold a shell button (edit ~/.buttons/buttons/<name>/main.sh)
 
+## Drawers chain buttons into workflows
+
+- ` + "`buttons drawer create <name>`" + `
+- ` + "`buttons drawer <name> add <button> [<button>...]`" + `
+- ` + "`buttons drawer <name> connect A to B`" + ` — auto-match output→args
+- ` + "`buttons drawer <name> press [field=value...]`" + `
+
+Refs inside step args: ` + "`${step_id.output.field}`" + `, ` + "`${inputs.<name>}`" + `, ` + "`${env.VAR}`" + `. Contents of ` + "`${...}`" + ` are CEL (arithmetic, ternary, ` + "`??`" + ` null-coalesce).
+
+## Webhook-triggered drawers
+
+- ` + "`buttons webhook setup`" + ` — one-time: Cloudflare login + pick hostname
+- ` + "`buttons drawer <name> trigger webhook [/path]`" + ` — default path = /<name>
+- ` + "`buttons webhook listen`" + ` — foreground dispatcher
+
+In a triggered drawer, the POST is available as ` + "`${inputs.webhook.body}`" + ` (+ headers, query, method, path, received_at). ` + "`${webhooks.<drawer-name>}`" + ` resolves to another drawer's full public URL — use it to configure upstream services with the correct callback URL.
+
+Dry-run a webhook drawer without the listener: ` + "`buttons drawer <name> press --webhook-body '{...}'`" + ` or ` + "`--webhook-body @fixture.json`" + `.
+
 See ` + "`.buttons/AGENT.md`" + ` for more detail.`
 
 // AgentMDBody is the always-installed `.buttons/AGENT.md` content.
@@ -153,6 +172,43 @@ Common commands:
     buttons create <name>           scaffold a shell button you can edit
 
 Project-local buttons (in this folder) and global buttons (at ~/.buttons/) are both visible to ` + "`buttons list`" + `.
+
+## Drawers
+
+Drawers chain buttons into workflows. Spec at ` + "`~/.buttons/drawers/<name>/drawer.json`" + `.
+
+    buttons drawer create <name>
+    buttons drawer <name> add <button> [<button>...]
+    buttons drawer <name> connect A to B          # auto-match output→args
+    buttons drawer <name> set step.args.field=<literal-or-${ref}>
+    buttons drawer <name> press [field=value...]
+
+Refs between steps use ` + "`${step_id.output.field}`" + `; ` + "`${inputs.<name>}`" + ` pulls drawer-level inputs; ` + "`${env.VAR}`" + ` pulls environment at execution time. Everything inside ` + "`${...}`" + ` is CEL (arithmetic, string concat, ternary, null coalescing with ` + "`??`" + `).
+
+## Webhooks
+
+Drawers can be invoked automatically by incoming HTTP POSTs.
+
+    buttons webhook setup                              # one-time: CF login + pick hostname
+    buttons drawer <name> trigger webhook [/path]      # default path = /<drawer-name>
+    buttons webhook listen                             # runs the dispatcher (foreground)
+
+A triggered drawer gets the request body/headers/query/method materialized as:
+
+    ${inputs.webhook.body}              parsed JSON body
+    ${inputs.webhook.body.<field>}      drill into it
+    ${inputs.webhook.headers.X-Foo}     single-value headers
+    ${inputs.webhook.query.<param>}
+    ${inputs.webhook.method}
+    ${inputs.webhook.path}
+    ${inputs.webhook.received_at}       RFC3339 UTC
+
+Cross-drawer reference: ` + "`${webhooks.<drawer-name>}`" + ` resolves to that drawer's full public URL. Use it when one drawer configures a third-party service with another drawer's webhook URL (e.g. set ` + "`start-scrape.args.webhook_url=${webhooks.on-scrape-done}`" + `).
+
+Dry-run a webhook drawer without running the listener:
+
+    buttons drawer <name> press --webhook-body '{"foo":1}'
+    buttons drawer <name> press --webhook-body @fixture.json
 
 Full docs: run ` + "`buttons --help`" + ` or see https://buttons.sh
 `

--- a/internal/agentskill/agentskill.go
+++ b/internal/agentskill/agentskill.go
@@ -139,8 +139,10 @@ Refs inside step args: ` + "`${step_id.output.field}`" + `, ` + "`${inputs.<name
 ## Webhook-triggered drawers
 
 - ` + "`buttons webhook setup`" + ` — one-time: Cloudflare login + pick hostname
-- ` + "`buttons drawer <name> trigger webhook [/path]`" + ` — default path = /<name>
+- ` + "`buttons drawer <name> trigger webhook [/path] [--auth TYPE ...]`" + ` — default path = /<name>
 - ` + "`buttons webhook listen`" + ` — foreground dispatcher
+
+Auth types (match n8n's four): ` + "`none`" + ` (default) / ` + "`basic`" + ` (` + "`--auth-user --auth-pass`" + `) / ` + "`header`" + ` (` + "`--auth-header-name --auth-header-value`" + `) / ` + "`jwt`" + ` (` + "`--jwt-secret [--jwt-algorithm HS256|HS384|HS512] [--jwt-issuer ...] [--jwt-audience ...]`" + `). Secret fields accept ` + "`$ENV{VAR}`" + ` resolved at match time so drawer.json stays commit-safe.
 
 In a triggered drawer, the POST is available as ` + "`${inputs.webhook.body}`" + ` (+ headers, query, method, path, received_at). ` + "`${webhooks.<drawer-name>}`" + ` resolves to another drawer's full public URL — use it to configure upstream services with the correct callback URL.
 
@@ -190,8 +192,20 @@ Refs between steps use ` + "`${step_id.output.field}`" + `; ` + "`${inputs.<name
 Drawers can be invoked automatically by incoming HTTP POSTs.
 
     buttons webhook setup                              # one-time: CF login + pick hostname
-    buttons drawer <name> trigger webhook [/path]      # default path = /<drawer-name>
+    buttons drawer <name> trigger webhook [/path] [--auth <type> ...]
     buttons webhook listen                             # runs the dispatcher (foreground)
+
+Auth types (mirror n8n's four built-in options):
+
+    --auth none                                        # default, open endpoint
+    --auth basic --auth-user U --auth-pass P
+    --auth header --auth-header-name X-Foo --auth-header-value V
+    --auth jwt --jwt-secret S [--jwt-algorithm HS256|HS384|HS512]
+                               [--jwt-issuer I] [--jwt-audience A]
+
+Any secret field accepts '$ENV{VAR_NAME}' — the listener resolves it
+at match time against its environment, so committed drawer.json never
+carries raw secrets.
 
 A triggered drawer gets the request body/headers/query/method materialized as:
 

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -19,6 +19,22 @@ type Button struct {
 	TimeoutSeconds       int               `json:"timeout_seconds"`
 	MaxResponseBytes     int64             `json:"max_response_bytes,omitempty"`
 	AllowPrivateNetworks bool              `json:"allow_private_networks,omitempty"`
+	// AllowedHost locks the scheme+host portion of an HTTP button's
+	// URL at create time. {{arg}} substitution never modifies scheme
+	// or host — only path, query, and fragment. Before dispatch,
+	// validateHTTPTarget enforces that the final URL's host matches
+	// this value.
+	//
+	// Auto-derived from URL when the scheme and host have no {{}}
+	// placeholders. A literal "*" opts out (requires
+	// BUTTONS_ALLOW_ANY_HOST=1 at press time to actually fire) for
+	// legacy buttons that genuinely need host templating.
+	//
+	// Defends against {{arg}} values from remote sources (webhook
+	// bodies) being used to redirect the button to an attacker-
+	// controlled host — a real exfil vector the private-network
+	// SSRF block didn't cover.
+	AllowedHost string `json:"allowed_host,omitempty"`
 	MCPEnabled           bool              `json:"mcp_enabled"`
 	// Pinned buttons render as large, clickable cards at the top of the
 	// `buttons board` TUI. Omitted from JSON when false to avoid polluting

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,6 +13,59 @@ import (
 
 	"github.com/autonoco/buttons/internal/config"
 )
+
+// extractLockedHost parses the scheme + authority portion of an HTTP
+// button URL template and returns a lowercased host (including port
+// when present). The template may contain {{arg}} placeholders in its
+// path, query, or fragment — those are tolerated — but placeholders
+// in the scheme or host are rejected so the URL is bound to a concrete
+// destination at create time.
+//
+// Existing patterns that stay valid:
+//   https://api.example.com/users/{{user}}
+//   https://api.example.com/things?filter={{filter}}
+//
+// Patterns rejected (with remediation):
+//   https://{{host}}.example.com/x      // host templating
+//   {{scheme}}://api.example.com/x      // scheme templating
+//   https://api.{{tenant}}/foo          // mid-host templating
+//
+// Returns the literal lowercased host on success. "*" as the whole
+// URL is reserved — not used here.
+func extractLockedHost(rawTemplate string) (string, error) {
+	// Split off path/query/fragment — everything after the first '/'
+	// following the scheme. What's left is scheme://host[:port].
+	schemeEnd := strings.Index(rawTemplate, "://")
+	if schemeEnd < 0 {
+		return "", fmt.Errorf("URL must start with http:// or https://")
+	}
+	rest := rawTemplate[schemeEnd+3:]
+	hostPart := rest
+	if slash := strings.IndexAny(rest, "/?#"); slash >= 0 {
+		hostPart = rest[:slash]
+	}
+	scheme := rawTemplate[:schemeEnd]
+	if strings.Contains(scheme, "{{") || strings.Contains(scheme, "}}") {
+		return "", fmt.Errorf("URL scheme cannot contain {{arg}} placeholders; use a literal http:// or https:// prefix")
+	}
+	if strings.Contains(hostPart, "{{") || strings.Contains(hostPart, "}}") {
+		return "", fmt.Errorf("URL host cannot contain {{arg}} placeholders (got %q); put variable parts in the path/query instead, or create a separate button per host", hostPart)
+	}
+	// Sanity-check parseability now that we know scheme+host are
+	// literal — catches malformed authority sections (e.g. missing
+	// host after scheme).
+	parsed, err := neturl.Parse(scheme + "://" + hostPart)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("URL is missing a host")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("URL with embedded user:pass is not allowed; put credentials in --header")
+	}
+	return strings.ToLower(parsed.Host), nil
+}
 
 const maxCodeBytes = 65536 // 64KB
 
@@ -98,10 +152,20 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 
 	// Validate URL
 	method := strings.ToUpper(opts.Method)
+	var allowedHost string
 	if hasURL {
 		if !strings.HasPrefix(opts.URL, "http://") && !strings.HasPrefix(opts.URL, "https://") {
 			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "URL must start with http:// or https://"}
 		}
+		// Lock scheme + host at create time so {{arg}} substitution
+		// later can only touch path/query/fragment. Parsing out the
+		// host without resolving template variables means literal
+		// URLs auto-derive their AllowedHost here.
+		host, hostErr := extractLockedHost(opts.URL)
+		if hostErr != nil {
+			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: hostErr.Error()}
+		}
+		allowedHost = host
 		if method == "" {
 			method = "GET"
 		}
@@ -168,6 +232,7 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 		TimeoutSeconds:       timeout,
 		MaxResponseBytes:     maxResponseBytes,
 		AllowPrivateNetworks: opts.AllowPrivateNetworks,
+		AllowedHost:          allowedHost,
 		MCPEnabled:           false,
 		CreatedAt:            now,
 		UpdatedAt:            now,

--- a/internal/drawer/entity.go
+++ b/internal/drawer/entity.go
@@ -68,16 +68,49 @@ type Drawer struct {
 // even before the corresponding listener ships.
 type Trigger struct {
 	Kind string `json:"kind" jsonschema:"enum=webhook,enum=cron,enum=file,enum=mcp,description=Trigger source"`
-	// Path is the URL path the `buttons serve` listener binds for this
-	// trigger. Must start with '/'. Mutually exclusive across drawers —
-	// two drawers cannot register the same path. Only used for
-	// kind=webhook today.
+	// Path is the URL path the `buttons webhook listen` listener binds
+	// for this trigger. Must start with '/'. Mutually exclusive across
+	// drawers — two drawers cannot register the same path. Only used
+	// for kind=webhook today.
 	Path string `json:"path,omitempty" jsonschema:"description=URL path on the webhook listener (kind=webhook only); e.g. /apify"`
-	// Secret is an optional shared token. When set, the listener
-	// compares against the X-Buttons-Token header (or ?token= query
-	// parameter) and rejects requests without a match. Keeps third
-	// parties who learn the URL from invoking the drawer.
-	Secret string `json:"secret,omitempty" jsonschema:"description=Shared token; if set, required via X-Buttons-Token header or ?token query param"`
+	// Auth configures how the listener verifies incoming POSTs. When
+	// nil (or Type==none), the path is open — anyone who knows the URL
+	// can press the drawer. See TriggerAuth for per-type semantics.
+	Auth *TriggerAuth `json:"auth,omitempty" jsonschema:"description=Authentication for incoming webhooks"`
+}
+
+// TriggerAuth is the incoming-webhook authentication configuration.
+// Matches n8n's four built-in auth modes (none / basic / header / jwt)
+// so agents familiar with n8n webhook nodes map 1:1.
+//
+// All secret-bearing string fields accept $ENV{VAR_NAME} references —
+// the listener resolves them at match time against its own environment
+// so credentials can stay out of version-controlled drawer.json.
+type TriggerAuth struct {
+	// Type selects the auth mechanism. "none" is equivalent to
+	// omitting Auth entirely; kept so drawer.json can record an
+	// explicit "no auth" decision.
+	Type string `json:"type" jsonschema:"enum=none,enum=basic,enum=header,enum=jwt,description=Auth mechanism"`
+
+	// --- Type == "basic" ---
+	Username string `json:"username,omitempty" jsonschema:"description=HTTP Basic username (type=basic); $ENV{VAR} supported"`
+	Password string `json:"password,omitempty" jsonschema:"description=HTTP Basic password (type=basic); $ENV{VAR} supported"`
+
+	// --- Type == "header" ---
+	// Match an arbitrary header name (e.g. "X-Buttons-Token",
+	// "Authorization") against an expected value, constant-time.
+	HeaderName  string `json:"header_name,omitempty" jsonschema:"description=Header name to check (type=header); e.g. X-Buttons-Token"`
+	HeaderValue string `json:"header_value,omitempty" jsonschema:"description=Expected header value (type=header); $ENV{VAR} supported"`
+
+	// --- Type == "jwt" ---
+	// Verify the request's bearer token as a JWT signed with
+	// JWTSecret. Algorithm is one of HS256 | HS384 | HS512 (default
+	// HS256). JWTIssuer and JWTAudience are optional extra claims; empty
+	// = skip. `exp` is always enforced if present on the token.
+	JWTSecret    string `json:"jwt_secret,omitempty" jsonschema:"description=HS-family signing secret (type=jwt); $ENV{VAR} supported"`
+	JWTAlgorithm string `json:"jwt_algorithm,omitempty" jsonschema:"enum=HS256,enum=HS384,enum=HS512,description=JWT signing algorithm (default: HS256)"`
+	JWTIssuer    string `json:"jwt_issuer,omitempty" jsonschema:"description=Expected iss claim (type=jwt); optional"`
+	JWTAudience  string `json:"jwt_audience,omitempty" jsonschema:"description=Expected aud claim (type=jwt); optional"`
 }
 
 // InputDef declares a drawer-level input. Mirrors button.ArgDef so

--- a/internal/drawer/entity.go
+++ b/internal/drawer/entity.go
@@ -45,8 +45,39 @@ type Drawer struct {
 	// Example: { "version": "${build.output.version}", "url": "${publish.output.url}" }
 	Return map[string]any `json:"return,omitempty" jsonschema:"description=CEL expressions producing the drawer's output fields"`
 
+	// Triggers declares how this drawer gets invoked automatically.
+	// Today the only kind is "webhook": an incoming HTTP POST to the
+	// configured path on the `buttons serve` listener presses the
+	// drawer with the request body materialized as
+	// ${inputs.webhook.body} (plus headers, query, etc.). Drawers
+	// without triggers are only invoked manually via `buttons drawer
+	// NAME press`.
+	Triggers []Trigger `json:"triggers,omitempty" jsonschema:"description=Ways this drawer gets invoked automatically (webhook, etc.)"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Trigger is one automatic invocation source for a drawer. The only
+// kind today is "webhook" — an incoming POST to the `buttons serve`
+// listener at Path presses the drawer with the request body available
+// as ${inputs.webhook.body}, ${inputs.webhook.headers.*}, etc.
+//
+// Future kinds reserved: "cron" (scheduled), "file" (fsnotify), "mcp"
+// (MCP-tool-invoked). Kept in schema now so drawers can declare intent
+// even before the corresponding listener ships.
+type Trigger struct {
+	Kind string `json:"kind" jsonschema:"enum=webhook,enum=cron,enum=file,enum=mcp,description=Trigger source"`
+	// Path is the URL path the `buttons serve` listener binds for this
+	// trigger. Must start with '/'. Mutually exclusive across drawers —
+	// two drawers cannot register the same path. Only used for
+	// kind=webhook today.
+	Path string `json:"path,omitempty" jsonschema:"description=URL path on the webhook listener (kind=webhook only); e.g. /apify"`
+	// Secret is an optional shared token. When set, the listener
+	// compares against the X-Buttons-Token header (or ?token= query
+	// parameter) and rejects requests without a match. Keeps third
+	// parties who learn the URL from invoking the drawer.
+	Secret string `json:"secret,omitempty" jsonschema:"description=Shared token; if set, required via X-Buttons-Token header or ?token query param"`
 }
 
 // InputDef declares a drawer-level input. Mirrors button.ArgDef so

--- a/internal/drawer/executor.go
+++ b/internal/drawer/executor.go
@@ -11,10 +11,24 @@ import (
 	"sync"
 	"time"
 
+	"path/filepath"
+
 	"github.com/autonoco/buttons/internal/battery"
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/engine"
 )
+
+// webhookConfigPath returns ~/.buttons/webhook.json. Duplicated from
+// internal/webhook.ConfigPath to avoid a drawer → webhook import
+// dependency (webhook already imports drawer-adjacent config).
+func webhookConfigPath() (string, error) {
+	base, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "webhook.json"), nil
+}
 
 // ExecuteResult is the aggregated return of a drawer press. Mirrors
 // engine.Result's envelope so agents see a consistent shape when
@@ -92,9 +106,14 @@ func (e *Executor) Execute(ctx context.Context, d *Drawer, inputValues map[strin
 		}
 	}
 
-	// Build initial resolution context with inputs only.
+	// Build initial resolution context with inputs plus the cross-
+	// drawer `webhooks` map: ${webhooks.<drawer-name>} resolves to the
+	// public URL of that drawer's webhook trigger, if one exists. Lets
+	// one drawer's step configure a third-party service with another
+	// drawer's webhook URL without copy-pasting strings.
 	ctxMap := Context{
-		"inputs": toAnyMap(inputValues),
+		"inputs":   toAnyMap(inputValues),
+		"webhooks": e.buildWebhooksMap(),
 	}
 
 	// Lazy battery load — only if the executor didn't get one via
@@ -869,6 +888,79 @@ func (e *Executor) runWaitStep(ctx context.Context, step *Step, ctxMap Context) 
 		"until":     target.UTC().Format(time.RFC3339),
 	}
 	return sr, nil
+}
+
+
+// buildWebhooksMap populates the ${webhooks.<drawer>} context var by
+// iterating drawers that have a webhook trigger and computing the
+// public URL from the webhook config (named tunnel → stable hostname;
+// quick mode → URL unknown at drawer-resolve time, we return a
+// placeholder that agents can detect and fall back from).
+//
+// Keys are the drawer name with hyphens swapped for underscores —
+// matches the CEL-safe identifier transform so agents can write
+// ${webhooks.on-apify-done} and have it resolve.
+//
+// Silent fallback on error: a broken drawer listing shouldn't prevent
+// unrelated drawers from pressing. Worst case, ${webhooks.foo} resolves
+// to nil and the agent sees a clear empty-string propagation.
+func (e *Executor) buildWebhooksMap() map[string]any {
+	out := map[string]any{}
+	if e.DrawerSvc == nil {
+		return out
+	}
+	drawers, err := e.DrawerSvc.List()
+	if err != nil {
+		return out
+	}
+	// Load webhook config to know the hostname. When named-tunnel is
+	// not configured, URLs are only knowable at `buttons webhook
+	// listen` start time — we emit an empty string so the agent can
+	// detect the unconfigured state instead of getting a misleading
+	// literal.
+	hostname := resolveWebhookHostname()
+	for _, d := range drawers {
+		for _, t := range d.Triggers {
+			if t.Kind != "webhook" || t.Path == "" {
+				continue
+			}
+			key := strings.ReplaceAll(d.Name, "-", "_")
+			if hostname != "" {
+				out[key] = "https://" + hostname + t.Path
+			} else {
+				out[key] = ""
+			}
+		}
+	}
+	return out
+}
+
+// resolveWebhookHostname reads the webhook config file directly rather
+// than importing internal/webhook (avoids a cycle risk and keeps the
+// executor's dependency graph shallow). Returns "" if no named tunnel
+// is configured.
+func resolveWebhookHostname() string {
+	// The config file lives alongside the data dir. We read JSON by
+	// hand because this is the only field we care about.
+	path, err := webhookConfigPath()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed path under DataDir
+	if err != nil {
+		return ""
+	}
+	var c struct {
+		Mode     string `json:"mode"`
+		Hostname string `json:"hostname"`
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return ""
+	}
+	if c.Mode != "named" {
+		return ""
+	}
+	return c.Hostname
 }
 
 // computeReturn evaluates a drawer's Return block against its

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -239,6 +239,10 @@
     "Trigger": {
       "additionalProperties": false,
       "properties": {
+        "auth": {
+          "$ref": "#/$defs/TriggerAuth",
+          "description": "Authentication for incoming webhooks"
+        },
         "kind": {
           "description": "Trigger source",
           "enum": [
@@ -252,14 +256,66 @@
         "path": {
           "description": "URL path on the webhook listener (kind=webhook only); e.g. /apify",
           "type": "string"
-        },
-        "secret": {
-          "description": "Shared token; if set",
-          "type": "string"
         }
       },
       "required": [
         "kind"
+      ],
+      "type": "object"
+    },
+    "TriggerAuth": {
+      "additionalProperties": false,
+      "properties": {
+        "header_name": {
+          "description": "Header name to check (type=header); e.g. X-Buttons-Token",
+          "type": "string"
+        },
+        "header_value": {
+          "description": "Expected header value (type=header); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "jwt_algorithm": {
+          "description": "JWT signing algorithm (default: HS256)",
+          "enum": [
+            "HS256",
+            "HS384",
+            "HS512"
+          ],
+          "type": "string"
+        },
+        "jwt_audience": {
+          "description": "Expected aud claim (type=jwt); optional",
+          "type": "string"
+        },
+        "jwt_issuer": {
+          "description": "Expected iss claim (type=jwt); optional",
+          "type": "string"
+        },
+        "jwt_secret": {
+          "description": "HS-family signing secret (type=jwt); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "password": {
+          "description": "HTTP Basic password (type=basic); $ENV{VAR} supported",
+          "type": "string"
+        },
+        "type": {
+          "description": "Auth mechanism",
+          "enum": [
+            "none",
+            "basic",
+            "header",
+            "jwt"
+          ],
+          "type": "string"
+        },
+        "username": {
+          "description": "HTTP Basic username (type=basic); $ENV{VAR} supported",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
       ],
       "type": "object"
     }

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -235,6 +235,33 @@
         "id"
       ],
       "type": "object"
+    },
+    "Trigger": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "description": "Trigger source",
+          "enum": [
+            "webhook",
+            "cron",
+            "file",
+            "mcp"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "description": "URL path on the webhook listener (kind=webhook only); e.g. /apify",
+          "type": "string"
+        },
+        "secret": {
+          "description": "Shared token; if set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://buttons.sh/schemas/drawer.schema.json",
@@ -285,6 +312,13 @@
       "description": "Ordered list of steps (depth-first execution)",
       "items": {
         "$ref": "#/$defs/Step"
+      },
+      "type": "array"
+    },
+    "triggers": {
+      "description": "Ways this drawer gets invoked automatically (webhook",
+      "items": {
+        "$ref": "#/$defs/Trigger"
       },
       "type": "array"
     },

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -423,16 +423,52 @@ func (s *Service) save(d *Drawer) error {
 	return nil
 }
 
+// validateTriggerAuth enforces the per-type field requirements for an
+// incoming-webhook auth configuration. Nil and Type=="none" are valid
+// (open endpoint). Other types need their corresponding fields set so
+// agents can't persist a useless half-configured auth block.
+func validateTriggerAuth(a *TriggerAuth) error {
+	if a == nil || a.Type == "" || a.Type == "none" {
+		return nil
+	}
+	switch a.Type {
+	case "basic":
+		if a.Username == "" || a.Password == "" {
+			return fmt.Errorf("auth type=basic requires username and password")
+		}
+	case "header":
+		if a.HeaderName == "" || a.HeaderValue == "" {
+			return fmt.Errorf("auth type=header requires header_name and header_value")
+		}
+	case "jwt":
+		if a.JWTSecret == "" {
+			return fmt.Errorf("auth type=jwt requires jwt_secret")
+		}
+		switch a.JWTAlgorithm {
+		case "", "HS256", "HS384", "HS512":
+			// OK — empty defaults to HS256 at verification time.
+		default:
+			return fmt.Errorf("auth type=jwt: algorithm must be HS256, HS384, or HS512 (got %q)", a.JWTAlgorithm)
+		}
+	default:
+		return fmt.Errorf("unknown auth type %q (valid: none, basic, header, jwt)", a.Type)
+	}
+	return nil
+}
+
 // SetWebhookTrigger declares (or replaces) the webhook trigger on a
 // drawer. Returns an error if `path` collides with another drawer that
 // already owns the same path — listener dispatch must be unambiguous.
-// Pass secret="" to unset the shared token.
-func (s *Service) SetWebhookTrigger(drawerName, path, secret string) (*Drawer, error) {
+// Pass auth=nil (or auth.Type=="none") for an open endpoint.
+func (s *Service) SetWebhookTrigger(drawerName, path string, auth *TriggerAuth) (*Drawer, error) {
 	if path == "" {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "trigger path required (e.g. /apify-done)"}
 	}
 	if path[0] != '/' {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "trigger path must start with '/'"}
+	}
+	if err := validateTriggerAuth(auth); err != nil {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: err.Error()}
 	}
 	// Reject collision with any other drawer that already owns this path.
 	others, err := s.List()
@@ -465,7 +501,12 @@ func (s *Service) SetWebhookTrigger(drawerName, path, secret string) (*Drawer, e
 			filtered = append(filtered, t)
 		}
 	}
-	filtered = append(filtered, Trigger{Kind: "webhook", Path: path, Secret: secret})
+	// Normalise: treat auth.Type=="none" as no auth — saves a noisy
+	// block in every drawer.json that doesn't actually use auth.
+	if auth != nil && auth.Type == "none" {
+		auth = nil
+	}
+	filtered = append(filtered, Trigger{Kind: "webhook", Path: path, Auth: auth})
 	d.Triggers = filtered
 	d.UpdatedAt = time.Now().UTC()
 	if err := s.save(d); err != nil {

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -423,6 +423,76 @@ func (s *Service) save(d *Drawer) error {
 	return nil
 }
 
+// SetWebhookTrigger declares (or replaces) the webhook trigger on a
+// drawer. Returns an error if `path` collides with another drawer that
+// already owns the same path — listener dispatch must be unambiguous.
+// Pass secret="" to unset the shared token.
+func (s *Service) SetWebhookTrigger(drawerName, path, secret string) (*Drawer, error) {
+	if path == "" {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "trigger path required (e.g. /apify-done)"}
+	}
+	if path[0] != '/' {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "trigger path must start with '/'"}
+	}
+	// Reject collision with any other drawer that already owns this path.
+	others, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, od := range others {
+		if od.Name == drawerName {
+			continue
+		}
+		for _, t := range od.Triggers {
+			if t.Kind == "webhook" && t.Path == path {
+				return nil, &ServiceError{
+					Code:    "TRIGGER_PATH_CONFLICT",
+					Message: fmt.Sprintf("path %q is already bound to drawer %q", path, od.Name),
+				}
+			}
+		}
+	}
+
+	d, err := s.Get(drawerName)
+	if err != nil {
+		return nil, err
+	}
+	// Replace any existing webhook trigger (we only allow one per drawer
+	// today; non-webhook triggers pass through).
+	filtered := make([]Trigger, 0, len(d.Triggers)+1)
+	for _, t := range d.Triggers {
+		if t.Kind != "webhook" {
+			filtered = append(filtered, t)
+		}
+	}
+	filtered = append(filtered, Trigger{Kind: "webhook", Path: path, Secret: secret})
+	d.Triggers = filtered
+	d.UpdatedAt = time.Now().UTC()
+	if err := s.save(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// FindByWebhookPath returns the drawer registered for a given webhook
+// path, or (nil, nil) if nothing matches.
+func (s *Service) FindByWebhookPath(path string) (*Drawer, error) {
+	ds, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range ds {
+		for _, t := range d.Triggers {
+			if t.Kind == "webhook" && t.Path == path {
+				// Return the full drawer (List might return summaries —
+				// follow up with Get to be safe).
+				return s.Get(d.Name)
+			}
+		}
+	}
+	return nil, nil
+}
+
 // PressedDir returns the path to a drawer's pressed/ directory —
 // parallels button.Service.PressedDir so the history package can
 // write trace files there.

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -476,17 +476,36 @@ func validateHTTPTarget(raw, allowedHost string, allowPrivate bool) (string, err
 		}
 	}
 
-	// Rebuild the URL from explicitly-validated scalars. Going through
-	// fmt.Sprintf with a literal format string gives static analyzers
-	// a clear break in the taint chain — the host component was
-	// explicitly compared against allowedHost above, so CodeQL's
-	// request-forgery tracker sees the constant-comparison sanitizer.
+	// Reconstruct the URL using allowedHost as the authority, NOT the
+	// parsed-from-input u.Host. allowedHost originates from the
+	// button's spec file (literal scheme+host locked at create time),
+	// which is not in the set of remote-reachable taint sources that
+	// CodeQL's go/request-forgery query tracks. Using it here gives
+	// the dataflow a concrete break: the host in the returned URL is
+	// no longer derived from the attacker-controlled POST body.
+	//
+	// We've already verified strings.EqualFold(u.Host, allowedHost)
+	// above, so semantically nothing changes — just swapping a
+	// verified-equal value for one with a cleaner provenance.
+	scheme = pickSafeScheme(scheme)
+	host := allowedHost
 	path := u.EscapedPath()
 	rawQuery := u.RawQuery
 	if rawQuery != "" {
-		return fmt.Sprintf("%s://%s%s?%s", scheme, hostPort, path, rawQuery), nil
+		return fmt.Sprintf("%s://%s%s?%s", scheme, host, path, rawQuery), nil
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, hostPort, path), nil
+	return fmt.Sprintf("%s://%s%s", scheme, host, path), nil
+}
+
+// pickSafeScheme maps the validated scheme to a constant literal so
+// the reconstructed URL's scheme doesn't flow from the tainted input
+// either. We've already ensured it's "http" or "https" at the top of
+// validateHTTPTarget, so this is an exhaustive switch.
+func pickSafeScheme(s string) string {
+	if s == "https" {
+		return "https"
+	}
+	return "http"
 }
 
 // httpClientFor returns the http.Client to use for a given URL button.

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -246,7 +248,22 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 	// encoding (path segments get PathEscape, query values get
 	// QueryEscape, fragment gets PathEscape). See SubstituteURL docs
 	// in substitute.go for the escape matrix and threat model.
-	url := SubstituteURL(btn.URL, args)
+	rawURL := SubstituteURL(btn.URL, args)
+
+	// SSRF guard: the button's {{arg}} values can carry data that
+	// originated from a remote source (webhook POST body, for
+	// instance). Enforce scheme + host constraints before dispatch so
+	// an attacker who controls an arg can't pivot a button into an
+	// arbitrary request against the operator's private network.
+	safeURL, err := validateHTTPTarget(rawURL, btn.AllowPrivateNetworks)
+	if err != nil {
+		result.Status = "error"
+		result.ExitCode = -1
+		result.ErrorType = "VALIDATION_ERROR"
+		result.Stderr = fmt.Sprintf("refusing request: %v", err)
+		result.DurationMs = time.Since(start).Milliseconds()
+		return result
+	}
 
 	method := btn.Method
 	if method == "" {
@@ -262,7 +279,7 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 		reqBody = strings.NewReader(body)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, safeURL, reqBody)
 	if err != nil {
 		result.Status = "error"
 		result.ExitCode = -1
@@ -325,6 +342,63 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 	}
 
 	return result
+}
+
+// validateHTTPTarget parses a URL after {{arg}} substitution and
+// returns the canonical form ready for http.NewRequest — or an error
+// if the URL shouldn't be dispatched. Runs BEFORE we build the request
+// so a bad substitution can't even reach http.Transport.
+//
+// Defensive layer on top of newSafeDialContext: the dial hook already
+// blocks connections to private IP ranges, but this function catches
+// attacks earlier (bad scheme, embedded credentials, malformed URL)
+// and provides a static sanitization barrier that static analyzers
+// (CodeQL) recognize as a taint break.
+//
+// Rules:
+//   - Scheme must be http or https. file://, ftp://, data:, gopher://,
+//     etc. are all rejected — an HTTP button by definition makes HTTP
+//     requests, so anything else is almost certainly an exfil attempt.
+//   - No userinfo: URLs like https://user:pass@host/ smuggle creds
+//     into the request. Refuse; the button's Headers are the right
+//     place for auth.
+//   - Host must be present. Empty-host URLs (http:///path) leak into
+//     schemes the default resolver doesn't handle sanely.
+//   - Host must parse to a valid hostname. Numeric IPv4 literals in
+//     the private ranges are pre-empted here too so the error is
+//     visible before a dial attempt — unless BUTTONS_ALLOW_PRIVATE_NETWORKS
+//     is set, which callers already use as an escape hatch.
+func validateHTTPTarget(raw string, allowPrivate bool) (string, error) {
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("malformed URL %q: %w", raw, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("scheme %q not allowed (only http/https)", u.Scheme)
+	}
+	if u.User != nil {
+		return "", errors.New("URLs with embedded user:pass are not allowed; put credentials in button headers instead")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", errors.New("URL is missing a host")
+	}
+	// If the host is a literal IP, short-circuit the private-range
+	// check here. DNS-resolved hosts still get blocked at dial time
+	// via newSafeDialContext, so this is just an early-fail path for
+	// the most common smuggling case (attacker supplies a raw IP).
+	if ip := net.ParseIP(host); ip != nil && !allowPrivate && !privateNetworksGloballyAllowed() {
+		for _, cidr := range privateNetworks {
+			if cidr.Contains(ip) {
+				return "", fmt.Errorf("%s resolves to a blocked private range", ip)
+			}
+		}
+	}
+	// Strip any fragment — fragments never hit the server and their
+	// presence on an HTTP request is usually a caller bug.
+	u.Fragment = ""
+	return u.String(), nil
 }
 
 // httpClientFor returns the http.Client to use for a given URL button.

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -255,7 +255,22 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 	// instance). Enforce scheme + host constraints before dispatch so
 	// an attacker who controls an arg can't pivot a button into an
 	// arbitrary request against the operator's private network.
-	safeURL, err := validateHTTPTarget(rawURL, btn.AllowPrivateNetworks)
+	// Derive the locked host. Priority:
+	//   1. btn.AllowedHost (explicit declaration, including "*")
+	//   2. the scheme+host of btn.URL (literal by construction — the
+	//      button service refuses to save URLs with {{arg}} in scheme
+	//      or host, and SubstituteURL never touches that prefix).
+	// This fallback is what lets old buttons (pre-AllowedHost) and
+	// direct Button{} construction in tests still work without an
+	// explicit field.
+	lockedHost := btn.AllowedHost
+	if lockedHost == "" {
+		if h, herr := deriveTemplateHost(btn.URL); herr == nil {
+			lockedHost = h
+		}
+	}
+
+	safeURL, err := validateHTTPTarget(rawURL, lockedHost, btn.AllowPrivateNetworks)
 	if err != nil {
 		result.Status = "error"
 		result.ExitCode = -1
@@ -344,6 +359,35 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 	return result
 }
 
+// deriveTemplateHost extracts the lowercased host (including port if
+// present) from an HTTP button's URL template. Intended as the runtime
+// fallback when btn.AllowedHost is empty — the scheme + authority are
+// guaranteed literal at that point because the button service rejects
+// templating in scheme/host at save time AND SubstituteURL never
+// substitutes in the scheme://host prefix. Returns an error if the
+// template doesn't parse or has no host.
+func deriveTemplateHost(template string) (string, error) {
+	schemeEnd := strings.Index(template, "://")
+	if schemeEnd < 0 {
+		return "", errors.New("template has no scheme")
+	}
+	rest := template[schemeEnd+3:]
+	hostPart := rest
+	if sep := strings.IndexAny(rest, "/?#"); sep >= 0 {
+		hostPart = rest[:sep]
+	}
+	if hostPart == "" {
+		return "", errors.New("template has no host")
+	}
+	// Reject placeholders defensively — if they leaked into the host
+	// of a saved button, we want a hard refusal here rather than a
+	// silent fallback.
+	if strings.Contains(hostPart, "{{") || strings.Contains(hostPart, "}}") {
+		return "", errors.New("template host contains {{arg}} placeholders")
+	}
+	return strings.ToLower(hostPart), nil
+}
+
 // validateHTTPTarget parses a URL after {{arg}} substitution and
 // returns the canonical form ready for http.NewRequest — or an error
 // if the URL shouldn't be dispatched. Runs BEFORE we build the request
@@ -368,7 +412,7 @@ func executeHTTP(ctx context.Context, btn *button.Button, args map[string]string
 //     the private ranges are pre-empted here too so the error is
 //     visible before a dial attempt — unless BUTTONS_ALLOW_PRIVATE_NETWORKS
 //     is set, which callers already use as an escape hatch.
-func validateHTTPTarget(raw string, allowPrivate bool) (string, error) {
+func validateHTTPTarget(raw, allowedHost string, allowPrivate bool) (string, error) {
 	u, err := neturl.Parse(raw)
 	if err != nil {
 		return "", fmt.Errorf("malformed URL %q: %w", raw, err)
@@ -380,34 +424,69 @@ func validateHTTPTarget(raw string, allowPrivate bool) (string, error) {
 	if u.User != nil {
 		return "", errors.New("URLs with embedded user:pass are not allowed; put credentials in button headers instead")
 	}
-	host := u.Hostname()
-	if host == "" {
+	hostPort := u.Host
+	if hostPort == "" {
 		return "", errors.New("URL is missing a host")
 	}
-	// If the host is a literal IP, short-circuit the private-range
-	// check here. DNS-resolved hosts still get blocked at dial time
-	// via newSafeDialContext, so this is just an early-fail path for
-	// the most common smuggling case (attacker supplies a raw IP).
-	if ip := net.ParseIP(host); ip != nil && !allowPrivate && !privateNetworksGloballyAllowed() {
+	// Guard against placeholder leakage from hand-edited button.json:
+	// if a {{ survives to this point it means the scheme or host got
+	// templated somehow, which the service layer normally rejects.
+	if strings.Contains(hostPort, "{{") || strings.Contains(scheme, "{{") {
+		return "", errors.New("URL scheme or host contains {{arg}} placeholder; re-create the button with a literal scheme+host")
+	}
+
+	// Host lock: the substituted URL's host must match the button's
+	// declared AllowedHost (derived at create time from the literal
+	// URL template's host). This is what blocks the exfil class of
+	// SSRF — a webhook POST body value can no longer redirect the
+	// button to an attacker-controlled hostname.
+	//
+	// "*" is an explicit opt-out for legacy buttons that genuinely
+	// need host templating; gated at press time by
+	// BUTTONS_ALLOW_ANY_HOST=1 so it's not silent.
+	if allowedHost == "" {
+		return "", errors.New(
+			"button is missing allowed_host — re-save the button to derive it from the URL " +
+				"(older buttons created before host-locking landed need this)",
+		)
+	}
+	if allowedHost != "*" {
+		gotHost := strings.ToLower(hostPort)
+		if !strings.EqualFold(gotHost, allowedHost) {
+			return "", fmt.Errorf(
+				"refusing to dispatch to %q — button is locked to host %q "+
+					"(post-substitution URL differs; {{arg}} values can only populate path/query, not scheme or host)",
+				gotHost, allowedHost,
+			)
+		}
+	} else if os.Getenv("BUTTONS_ALLOW_ANY_HOST") != "1" {
+		return "", errors.New(
+			"button has allowed_host=\"*\" but BUTTONS_ALLOW_ANY_HOST is not set; " +
+				"confirm you want an unrestricted-host button and export BUTTONS_ALLOW_ANY_HOST=1",
+		)
+	}
+
+	// Literal-IP private-range check. DNS-resolved hosts still get
+	// blocked at dial time via newSafeDialContext.
+	if ip := net.ParseIP(u.Hostname()); ip != nil && !allowPrivate && !privateNetworksGloballyAllowed() {
 		for _, cidr := range privateNetworks {
 			if cidr.Contains(ip) {
 				return "", fmt.Errorf("%s resolves to a blocked private range", ip)
 			}
 		}
 	}
+
 	// Rebuild the URL from explicitly-validated scalars. Going through
-	// fmt.Sprintf with a literal format string (scheme + host come
-	// from local vars after the checks above; path + query are
-	// URL-encoded by net/url) gives static analyzers a clear break in
-	// the taint chain — the returned string is constructed here, not
-	// propagated from the raw input. Fragment is dropped intentionally:
-	// it never hits the server.
+	// fmt.Sprintf with a literal format string gives static analyzers
+	// a clear break in the taint chain — the host component was
+	// explicitly compared against allowedHost above, so CodeQL's
+	// request-forgery tracker sees the constant-comparison sanitizer.
 	path := u.EscapedPath()
 	rawQuery := u.RawQuery
 	if rawQuery != "" {
-		return fmt.Sprintf("%s://%s%s?%s", scheme, u.Host, path, rawQuery), nil
+		return fmt.Sprintf("%s://%s%s?%s", scheme, hostPort, path, rawQuery), nil
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, u.Host, path), nil
+	return fmt.Sprintf("%s://%s%s", scheme, hostPort, path), nil
 }
 
 // httpClientFor returns the http.Client to use for a given URL button.

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -395,10 +395,19 @@ func validateHTTPTarget(raw string, allowPrivate bool) (string, error) {
 			}
 		}
 	}
-	// Strip any fragment — fragments never hit the server and their
-	// presence on an HTTP request is usually a caller bug.
-	u.Fragment = ""
-	return u.String(), nil
+	// Rebuild the URL from explicitly-validated scalars. Going through
+	// fmt.Sprintf with a literal format string (scheme + host come
+	// from local vars after the checks above; path + query are
+	// URL-encoded by net/url) gives static analyzers a clear break in
+	// the taint chain — the returned string is constructed here, not
+	// propagated from the raw input. Fragment is dropped intentionally:
+	// it never hits the server.
+	path := u.EscapedPath()
+	rawQuery := u.RawQuery
+	if rawQuery != "" {
+		return fmt.Sprintf("%s://%s%s?%s", scheme, u.Host, path, rawQuery), nil
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, u.Host, path), nil
 }
 
 // httpClientFor returns the http.Client to use for a given URL button.

--- a/internal/engine/substitute.go
+++ b/internal/engine/substitute.go
@@ -33,14 +33,23 @@ import (
 //	args:     {"user": "alice&admin=true"}
 //	result:   "https://api.example.com/users/alice%26admin%3Dtrue"  (safe)
 func SubstituteURL(template string, args map[string]string) string {
-	// Split on the first `#` to find the fragment, then on the first `?`
-	// to find the query. Using strings.Index here rather than url.Parse
-	// because the template contains `{{arg}}` placeholders which a
-	// strict parser may choke on.
+	// Split into a locked scheme+host prefix and a substitutable
+	// suffix (path + query + fragment). {{arg}} placeholders in the
+	// prefix are deliberately NOT touched — button.Service validates
+	// at create time that scheme and host are literal, so if we see
+	// placeholders here it means a hand-edited button.json slipped
+	// through; leave them in place so validateHTTPTarget in engine
+	// can surface a VALIDATION_ERROR rather than silently making an
+	// exfil-friendly request.
+	prefix, suffix := splitSchemeHost(template)
+
+	// Split suffix on the first `#` to find the fragment, then on
+	// the first `?` for the query. We substitute in each with the
+	// context-appropriate encoder.
 	var path, query, fragment string
 	var hasQuery, hasFragment bool
 
-	rest := template
+	rest := suffix
 	if i := strings.Index(rest, "#"); i != -1 {
 		hasFragment = true
 		fragment = rest[i+1:]
@@ -60,7 +69,7 @@ func SubstituteURL(template string, args map[string]string) string {
 		fragment = strings.ReplaceAll(fragment, placeholder, url.PathEscape(v))
 	}
 
-	result := path
+	result := prefix + path
 	if hasQuery {
 		result += "?" + query
 	}
@@ -68,6 +77,26 @@ func SubstituteURL(template string, args map[string]string) string {
 		result += "#" + fragment
 	}
 	return result
+}
+
+// splitSchemeHost returns (prefix, suffix) where prefix is everything
+// up to and including the authority (scheme://host[:port]) and suffix
+// is everything after — the first /, ?, or # boundary. A template
+// that doesn't start with http:// or https:// gets an empty prefix
+// (validateHTTPTarget will reject it downstream).
+func splitSchemeHost(template string) (string, string) {
+	schemeEnd := strings.Index(template, "://")
+	if schemeEnd < 0 {
+		return "", template
+	}
+	authStart := schemeEnd + 3
+	sepOffset := strings.IndexAny(template[authStart:], "/?#")
+	if sepOffset < 0 {
+		// URL is just scheme://host with nothing after.
+		return template, ""
+	}
+	boundary := authStart + sepOffset
+	return template[:boundary], template[boundary:]
 }
 
 // SubstituteBody replaces every {{arg}} placeholder in a request body

--- a/internal/webhook/auth.go
+++ b/internal/webhook/auth.go
@@ -1,0 +1,325 @@
+package webhook
+
+// Trigger-webhook authentication. Mirrors n8n's four auth types
+// (None | Basic | Header | JWT) so agents familiar with n8n webhook
+// nodes get an identical mental model. Every string-vs-string
+// comparison runs through crypto/subtle so timing side-channels
+// don't leak the configured secret.
+//
+// Secrets referenced as $ENV{VAR_NAME} in drawer.json are resolved at
+// match time against the listener's process environment, so agents
+// can commit a drawer.json that encodes the auth shape but not the
+// secret itself.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// AuthResult is the structured outcome of a verification attempt.
+// Separate from a plain error so the dispatcher can map cleanly to
+// HTTP status codes and agent-facing error codes.
+type AuthResult struct {
+	// OK is true when the request satisfies the configured auth.
+	OK bool
+	// Code is a stable uppercase token used in the HTTP response body
+	// so clients can distinguish "missing creds" from "wrong creds".
+	Code string
+	// Status is the HTTP status code the dispatcher should return.
+	Status int
+	// Detail is a short human string. Never includes secret material.
+	Detail string
+}
+
+// authResultOK is the sentinel for a cleanly-passing check. Using a
+// helper so call sites don't have to remember to set Status=200.
+func authResultOK() AuthResult {
+	return AuthResult{OK: true, Status: http.StatusOK, Code: "OK"}
+}
+
+// VerifyAuth checks the request against a drawer trigger's auth
+// configuration. A nil or Type=="none" auth always passes — that's
+// the open-endpoint case.
+type TriggerAuthConfig struct {
+	Type         string
+	Username     string
+	Password     string
+	HeaderName   string
+	HeaderValue  string
+	JWTSecret    string
+	JWTAlgorithm string
+	JWTIssuer    string
+	JWTAudience  string
+}
+
+// VerifyAuth is the single entry point the dispatcher calls.
+// Resolves $ENV{VAR} references in the auth's string fields before
+// comparing.
+func VerifyAuth(cfg *TriggerAuthConfig, r *http.Request) AuthResult {
+	if cfg == nil || cfg.Type == "" || cfg.Type == "none" {
+		return authResultOK()
+	}
+	switch cfg.Type {
+	case "basic":
+		return verifyBasic(cfg, r)
+	case "header":
+		return verifyHeader(cfg, r)
+	case "jwt":
+		return verifyJWT(cfg, r)
+	}
+	return AuthResult{
+		Code:   "AUTH_UNKNOWN_TYPE",
+		Status: http.StatusInternalServerError,
+		Detail: fmt.Sprintf("unknown auth type %q", cfg.Type),
+	}
+}
+
+// --- basic ---
+
+func verifyBasic(cfg *TriggerAuthConfig, r *http.Request) AuthResult {
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		return AuthResult{
+			Code:   "AUTH_MISSING",
+			Status: http.StatusUnauthorized,
+			Detail: "HTTP Basic credentials required",
+		}
+	}
+	wantUser := resolveEnvRef(cfg.Username)
+	wantPass := resolveEnvRef(cfg.Password)
+	if !ctEqual(user, wantUser) || !ctEqual(pass, wantPass) {
+		return AuthResult{
+			Code:   "AUTH_INVALID",
+			Status: http.StatusUnauthorized,
+			Detail: "HTTP Basic credentials rejected",
+		}
+	}
+	return authResultOK()
+}
+
+// --- header ---
+
+func verifyHeader(cfg *TriggerAuthConfig, r *http.Request) AuthResult {
+	got := r.Header.Get(cfg.HeaderName)
+	want := resolveEnvRef(cfg.HeaderValue)
+	if got == "" {
+		return AuthResult{
+			Code:   "AUTH_MISSING",
+			Status: http.StatusUnauthorized,
+			Detail: fmt.Sprintf("header %q required", cfg.HeaderName),
+		}
+	}
+	if !ctEqual(got, want) {
+		return AuthResult{
+			Code:   "AUTH_INVALID",
+			Status: http.StatusUnauthorized,
+			Detail: fmt.Sprintf("header %q value rejected", cfg.HeaderName),
+		}
+	}
+	return authResultOK()
+}
+
+// --- jwt ---
+
+func verifyJWT(cfg *TriggerAuthConfig, r *http.Request) AuthResult {
+	token := bearerToken(r)
+	if token == "" {
+		return AuthResult{
+			Code:   "AUTH_MISSING",
+			Status: http.StatusUnauthorized,
+			Detail: "Authorization: Bearer <jwt> required",
+		}
+	}
+	alg := cfg.JWTAlgorithm
+	if alg == "" {
+		alg = "HS256"
+	}
+	secret := resolveEnvRef(cfg.JWTSecret)
+	claims, err := parseAndVerifyJWT(token, alg, secret)
+	if err != nil {
+		return AuthResult{
+			Code:   "AUTH_INVALID",
+			Status: http.StatusUnauthorized,
+			Detail: "JWT rejected: " + err.Error(),
+		}
+	}
+	if cfg.JWTIssuer != "" {
+		if iss, _ := claims["iss"].(string); iss != cfg.JWTIssuer {
+			return AuthResult{
+				Code:   "AUTH_INVALID",
+				Status: http.StatusUnauthorized,
+				Detail: "JWT issuer mismatch",
+			}
+		}
+	}
+	if cfg.JWTAudience != "" && !jwtAudienceMatches(claims["aud"], cfg.JWTAudience) {
+		return AuthResult{
+			Code:   "AUTH_INVALID",
+			Status: http.StatusUnauthorized,
+			Detail: "JWT audience mismatch",
+		}
+	}
+	return authResultOK()
+}
+
+// parseAndVerifyJWT decodes a compact-serialised JWT, verifies the
+// signature with the configured HS-family algorithm, and enforces the
+// `exp` claim if present. Returns the decoded claims map on success.
+//
+// We roll our own rather than importing golang-jwt/jwt because the
+// stdlib has every primitive we need and the feature surface is
+// small (HS256/384/512, exp enforcement, optional iss/aud). Avoids a
+// transitive-dep footprint.
+func parseAndVerifyJWT(token, alg, secret string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("malformed (expected 3 segments)")
+	}
+	// Header check: confirm alg matches configured algorithm; reject
+	// "none" and any asymmetric alg since we only verify HMAC.
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("bad header b64: %w", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("bad header json: %w", err)
+	}
+	if !strings.EqualFold(header.Alg, alg) {
+		return nil, fmt.Errorf("algorithm mismatch (token: %s, expected: %s)", header.Alg, alg)
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("bad payload b64: %w", err)
+	}
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("bad signature b64: %w", err)
+	}
+
+	// HMAC verification. Signing input is `header.payload` (the
+	// base64-encoded originals, not the decoded bytes).
+	signingInput := parts[0] + "." + parts[1]
+	expected, err := computeHMAC(alg, secret, signingInput)
+	if err != nil {
+		return nil, err
+	}
+	if subtle.ConstantTimeCompare(sigBytes, expected) != 1 {
+		return nil, errors.New("signature invalid")
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, fmt.Errorf("bad claims json: %w", err)
+	}
+	// exp enforcement if present. Accept int or float (JSON number
+	// decodes as float64 in Go). Allow 30s of clock skew.
+	if rawExp, ok := claims["exp"]; ok {
+		var expUnix int64
+		switch v := rawExp.(type) {
+		case float64:
+			expUnix = int64(v)
+		case int64:
+			expUnix = v
+		case int:
+			expUnix = int64(v)
+		default:
+			return nil, errors.New("exp claim must be a number")
+		}
+		if time.Now().Add(-30 * time.Second).Unix() > expUnix {
+			return nil, errors.New("token expired")
+		}
+	}
+	return claims, nil
+}
+
+// computeHMAC returns the raw signature bytes for signingInput under
+// the given HS-family algorithm.
+func computeHMAC(alg, secret, signingInput string) ([]byte, error) {
+	var h hash.Hash
+	switch strings.ToUpper(alg) {
+	case "HS256":
+		h = hmac.New(sha256.New, []byte(secret))
+	case "HS384":
+		h = hmac.New(sha512.New384, []byte(secret))
+	case "HS512":
+		h = hmac.New(sha512.New, []byte(secret))
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q", alg)
+	}
+	h.Write([]byte(signingInput))
+	return h.Sum(nil), nil
+}
+
+func jwtAudienceMatches(raw any, want string) bool {
+	switch v := raw.(type) {
+	case string:
+		return v == want
+	case []any:
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func bearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return ""
+	}
+	const pfx = "Bearer "
+	if !strings.HasPrefix(h, pfx) {
+		return ""
+	}
+	return strings.TrimSpace(h[len(pfx):])
+}
+
+// --- shared helpers ---
+
+// ctEqual compares two strings in constant time relative to their
+// length. Treats mismatched lengths as non-equal up front, which is
+// the common behavior expected from a timing-safe comparator.
+func ctEqual(got, want string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// envRef matches $ENV{VAR_NAME} with a conservative var-name charset.
+// Anchored so partial matches in the middle of strings aren't
+// accidentally expanded.
+var envRef = regexp.MustCompile(`^\$ENV\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
+// resolveEnvRef returns the environment value if v is exactly
+// "$ENV{NAME}", otherwise returns v unchanged. We intentionally only
+// support full-string references (not inline interpolation) for auth
+// fields — mixing a literal prefix with a secret is almost always a
+// configuration mistake, and the narrow contract keeps the error
+// surface small.
+func resolveEnvRef(v string) string {
+	m := envRef.FindStringSubmatch(v)
+	if m == nil {
+		return v
+	}
+	return os.Getenv(m[1])
+}

--- a/internal/webhook/config.go
+++ b/internal/webhook/config.go
@@ -1,0 +1,128 @@
+// Package webhook exposes a local HTTP listener through a Cloudflare
+// tunnel so drawer steps can register a public URL with a third-party
+// service, wait for the service to POST back, and resume.
+//
+// Two modes:
+//
+//  - "quick": no config required. Each run spawns a fresh Cloudflare
+//    Quick Tunnel. The public URL is ephemeral (*.trycloudflare.com)
+//    and changes every invocation. Works for any service that accepts
+//    a per-run webhook URL (Apify, etc.).
+//
+//  - "named": a stable hostname on the user's own Cloudflare account,
+//    configured once via `buttons webhook setup`. Required when a
+//    service wants a fixed URL registered once (GitHub webhooks).
+//
+// Config is stored at ~/.buttons/webhook.json so it's per-machine and
+// survives across projects. Nothing secret is kept here — the actual
+// Cloudflare credentials live under ~/.cloudflared/ where the
+// `cloudflared` binary manages them.
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/autonoco/buttons/internal/config"
+)
+
+// ConfigSchemaVersion pins the shape of webhook.json. Bump on breaks.
+const ConfigSchemaVersion = 1
+
+// Mode is the runtime mode for exposing the local listener.
+type Mode string
+
+const (
+	// ModeQuick uses Cloudflared's anonymous trycloudflare.com tunnels.
+	ModeQuick Mode = "quick"
+	// ModeNamed uses a user-owned Cloudflare tunnel with a stable DNS
+	// hostname. Set up via `buttons webhook setup`.
+	ModeNamed Mode = "named"
+)
+
+// Config is the on-disk webhook connection.
+type Config struct {
+	SchemaVersion int    `json:"schema_version"`
+	Mode          Mode   `json:"mode"`
+	Hostname      string `json:"hostname,omitempty"`
+	TunnelName    string `json:"tunnel_name,omitempty"`
+	TunnelID      string `json:"tunnel_id,omitempty"`
+}
+
+// ConfigPath returns ~/.buttons/webhook.json using the standard data
+// directory resolution (project-local .buttons/ beats global ~/.buttons/).
+func ConfigPath() (string, error) {
+	base, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "webhook.json"), nil
+}
+
+// LoadConfig returns the persisted webhook config. A missing file maps
+// to (nil, nil) — callers fall back to quick-tunnel semantics.
+func LoadConfig() (*Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed path under DataDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// SaveConfig writes the config atomically at 0600.
+func SaveConfig(c *Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	c.SchemaVersion = ConfigSchemaVersion
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// DeleteConfig removes the webhook config file. Missing = no-op.
+func DeleteConfig() error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// EffectiveMode reports which mode the CLI will use if a webhook step
+// runs right now. No config = quick.
+func EffectiveMode() (Mode, error) {
+	c, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	if c == nil || c.Mode == "" {
+		return ModeQuick, nil
+	}
+	return c.Mode, nil
+}

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -1,0 +1,192 @@
+package webhook
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Event is one webhook POST captured from an upstream service. Headers
+// are trimmed to the small set we care about so a large Authorization
+// value doesn't bleed into drawer history.
+type Event struct {
+	Method    string            `json:"method"`
+	Path      string            `json:"path"`
+	Headers   map[string]string `json:"headers"`
+	Body      json.RawMessage   `json:"body"`
+	ReceivedAt time.Time        `json:"received_at"`
+}
+
+// Server is the local HTTP receiver for webhook POSTs. One listener per
+// process is enough — we multiplex by correlation id embedded in the
+// URL path (/webhook/<id>).
+type Server struct {
+	listener net.Listener
+	http     *http.Server
+
+	mu      sync.Mutex
+	waiters map[string]chan Event // correlation id -> delivery channel
+	pending map[string]Event      // id -> event received before Wait() registered
+}
+
+// NewServer binds on 127.0.0.1 with an OS-picked free port and starts
+// accepting. The public URL is stitched together later by the tunnel —
+// this object only cares about the local side.
+func NewServer() (*Server, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("bind local webhook listener: %w", err)
+	}
+	s := &Server{
+		listener: ln,
+		waiters:  make(map[string]chan Event),
+		pending:  make(map[string]Event),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook/", s.handleWebhook)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	s.http = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = s.http.Serve(ln) }()
+	return s, nil
+}
+
+// Port returns the randomly-assigned local port.
+func (s *Server) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+// LocalURL is what we hand cloudflared as its upstream.
+func (s *Server) LocalURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", s.Port())
+}
+
+// NewCorrelationID returns a random unguessable id. Used as path suffix
+// so a third party who guesses the public hostname still can't
+// enumerate other pending webhooks.
+func NewCorrelationID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("random correlation id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Wait blocks until a webhook for the given correlation id arrives or
+// the context fires. If the event was already received before Wait was
+// called, it returns immediately — this is the common case in our drawer
+// flow where Register → return URL → Wait all happen in sequence.
+func (s *Server) Wait(ctx context.Context, correlationID string) (Event, error) {
+	s.mu.Lock()
+	if ev, ok := s.pending[correlationID]; ok {
+		delete(s.pending, correlationID)
+		s.mu.Unlock()
+		return ev, nil
+	}
+	ch, ok := s.waiters[correlationID]
+	if !ok {
+		ch = make(chan Event, 1)
+		s.waiters[correlationID] = ch
+	}
+	s.mu.Unlock()
+
+	select {
+	case ev := <-ch:
+		return ev, nil
+	case <-ctx.Done():
+		s.mu.Lock()
+		delete(s.waiters, correlationID)
+		s.mu.Unlock()
+		return Event{}, ctx.Err()
+	}
+}
+
+// Close stops the listener. Pending waiters observe a closed server via
+// their context (the executor is responsible for passing a cancellable
+// ctx to Wait).
+func (s *Server) Close() error {
+	if s.http == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return s.http.Shutdown(ctx)
+}
+
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/webhook/")
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, "bad correlation id", http.StatusBadRequest)
+		return
+	}
+
+	// Cap body at 1 MiB — webhook payloads over this are a misuse of
+	// the channel; the real data lives wherever the service stored it
+	// (dataset, object store, etc.).
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	_ = r.Body.Close()
+
+	var raw json.RawMessage = body
+	if len(body) == 0 {
+		raw = json.RawMessage("null")
+	} else if !json.Valid(body) {
+		// Store non-JSON as a quoted string so downstream JSON
+		// consumers don't choke. Most services post JSON; the ones
+		// that don't still deserve to be observable.
+		quoted, _ := json.Marshal(string(body))
+		raw = quoted
+	}
+
+	headers := map[string]string{}
+	for _, k := range []string{"Content-Type", "User-Agent", "X-Forwarded-For"} {
+		if v := r.Header.Get(k); v != "" {
+			headers[k] = v
+		}
+	}
+	ev := Event{
+		Method:     r.Method,
+		Path:       r.URL.Path,
+		Headers:    headers,
+		Body:       raw,
+		ReceivedAt: time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	if ch, ok := s.waiters[id]; ok {
+		delete(s.waiters, id)
+		s.mu.Unlock()
+		// Non-blocking send; buffer of 1 guarantees success.
+		ch <- ev
+	} else {
+		// Stash for a Wait() that hasn't landed yet.
+		s.pending[id] = ev
+		s.mu.Unlock()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+// ErrAlreadyRegistered is returned when the same correlation id is
+// reused within a process. Shouldn't happen in practice because we mint
+// fresh ids, but guarded so duplicate ids can't collide silently.
+var ErrAlreadyRegistered = errors.New("correlation id already registered")

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -1,0 +1,195 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DefaultTunnelName is used when the user doesn't override via
+// SetupOpts.TunnelName. "buttons" is memorable and unambiguous in the
+// Cloudflare dashboard.
+const DefaultTunnelName = "buttons"
+
+// SetupOpts configures the one-time named-tunnel setup flow. Leave
+// fields empty to accept defaults / fall back to interactive prompts in
+// the CLI wrapper.
+type SetupOpts struct {
+	Hostname   string // e.g. "webhooks.autono.dev"
+	TunnelName string // defaults to DefaultTunnelName
+	// SkipLogin assumes `cloudflared tunnel login` has already been run
+	// on this machine. Used by the CLI after it confirms ~/.cloudflared/cert.pem exists.
+	SkipLogin bool
+}
+
+// SetupResult reports what got persisted so the CLI can render a clean
+// summary.
+type SetupResult struct {
+	Hostname   string `json:"hostname"`
+	TunnelName string `json:"tunnel_name"`
+	TunnelID   string `json:"tunnel_id"`
+}
+
+// CertPath is where cloudflared stores the CA cert after `tunnel login`.
+// We never read it — we only check existence so the CLI can decide
+// whether to trigger the login step.
+const CertPath = "cert.pem"
+
+// HasCloudflaredCert returns true when ~/.cloudflared/cert.pem exists,
+// which is cloudflared's indicator that `tunnel login` has run.
+func HasCloudflaredCert() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(fmt.Sprintf("%s/.cloudflared/%s", home, CertPath))
+	return err == nil
+}
+
+// Login runs `cloudflared tunnel login`, which opens a browser so the
+// user authorizes a Cloudflare account + zone. Returns once cert.pem is
+// on disk or ctx fires.
+func Login(ctx context.Context) error {
+	if err := CheckCloudflared(); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "login") // #nosec G204 -- literal args
+	cmd.Stdout = os.Stderr // cloudflared prints the auth URL; show on TTY
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cloudflared tunnel login: %w", err)
+	}
+	if !HasCloudflaredCert() {
+		return errors.New("cloudflared login completed but ~/.cloudflared/cert.pem missing")
+	}
+	return nil
+}
+
+// tunnelIDPattern picks the tunnel UUID out of `cloudflared tunnel
+// create` output. The line looks roughly like:
+//   Created tunnel buttons with id 1234abcd-...
+var tunnelIDPattern = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+// createOrFindTunnel creates a named tunnel or returns the existing
+// tunnel's UUID if it already exists. Idempotent so re-running setup is
+// safe.
+func createOrFindTunnel(ctx context.Context, name string) (string, error) {
+	// Try list first — faster path if the tunnel already exists.
+	if id, err := findTunnelID(ctx, name); err == nil && id != "" {
+		return id, nil
+	}
+	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "create", name) // #nosec G204
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// "already exists" path — ask list again.
+		if strings.Contains(string(out), "already exists") {
+			if id, e2 := findTunnelID(ctx, name); e2 == nil && id != "" {
+				return id, nil
+			}
+		}
+		return "", fmt.Errorf("cloudflared tunnel create %s: %w\n%s", name, err, string(out))
+	}
+	if m := tunnelIDPattern.FindString(string(out)); m != "" {
+		return m, nil
+	}
+	// Last resort: list.
+	if id, err := findTunnelID(ctx, name); err == nil && id != "" {
+		return id, nil
+	}
+	return "", fmt.Errorf("could not determine tunnel id for %s from:\n%s", name, string(out))
+}
+
+// findTunnelID shells out to `cloudflared tunnel list --output json` and
+// picks the first tunnel matching `name`. `--output json` has been
+// stable in cloudflared for years.
+func findTunnelID(ctx context.Context, name string) (string, error) {
+	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "list", "--output", "json") // #nosec G204
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	var tunnels []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &tunnels); err != nil {
+		return "", fmt.Errorf("parse tunnel list: %w", err)
+	}
+	for _, t := range tunnels {
+		if t.Name == name {
+			return t.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// routeDNS attaches the hostname to the tunnel. Idempotent — repeated
+// calls surface "already exists" on stderr which we treat as success.
+func routeDNS(ctx context.Context, tunnelName, hostname string) error {
+	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "route", "dns", tunnelName, hostname) // #nosec G204
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		combined := string(out)
+		if strings.Contains(combined, "already exists") || strings.Contains(combined, "record with that host") {
+			return nil
+		}
+		return fmt.Errorf("route dns %s → %s: %w\n%s", hostname, tunnelName, err, combined)
+	}
+	return nil
+}
+
+// RunSetup orchestrates the full named-tunnel setup: verify cloudflared,
+// login (unless skipped), create tunnel, route DNS, persist config. It
+// does not prompt — the caller (CLI) handles interactive input.
+func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
+	if opts.Hostname == "" {
+		return nil, errors.New("hostname is required")
+	}
+	if opts.TunnelName == "" {
+		opts.TunnelName = DefaultTunnelName
+	}
+	if err := CheckCloudflared(); err != nil {
+		return nil, err
+	}
+	if !opts.SkipLogin && !HasCloudflaredCert() {
+		if err := Login(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	// 60s cap per cloudflared operation to avoid hanging forever on
+	// network flakes.
+	opCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	id, err := createOrFindTunnel(opCtx, opts.TunnelName)
+	if err != nil {
+		return nil, err
+	}
+	if err := routeDNS(opCtx, opts.TunnelName, opts.Hostname); err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{
+		SchemaVersion: ConfigSchemaVersion,
+		Mode:          ModeNamed,
+		Hostname:      opts.Hostname,
+		TunnelName:    opts.TunnelName,
+		TunnelID:      id,
+	}
+	if err := SaveConfig(cfg); err != nil {
+		return nil, err
+	}
+	return &SetupResult{
+		Hostname:   cfg.Hostname,
+		TunnelName: cfg.TunnelName,
+		TunnelID:   cfg.TunnelID,
+	}, nil
+}

--- a/internal/webhook/signal_unix.go
+++ b/internal/webhook/signal_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package webhook
+
+import (
+	"os"
+	"syscall"
+)
+
+var signalTerm os.Signal = syscall.SIGTERM

--- a/internal/webhook/signal_windows.go
+++ b/internal/webhook/signal_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package webhook
+
+import "os"
+
+// Windows has no SIGTERM; cmd.Process.Kill() is the only option, which
+// Stop() falls back to after the grace period.
+var signalTerm os.Signal = os.Interrupt

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -1,0 +1,250 @@
+package webhook
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Tunnel is a running cloudflared subprocess that exposes a public URL
+// routing to the local Server.
+type Tunnel struct {
+	URL    string   // public https URL agents put into webhook config
+	Mode   Mode     // ModeQuick or ModeNamed
+	cmd    *exec.Cmd
+	done   chan struct{}
+	stderr *strings.Builder // last ~4KB of output, used when we error
+}
+
+// CloudflaredMissingError is returned when the binary isn't on PATH.
+// The CLI uses this to print a clean install hint instead of a stack.
+type CloudflaredMissingError struct{}
+
+func (CloudflaredMissingError) Error() string {
+	return "cloudflared not found on PATH — install via: brew install cloudflared"
+}
+
+// CheckCloudflared returns (nil) if the binary is usable. Uses
+// `cloudflared --version` because it's cheap and side-effect-free.
+func CheckCloudflared() error {
+	if _, err := exec.LookPath("cloudflared"); err != nil {
+		return CloudflaredMissingError{}
+	}
+	return nil
+}
+
+// StartTunnel launches cloudflared in the appropriate mode based on
+// persisted config and waits until a public URL is known or ctx fires.
+func StartTunnel(ctx context.Context, local string) (*Tunnel, error) {
+	if err := CheckCloudflared(); err != nil {
+		return nil, err
+	}
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	if cfg != nil && cfg.Mode == ModeNamed {
+		return startNamed(ctx, local, cfg)
+	}
+	return startQuick(ctx, local)
+}
+
+// quickURLPattern matches the line cloudflared prints when the Quick
+// Tunnel is up. Example:
+//   2026-04-20T12:00:00Z INF |  https://random-words.trycloudflare.com  |
+var quickURLPattern = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
+
+func startQuick(ctx context.Context, local string) (*Tunnel, error) {
+	cmd := exec.Command("cloudflared", "tunnel",
+		"--url", local,
+		"--no-autoupdate",
+	) // #nosec G204 -- arguments are literals + local loopback URL
+	return runTunnel(ctx, cmd, ModeQuick, func(line string) (string, bool) {
+		if m := quickURLPattern.FindString(line); m != "" {
+			return m, true
+		}
+		return "", false
+	}, "")
+}
+
+func startNamed(ctx context.Context, local string, cfg *Config) (*Tunnel, error) {
+	if cfg.TunnelName == "" {
+		return nil, errors.New("named tunnel config missing tunnel_name — run `buttons webhook setup`")
+	}
+	if cfg.Hostname == "" {
+		return nil, errors.New("named tunnel config missing hostname — run `buttons webhook setup`")
+	}
+	cmd := exec.Command("cloudflared", "tunnel",
+		"run",
+		"--url", local,
+		"--no-autoupdate",
+		cfg.TunnelName,
+	) // #nosec G204 -- TunnelName validated by setup flow
+	url := "https://" + cfg.Hostname
+	// For named tunnels we know the URL up front; the "ready" signal
+	// is cloudflared's "Registered tunnel connection" log line.
+	readyPattern := regexp.MustCompile(`(?i)registered tunnel connection|connection.*registered|serving http`)
+	return runTunnel(ctx, cmd, ModeNamed, func(line string) (string, bool) {
+		if readyPattern.MatchString(line) {
+			return url, true
+		}
+		return "", false
+	}, url)
+}
+
+// runTunnel starts the cloudflared subprocess and scans its combined
+// output for a URL-ready signal. detectURL returns (url, true) on the
+// first matching line; fallbackURL supplies a known URL for named-tunnel
+// mode where the detector signals readiness rather than emitting a URL.
+func runTunnel(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	mode Mode,
+	detectURL func(string) (string, bool),
+	fallbackURL string,
+) (*Tunnel, error) {
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start cloudflared: %w", err)
+	}
+
+	t := &Tunnel{
+		cmd:    cmd,
+		Mode:   mode,
+		done:   make(chan struct{}),
+		stderr: &strings.Builder{},
+	}
+
+	urlCh := make(chan string, 1)
+	var once sync.Once
+	emit := func(u string) {
+		once.Do(func() { urlCh <- u })
+	}
+
+	scan := func(r io.Reader) {
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 64*1024), 512*1024)
+		for sc.Scan() {
+			line := sc.Text()
+			// Keep a tail of recent output for error reporting.
+			if t.stderr.Len() > 4096 {
+				t.stderr.Reset()
+			}
+			t.stderr.WriteString(line)
+			t.stderr.WriteByte('\n')
+			if u, ok := detectURL(line); ok {
+				emit(u)
+			}
+		}
+	}
+	go scan(stderr)
+	go scan(stdout)
+	go func() {
+		_ = cmd.Wait()
+		close(t.done)
+	}()
+
+	// First wait for cloudflared to print (or imply) a public URL.
+	urlTimeout := 30 * time.Second
+	var publicURL string
+	select {
+	case u := <-urlCh:
+		publicURL = u
+	case <-time.After(urlTimeout):
+		if fallbackURL != "" {
+			publicURL = fallbackURL
+		} else {
+			_ = t.Stop()
+			return nil, fmt.Errorf("cloudflared did not emit a public URL within %s; last output:\n%s", urlTimeout, t.stderr.String())
+		}
+	case <-t.done:
+		return nil, fmt.Errorf("cloudflared exited before emitting URL; output:\n%s", t.stderr.String())
+	case <-ctx.Done():
+		_ = t.Stop()
+		return nil, ctx.Err()
+	}
+
+	// Cloudflared prints the URL before edge DNS + routing is fully
+	// warm. Poll /healthz until it answers 200 so the URL we return to
+	// the caller is actually usable. Without this, the first request a
+	// drawer step makes often fails with "no such host" or 502.
+	if err := waitForReady(ctx, publicURL, 60*time.Second); err != nil {
+		_ = t.Stop()
+		return nil, fmt.Errorf("tunnel URL %s did not become reachable: %w; last output:\n%s", publicURL, err, t.stderr.String())
+	}
+	t.URL = publicURL
+	return t, nil
+}
+
+// waitForReady polls the tunnel's /healthz endpoint until it returns 2xx
+// or the timeout elapses. Using the local Server's /healthz means we're
+// testing the full chain — edge DNS, CF → local, local handler — not
+// just any part of it.
+func waitForReady(ctx context.Context, publicURL string, total time.Duration) error {
+	deadline := time.Now().Add(total)
+	backoff := 500 * time.Millisecond
+	client := &http.Client{Timeout: 5 * time.Second}
+	var lastErr error
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, publicURL+"/healthz", nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		if backoff < 4*time.Second {
+			backoff *= 2
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("timeout")
+	}
+	return lastErr
+}
+
+// Stop terminates cloudflared. Safe to call multiple times.
+func (t *Tunnel) Stop() error {
+	if t == nil || t.cmd == nil || t.cmd.Process == nil {
+		return nil
+	}
+	_ = t.cmd.Process.Signal(signalTerm)
+	select {
+	case <-t.done:
+	case <-time.After(3 * time.Second):
+		_ = t.cmd.Process.Kill()
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Drawers can now declare a webhook trigger. An incoming POST to the configured path presses the drawer **asynchronously** with the request body/headers/query/method available as `\${inputs.webhook.*}`. Webhooks are the entry point to a flow, not a blocking mid-step — the drawer IS the handler.

- New package `internal/webhook/` manages a `cloudflared` subprocess (quick or named mode) + a local HTTP listener.
- `Drawer.Triggers []Trigger` declares the trigger on disk. Service-level collision detection prevents two drawers from owning the same path.
- New foreground dispatcher `buttons webhook listen` routes POSTs → drawers.

## CLI surface (clustered under `buttons webhook`)

```
buttons webhook setup       # one-time CF login + named tunnel
buttons webhook status      # mode, hostname, cloudflared check
buttons webhook test        # round-trip verify
buttons webhook listen      # foreground dispatcher
buttons webhook logout      # forget named-tunnel config

buttons drawer NAME trigger webhook [PATH] [--secret TOKEN]
buttons drawer NAME press --webhook-body <JSON|@file>   # local dry-run
```

## Two modes, auto-selected

- **quick**: zero setup, ephemeral `*.trycloudflare.com` per run. Good when the service accepts a per-run URL.
- **named**: stable hostname on the user's own Cloudflare account via `buttons webhook setup`. Required when a service wants a fixed URL registered once.

## Agent ergonomics (after a design review)

- **Input shape printed on registration** (stderr + `input_shape[]` in JSON) so agents see exactly what `\${inputs.webhook.body/headers/query/method/path/received_at}` materializes without reading source.
- **`\${webhooks.<drawer-name>}` context var** resolves to another drawer's full public URL. Lets one drawer configure upstream services with another's callback URL — no copy-paste.
- **Webhook URL surfaced everywhere**: `drawer --summary`, `drawer list` (trailing `webhook=` column), and `buttons summary --json` (top-level `webhook` block with `mode`, `hostname`, `base_url`, `routes[]`, `listen_hint`).
- **AGENT.md / SKILL.md / CLAUDE.md updated** — drawer + webhook flows documented so new projects running `buttons init` pick up the full surface.
- **Shared-token validation** via `X-Buttons-Token` header or `?token=` query param.

## Key implementation notes

- Readiness polling: after cloudflared prints a URL, we poll `{url}/healthz` until 200 before returning. Fixes a real race where cloudflared emitted the URL before edge DNS propagated.
- Listener responds `202 Accepted` immediately; drawer presses in a goroutine with a 1h cap. No webhook sender ever blocks on a slow drawer.
- Schema regenerated: `docs/schemas/drawer.schema.json` now has `triggers[]`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green (including drawer unit + integration)
- [x] Smoke tested end-to-end with `--no-tunnel`: drawer create → trigger webhook → listen → POST → drawer pressed → log + 202 response (all in 0ms)
- [ ] Manual: verify `buttons webhook listen` with real cloudflared quick tunnel
- [ ] Manual: verify `buttons webhook setup` → real Cloudflare account → named tunnel → POST round-trip
- [ ] Verify `--webhook-body @fixture.json` dry-run produces the same `\${inputs.webhook.*}` shape as a real POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)