### PR TITLE
fix(webhook): QA review criticals — shutdown drain, readiness token, pending-map leak, tests

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -94,7 +94,10 @@ func runListen(cmd *cobra.Command, args []string) error {
 	// Press context: shared across every in-flight drawer press so
 	// shutdown can cancel all of them at once (cooperative cancel
 	// lands way faster than waiting out the 1h press deadline).
+	// Defer the cancel so early-return paths don't leak the context —
+	// vet flags uncalled cancel functions as a leak risk.
 	pressCtx, cancelPresses := context.WithCancel(context.Background())
+	defer cancelPresses()
 
 	// Readiness token: the tunnel verifier pulls /healthz through the
 	// public URL and matches this token. Closes the "stale DNS

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -91,12 +91,31 @@ func runListen(cmd *cobra.Command, args []string) error {
 	}
 	localURL := fmt.Sprintf("http://%s", ln.Addr().String())
 
+	// Press context: shared across every in-flight drawer press so
+	// shutdown can cancel all of them at once (cooperative cancel
+	// lands way faster than waiting out the 1h press deadline).
+	pressCtx, cancelPresses := context.WithCancel(context.Background())
+
+	// Readiness token: the tunnel verifier pulls /healthz through the
+	// public URL and matches this token. Closes the "stale DNS
+	// pointing elsewhere returns 2xx" gap.
+	readyToken, err := webhook.MintReadyToken()
+	if err != nil {
+		return fmt.Errorf("mint ready token: %w", err)
+	}
+
 	mux := http.NewServeMux()
-	h := &serveHandler{dsvc: dsvc, routes: routes}
+	h := &serveHandler{
+		dsvc:      dsvc,
+		routes:    routes,
+		pressCtx:  pressCtx,
+		cancelAll: cancelPresses,
+	}
 	mux.Handle("/", h)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true,"token":"` + readyToken + `"}`))
 	})
 
 	srv := &http.Server{
@@ -119,7 +138,7 @@ func runListen(cmd *cobra.Command, args []string) error {
 			return handleWebhookErr(err)
 		}
 		tunnelCtx, tunnelCancel := context.WithTimeout(ctx, 90*time.Second)
-		tunnel, err = webhook.StartTunnel(tunnelCtx, localURL)
+		tunnel, err = webhook.StartTunnel(tunnelCtx, localURL, readyToken)
 		tunnelCancel()
 		if err != nil {
 			_ = srv.Shutdown(context.Background())
@@ -146,9 +165,40 @@ func runListen(cmd *cobra.Command, args []string) error {
 	case <-ctx.Done():
 	}
 
+	// Orderly shutdown:
+	//
+	//   1. Stop accepting new connections (srv.Shutdown) — 5s grace.
+	//   2. Wait for in-flight presses up to drainTimeout. Shorter than
+	//      the per-press cap on purpose: operators want Ctrl-C to
+	//      feel responsive, and steps that haven't already observed
+	//      cancellation probably won't.
+	//   3. Cancel every in-flight press (cancelPresses) so any
+	//      remaining goroutines unwind via context.Done and we don't
+	//      leave zombies after runListen returns.
+	const drainTimeout = 30 * time.Second
+
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 	_ = srv.Shutdown(shutdownCtx)
+
+	drained := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		// All presses finished cleanly.
+	case <-time.After(drainTimeout):
+		fmt.Fprintln(os.Stderr, "draining in-flight presses timed out; cancelling remaining work")
+	}
+	cancelPresses()
+	// Short final wait so cancel-triggered goroutines can clean up
+	// before runListen's caller returns (history flush, etc.).
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+	}
 	return nil
 }
 
@@ -236,14 +286,18 @@ func printServeBanner(publicBase string, routes []route, tunnel *webhook.Tunnel)
 }
 
 // serveHandler dispatches incoming POSTs to the drawer registered for
-// the request path. Holds a sync.Mutex around the in-flight count so a
-// graceful shutdown can wait for drawer presses rather than dropping
-// them mid-run.
+// the request path. A WaitGroup tracks in-flight drawer presses so
+// graceful shutdown can actually wait for them to finish instead of
+// abandoning goroutines the moment the HTTP listener closes. The
+// press context is derived from pressCtx so Ctrl-C propagates
+// cooperatively — drawer steps honoring ctx cancellation return
+// promptly rather than hanging until the 1h press deadline.
 type serveHandler struct {
-	dsvc    *drawer.Service
-	routes  []route
-	mu      sync.Mutex
-	inFlight int
+	dsvc      *drawer.Service
+	routes    []route
+	wg        sync.WaitGroup
+	pressCtx  context.Context
+	cancelAll context.CancelFunc
 }
 
 func (h *serveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -353,19 +407,17 @@ func (h *serveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Press asynchronously: respond to the webhook sender right away
 	// with a run id. Most services retry aggressively on slow webhook
 	// responses, and a long-running drawer would block them needlessly.
-	h.mu.Lock()
-	h.inFlight++
-	h.mu.Unlock()
+	//
+	// WaitGroup lets runListen's shutdown path drain in-flight presses
+	// instead of abandoning them.
+	h.wg.Add(1)
 
 	go func() {
-		defer func() {
-			h.mu.Lock()
-			h.inFlight--
-			h.mu.Unlock()
-		}()
-		// Fresh context — not tied to the request (which is about to
-		// close). 1h cap so a hung drawer can't leak forever.
-		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+		defer h.wg.Done()
+		// Derive from h.pressCtx (cancelled on shutdown) with a 1h
+		// cap so a wedged drawer can't leak forever. Steps that honor
+		// ctx observe cancellation and return cleanly.
+		ctx, cancel := context.WithTimeout(h.pressCtx, time.Hour)
 		defer cancel()
 
 		exec := drawer.NewExecutor()

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -253,7 +253,7 @@ func runWebhookTest(cmd *cobra.Command, args []string) error {
 	if !jsonOutput {
 		fmt.Fprintf(os.Stderr, "  Starting tunnel (this takes ~15s)…\n")
 	}
-	t, err := webhook.StartTunnel(ctx, srv.LocalURL())
+	t, err := webhook.StartTunnel(ctx, srv.LocalURL(), srv.ReadyToken())
 	if err != nil {
 		return handleWebhookErr(err)
 	}
@@ -263,6 +263,12 @@ func runWebhookTest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return handleWebhookErr(err)
 	}
+	// Register the waiter BEFORE publishing the URL (spawning the
+	// POST goroutine). Eliminates the "event arrives before Wait
+	// registers" race — no pending-map needed server-side.
+	waiterCh := srv.Register(corr)
+	defer srv.Deregister(corr)
+
 	postURL := fmt.Sprintf("%s/webhook/%s", t.URL, corr)
 
 	if !jsonOutput {
@@ -270,9 +276,8 @@ func runWebhookTest(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  POSTing to %s …\n", postURL)
 	}
 
-	// Fire the test POST in the background; cloudflared sometimes
-	// needs a beat before the first edge request routes, so we retry
-	// with a short backoff.
+	// Fire the test POST in the background. Tunnel readiness is
+	// already verified by StartTunnel's /healthz + token check.
 	delivery := make(chan error, 1)
 	go func() {
 		delivery <- selfPost(ctx, postURL)
@@ -280,7 +285,14 @@ func runWebhookTest(cmd *cobra.Command, args []string) error {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 60*time.Second)
 	defer waitCancel()
-	ev, waitErr := srv.Wait(waitCtx, corr)
+
+	var ev webhook.Event
+	var waitErr error
+	select {
+	case ev = <-waiterCh:
+	case <-waitCtx.Done():
+		waitErr = waitCtx.Err()
+	}
 	if waitErr != nil {
 		postErr := <-delivery
 		return handleWebhookErr(fmt.Errorf("no webhook received within 60s (post err: %v, wait err: %w)", postErr, waitErr))

--- a/internal/webhook/auth_test.go
+++ b/internal/webhook/auth_test.go
@@ -1,0 +1,167 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Guards the four n8n-style auth paths end-to-end. Each test uses a
+// plain httptest request (no tunnel/server) and feeds directly into
+// VerifyAuth so these stay fast and deterministic.
+
+func TestVerifyAuth_NoneAndNil(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	for _, cfg := range []*TriggerAuthConfig{nil, {Type: ""}, {Type: "none"}} {
+		if res := VerifyAuth(cfg, req); !res.OK {
+			t.Errorf("nil/empty/none cfg should pass, got %+v", res)
+		}
+	}
+}
+
+func TestVerifyAuth_BasicHappyPath(t *testing.T) {
+	cfg := &TriggerAuthConfig{Type: "basic", Username: "u", Password: "p"}
+	req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	req.SetBasicAuth("u", "p")
+	if res := VerifyAuth(cfg, req); !res.OK {
+		t.Fatalf("basic should pass with matching creds: %+v", res)
+	}
+}
+
+func TestVerifyAuth_BasicRejects(t *testing.T) {
+	cfg := &TriggerAuthConfig{Type: "basic", Username: "u", Password: "p"}
+	cases := []struct {
+		name      string
+		apply     func(*http.Request)
+		wantCode  string
+		wantStatus int
+	}{
+		{"missing", func(r *http.Request) {}, "AUTH_MISSING", http.StatusUnauthorized},
+		{"wrong_user", func(r *http.Request) { r.SetBasicAuth("x", "p") }, "AUTH_INVALID", http.StatusUnauthorized},
+		{"wrong_pass", func(r *http.Request) { r.SetBasicAuth("u", "x") }, "AUTH_INVALID", http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+			tc.apply(req)
+			res := VerifyAuth(cfg, req)
+			if res.OK {
+				t.Fatalf("should have failed")
+			}
+			if res.Code != tc.wantCode || res.Status != tc.wantStatus {
+				t.Errorf("got %s/%d, want %s/%d", res.Code, res.Status, tc.wantCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestVerifyAuth_HeaderHappyAndMismatch(t *testing.T) {
+	cfg := &TriggerAuthConfig{Type: "header", HeaderName: "X-Token", HeaderValue: "s3cret"}
+	req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Token", "s3cret")
+	if res := VerifyAuth(cfg, req); !res.OK {
+		t.Fatalf("should pass with matching header: %+v", res)
+	}
+	req2, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	req2.Header.Set("X-Token", "wrong")
+	if res := VerifyAuth(cfg, req2); res.OK {
+		t.Fatal("should reject on mismatch")
+	}
+	req3, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	// no header at all
+	res := VerifyAuth(cfg, req3)
+	if res.Code != "AUTH_MISSING" {
+		t.Errorf("expected AUTH_MISSING on header absent, got %s", res.Code)
+	}
+}
+
+func TestVerifyAuth_EnvRefResolution(t *testing.T) {
+	t.Setenv("BUTTONS_TEST_SECRET", "env-val")
+	cfg := &TriggerAuthConfig{Type: "header", HeaderName: "X-Token", HeaderValue: "$ENV{BUTTONS_TEST_SECRET}"}
+	req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Token", "env-val")
+	if res := VerifyAuth(cfg, req); !res.OK {
+		t.Fatalf("env-backed header should match its resolved value, got %+v", res)
+	}
+}
+
+// TestVerifyAuth_JWT runs through a full HS256 signing flow against
+// our verifier using only stdlib primitives so the test doesn't
+// depend on a JWT library the production code deliberately avoids.
+func TestVerifyAuth_JWT(t *testing.T) {
+	secret := "test-secret"
+	token := signHS256Token(t, secret, map[string]any{
+		"iss": "test-issuer",
+		"aud": "test-aud",
+		"exp": time.Now().Add(1 * time.Hour).Unix(),
+	})
+
+	cfg := &TriggerAuthConfig{Type: "jwt", JWTSecret: secret, JWTIssuer: "test-issuer", JWTAudience: "test-aud"}
+	req, _ := http.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	if res := VerifyAuth(cfg, req); !res.OK {
+		t.Fatalf("valid JWT should pass: %+v", res)
+	}
+
+	t.Run("wrong_issuer", func(t *testing.T) {
+		cfg2 := &TriggerAuthConfig{Type: "jwt", JWTSecret: secret, JWTIssuer: "other"}
+		if res := VerifyAuth(cfg2, req); res.OK {
+			t.Fatal("should reject issuer mismatch")
+		}
+	})
+	t.Run("bad_signature", func(t *testing.T) {
+		cfg2 := &TriggerAuthConfig{Type: "jwt", JWTSecret: "different-secret"}
+		if res := VerifyAuth(cfg2, req); res.OK {
+			t.Fatal("should reject signature mismatch")
+		}
+	})
+	t.Run("expired", func(t *testing.T) {
+		expired := signHS256Token(t, secret, map[string]any{
+			"exp": time.Now().Add(-2 * time.Hour).Unix(),
+		})
+		req2, _ := http.NewRequest(http.MethodPost, "/x", nil)
+		req2.Header.Set("Authorization", "Bearer "+expired)
+		cfg2 := &TriggerAuthConfig{Type: "jwt", JWTSecret: secret}
+		res := VerifyAuth(cfg2, req2)
+		if res.OK {
+			t.Fatal("should reject expired")
+		}
+		if !strings.Contains(res.Detail, "expired") {
+			t.Errorf("expected 'expired' in detail, got %q", res.Detail)
+		}
+	})
+	t.Run("missing_bearer", func(t *testing.T) {
+		req2, _ := http.NewRequest(http.MethodPost, "/x", nil)
+		cfg2 := &TriggerAuthConfig{Type: "jwt", JWTSecret: secret}
+		if res := VerifyAuth(cfg2, req2); res.Code != "AUTH_MISSING" {
+			t.Errorf("expected AUTH_MISSING, got %s", res.Code)
+		}
+	})
+}
+
+// signHS256Token builds a minimal JWT using only stdlib so our tests
+// don't rely on golang-jwt/jwt — that's a deliberate avoidance in
+// production code we don't want to undo just for tests.
+func signHS256Token(t *testing.T, secret string, claims map[string]any) string {
+	t.Helper()
+	header := map[string]any{"alg": "HS256", "typ": "JWT"}
+	hb, _ := json.Marshal(header)
+	cb, _ := json.Marshal(claims)
+	h := base64.RawURLEncoding.EncodeToString(hb)
+	c := base64.RawURLEncoding.EncodeToString(cb)
+	signingInput := h + "." + c
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return signingInput + "." + sig
+}
+
+// ensure httptest import used — avoids unused-import break under
+// future refactors that might trim this file.
+var _ = httptest.NewServer

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -29,13 +29,19 @@ type Event struct {
 // Server is the local HTTP receiver for webhook POSTs. One listener per
 // process is enough — we multiplex by correlation id embedded in the
 // URL path (/webhook/<id>).
+//
+// readyToken is a per-process random secret embedded in the /healthz
+// response. The tunnel readiness check fetches /healthz through the
+// public URL and matches the token — this closes the loop through
+// edge DNS + CF → local process and rejects stale DNS pointing
+// somewhere else that happens to return 2xx.
 type Server struct {
-	listener net.Listener
-	http     *http.Server
+	listener   net.Listener
+	http       *http.Server
+	readyToken string
 
 	mu      sync.Mutex
-	waiters map[string]chan Event // correlation id -> delivery channel
-	pending map[string]Event      // id -> event received before Wait() registered
+	waiters map[string]chan Event // correlation id -> delivery channel; callers Register before publishing URL
 }
 
 // NewServer binds on 127.0.0.1 with an OS-picked free port and starts
@@ -46,23 +52,42 @@ func NewServer() (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bind local webhook listener: %w", err)
 	}
+	tokenBytes := make([]byte, 16)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("mint readiness token: %w", err)
+	}
 	s := &Server{
-		listener: ln,
-		waiters:  make(map[string]chan Event),
-		pending:  make(map[string]Event),
+		listener:   ln,
+		readyToken: hex.EncodeToString(tokenBytes),
+		waiters:    make(map[string]chan Event),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook/", s.handleWebhook)
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ok":true}`))
-	})
+	mux.HandleFunc("/healthz", s.handleHealthz)
 	s.http = &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() { _ = s.http.Serve(ln) }()
 	return s, nil
+}
+
+// ReadyToken returns the process-local secret embedded in /healthz
+// responses. Callers pass it to tunnel readiness checks so a 2xx from
+// a hostname pointing at some unrelated origin isn't accepted.
+func (s *Server) ReadyToken() string {
+	return s.readyToken
+}
+
+// handleHealthz serves the readiness token in JSON. Kept separate
+// from the webhook handler so the token surface is minimal and
+// obvious at a glance. CORS not needed — only cloudflared and the
+// drawer dispatcher hit this endpoint.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"ok":true,"token":"` + s.readyToken + `"}`))
 }
 
 // Port returns the randomly-assigned local port.
@@ -86,31 +111,44 @@ func NewCorrelationID() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// Wait blocks until a webhook for the given correlation id arrives or
-// the context fires. If the event was already received before Wait was
-// called, it returns immediately — this is the common case in our drawer
-// flow where Register → return URL → Wait all happen in sequence.
-func (s *Server) Wait(ctx context.Context, correlationID string) (Event, error) {
+// Register creates a waiter channel for the given correlation id and
+// returns it. Callers must call Register BEFORE making the external
+// URL publicly available (e.g. before spawning the POST goroutine in
+// `webhook test`); that way the handler always finds a waiter when
+// the event arrives and we don't need an unbounded pending-map stash.
+// The returned channel is buffered (size 1) so handler delivery
+// always succeeds without blocking.
+//
+// Caller is responsible for calling Deregister (e.g. via defer) if
+// the waiter is never consumed — on ctx cancel, timeout, etc. Without
+// that we'd leak one map entry per abandoned Wait.
+func (s *Server) Register(correlationID string) <-chan Event {
+	ch := make(chan Event, 1)
 	s.mu.Lock()
-	if ev, ok := s.pending[correlationID]; ok {
-		delete(s.pending, correlationID)
-		s.mu.Unlock()
-		return ev, nil
-	}
-	ch, ok := s.waiters[correlationID]
-	if !ok {
-		ch = make(chan Event, 1)
-		s.waiters[correlationID] = ch
-	}
+	s.waiters[correlationID] = ch
 	s.mu.Unlock()
+	return ch
+}
 
+// Deregister removes a correlation id's waiter entry. Safe to call
+// even if the waiter was already consumed (idempotent).
+func (s *Server) Deregister(correlationID string) {
+	s.mu.Lock()
+	delete(s.waiters, correlationID)
+	s.mu.Unlock()
+}
+
+// Wait is a convenience helper: Register + block on the returned
+// channel or ctx.Done, with Deregister on exit. Matches the previous
+// Wait() signature so existing callers compile unchanged — they just
+// get the leak-free Register-first semantics.
+func (s *Server) Wait(ctx context.Context, correlationID string) (Event, error) {
+	ch := s.Register(correlationID)
+	defer s.Deregister(correlationID)
 	select {
 	case ev := <-ch:
 		return ev, nil
 	case <-ctx.Done():
-		s.mu.Lock()
-		delete(s.waiters, correlationID)
-		s.mu.Unlock()
 		return Event{}, ctx.Err()
 	}
 }
@@ -170,16 +208,18 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	if ch, ok := s.waiters[id]; ok {
+	ch, ok := s.waiters[id]
+	if ok {
 		delete(s.waiters, id)
-		s.mu.Unlock()
+	}
+	s.mu.Unlock()
+	if ok {
 		// Non-blocking send; buffer of 1 guarantees success.
 		ch <- ev
-	} else {
-		// Stash for a Wait() that hasn't landed yet.
-		s.pending[id] = ev
-		s.mu.Unlock()
 	}
+	// No waiter registered → drop. Callers must Register before
+	// publishing the URL so this path should be rare; if it happens
+	// it means a stray POST arrived outside any active flow.
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -1,0 +1,151 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewCorrelationID_Uniqueness sanity-checks the random-id helper
+// at scale so a future refactor can't accidentally introduce a
+// collision-prone source (e.g. truncating the byte slice).
+func TestNewCorrelationID_Uniqueness(t *testing.T) {
+	const N = 10_000
+	seen := make(map[string]struct{}, N)
+	for i := 0; i < N; i++ {
+		id, err := NewCorrelationID()
+		if err != nil {
+			t.Fatalf("NewCorrelationID: %v", err)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate id at iteration %d: %s", i, id)
+		}
+		seen[id] = struct{}{}
+		if len(id) != 32 {
+			t.Errorf("expected 32-char hex id, got %d chars", len(id))
+		}
+	}
+}
+
+// TestServer_RegisterBeforeReceive covers the primary flow we care
+// about after dropping the pending map: Register returns a channel,
+// the POST arrives, the channel delivers the event.
+func TestServer_RegisterBeforeReceive(t *testing.T) {
+	srv, err := NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	id := "test-corr-1"
+	ch := srv.Register(id)
+	defer srv.Deregister(id)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond) // simulate external round-trip
+		postTo(t, srv.LocalURL()+"/webhook/"+id, `{"hello":"world"}`)
+	}()
+
+	select {
+	case ev := <-ch:
+		var body map[string]any
+		_ = json.Unmarshal(ev.Body, &body)
+		if body["hello"] != "world" {
+			t.Errorf("unexpected body: %s", string(ev.Body))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for webhook delivery")
+	}
+}
+
+// TestServer_WaitContextCancelled verifies Wait deregisters its
+// waiter on ctx cancel — without that we'd slowly leak the waiters
+// map over any long-running listener session that hits timeouts.
+func TestServer_WaitContextCancelled(t *testing.T) {
+	srv, err := NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = srv.Wait(ctx, "never-delivered")
+	if err == nil {
+		t.Fatal("expected ctx error, got nil")
+	}
+	// Map should be empty after deregister. Peek via Register: if the
+	// id we just cancelled still owned a channel we'd overwrite it,
+	// but with proper cleanup Register starts fresh.
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, still := srv.waiters["never-delivered"]; still {
+		t.Error("cancelled waiter was not cleaned up from the map")
+	}
+}
+
+// TestServer_HandleWebhook_RejectsSlashInID keeps the path parser
+// honest. A request to /webhook/foo/bar should not match correlation
+// id "foo/bar" — it's a clear client error.
+func TestServer_HandleWebhook_RejectsSlashInID(t *testing.T) {
+	srv, err := NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	resp, err := http.Post(srv.LocalURL()+"/webhook/foo/bar", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestServer_Healthz_TokenEmbedded proves the /healthz endpoint
+// returns the readiness token so StartTunnel's waitForReady can
+// distinguish a correctly-tunneled request from a stale-DNS 2xx.
+func TestServer_Healthz_TokenEmbedded(t *testing.T) {
+	srv, err := NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	resp, err := http.Get(srv.LocalURL() + "/healthz")
+	if err != nil {
+		t.Fatalf("get healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK    bool   `json:"ok"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode healthz: %v", err)
+	}
+	if !body.OK {
+		t.Error("expected ok=true in healthz body")
+	}
+	if body.Token == "" || body.Token != srv.ReadyToken() {
+		t.Errorf("token mismatch: body=%q server=%q", body.Token, srv.ReadyToken())
+	}
+}
+
+func postTo(t *testing.T, url, body string) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -3,6 +3,9 @@ package webhook
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -42,8 +45,26 @@ func CheckCloudflared() error {
 }
 
 // StartTunnel launches cloudflared in the appropriate mode based on
-// persisted config and waits until a public URL is known or ctx fires.
-func StartTunnel(ctx context.Context, local string) (*Tunnel, error) {
+// persisted config and blocks until a public URL is known AND the
+// tunnel actually routes back to the caller's local listener — we
+// verify by pulling /healthz through the public URL and matching
+// `readyToken` against the JSON body's `token` field. Without this,
+// a stale DNS record pointing the hostname at some unrelated origin
+// that returns 2xx would pass a naive check.
+//
+// Callers are responsible for serving a /healthz endpoint on
+// `localURL` that returns `{"ok":true,"token":"<readyToken>"}`.
+// webhook.Server does this automatically via ReadyToken(); callers
+// that spin up their own listener (cmd/serve.go's dispatcher) should
+// use MintReadyToken() + wire the returned string into their /healthz
+// handler.
+func StartTunnel(ctx context.Context, localURL, readyToken string) (*Tunnel, error) {
+	if localURL == "" {
+		return nil, errors.New("StartTunnel: localURL required")
+	}
+	if readyToken == "" {
+		return nil, errors.New("StartTunnel: readyToken required (serve /healthz with a matching token)")
+	}
 	if err := CheckCloudflared(); err != nil {
 		return nil, err
 	}
@@ -52,9 +73,22 @@ func StartTunnel(ctx context.Context, local string) (*Tunnel, error) {
 		return nil, err
 	}
 	if cfg != nil && cfg.Mode == ModeNamed {
-		return startNamed(ctx, local, cfg)
+		return startNamed(ctx, localURL, readyToken, cfg)
 	}
-	return startQuick(ctx, local)
+	return startQuick(ctx, localURL, readyToken)
+}
+
+// MintReadyToken returns a fresh unguessable token for use with
+// StartTunnel. Callers that spin up their own HTTP listener (not
+// webhook.Server) embed this in their /healthz JSON body so the
+// tunnel readiness check can prove the tunnel routes back to *them*
+// and not a stale origin.
+func MintReadyToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("mint ready token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // quickURLPattern matches the line cloudflared prints when the Quick
@@ -62,12 +96,12 @@ func StartTunnel(ctx context.Context, local string) (*Tunnel, error) {
 //   2026-04-20T12:00:00Z INF |  https://random-words.trycloudflare.com  |
 var quickURLPattern = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 
-func startQuick(ctx context.Context, local string) (*Tunnel, error) {
+func startQuick(ctx context.Context, local, token string) (*Tunnel, error) {
 	cmd := exec.Command("cloudflared", "tunnel",
 		"--url", local,
 		"--no-autoupdate",
 	) // #nosec G204 -- arguments are literals + local loopback URL
-	return runTunnel(ctx, cmd, ModeQuick, func(line string) (string, bool) {
+	return runTunnel(ctx, cmd, ModeQuick, token, func(line string) (string, bool) {
 		if m := quickURLPattern.FindString(line); m != "" {
 			return m, true
 		}
@@ -75,7 +109,7 @@ func startQuick(ctx context.Context, local string) (*Tunnel, error) {
 	}, "")
 }
 
-func startNamed(ctx context.Context, local string, cfg *Config) (*Tunnel, error) {
+func startNamed(ctx context.Context, local, token string, cfg *Config) (*Tunnel, error) {
 	if cfg.TunnelName == "" {
 		return nil, errors.New("named tunnel config missing tunnel_name — run `buttons webhook setup`")
 	}
@@ -92,7 +126,7 @@ func startNamed(ctx context.Context, local string, cfg *Config) (*Tunnel, error)
 	// For named tunnels we know the URL up front; the "ready" signal
 	// is cloudflared's "Registered tunnel connection" log line.
 	readyPattern := regexp.MustCompile(`(?i)registered tunnel connection|connection.*registered|serving http`)
-	return runTunnel(ctx, cmd, ModeNamed, func(line string) (string, bool) {
+	return runTunnel(ctx, cmd, ModeNamed, token, func(line string) (string, bool) {
 		if readyPattern.MatchString(line) {
 			return url, true
 		}
@@ -108,6 +142,7 @@ func runTunnel(
 	ctx context.Context,
 	cmd *exec.Cmd,
 	mode Mode,
+	readyToken string,
 	detectURL func(string) (string, bool),
 	fallbackURL string,
 ) (*Tunnel, error) {
@@ -183,7 +218,7 @@ func runTunnel(
 	// warm. Poll /healthz until it answers 200 so the URL we return to
 	// the caller is actually usable. Without this, the first request a
 	// drawer step makes often fails with "no such host" or 502.
-	if err := waitForReady(ctx, publicURL, 60*time.Second); err != nil {
+	if err := waitForReady(ctx, publicURL, readyToken, 60*time.Second); err != nil {
 		_ = t.Stop()
 		return nil, fmt.Errorf("tunnel URL %s did not become reachable: %w; last output:\n%s", publicURL, err, t.stderr.String())
 	}
@@ -191,11 +226,11 @@ func runTunnel(
 	return t, nil
 }
 
-// waitForReady polls the tunnel's /healthz endpoint until it returns 2xx
-// or the timeout elapses. Using the local Server's /healthz means we're
-// testing the full chain — edge DNS, CF → local, local handler — not
-// just any part of it.
-func waitForReady(ctx context.Context, publicURL string, total time.Duration) error {
+// waitForReady polls the tunnel's /healthz endpoint until the response
+// body's token field matches the expected readyToken — proving the
+// tunnel actually routes to this process, not some stale origin
+// responding 2xx on /healthz. Times out after `total` wall time.
+func waitForReady(ctx context.Context, publicURL, expectedToken string, total time.Duration) error {
 	deadline := time.Now().Add(total)
 	backoff := 500 * time.Millisecond
 	client := &http.Client{Timeout: 5 * time.Second}
@@ -214,11 +249,40 @@ func waitForReady(ctx context.Context, publicURL string, total time.Duration) er
 		if err != nil {
 			lastErr = err
 		} else {
-			_ = resp.Body.Close()
-			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			func() {
+				defer resp.Body.Close()
+				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+					lastErr = fmt.Errorf("status %d", resp.StatusCode)
+					return
+				}
+				// Cap body read — /healthz payload is tiny; anything
+				// huge means we're talking to the wrong server.
+				body, rerr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+				if rerr != nil {
+					lastErr = fmt.Errorf("read healthz: %w", rerr)
+					return
+				}
+				var payload struct {
+					OK    bool   `json:"ok"`
+					Token string `json:"token"`
+				}
+				if uerr := json.Unmarshal(body, &payload); uerr != nil {
+					lastErr = fmt.Errorf("healthz parse: %w (body=%q)", uerr, string(body))
+					return
+				}
+				if payload.Token == "" {
+					lastErr = fmt.Errorf("healthz missing token (body=%q) — tunnel may be routing to the wrong origin", string(body))
+					return
+				}
+				if payload.Token != expectedToken {
+					lastErr = fmt.Errorf("healthz token mismatch — tunnel is routing to a different process (stale DNS record?)")
+					return
+				}
+				lastErr = nil
+			}()
+			if lastErr == nil {
 				return nil
 			}
-			lastErr = fmt.Errorf("status %d", resp.StatusCode)
 		}
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Closes the four findings from the post-merge QA review of #161.

## What's in

**C1 — in-flight drawer presses were abandoned on Ctrl-C.** \`h.inFlight\` was incremented under a mutex but never read. Replaced with \`sync.WaitGroup\` + shared \`pressCtx\`. Shutdown now drains presses up to 30s then cancels the context so cooperative-cancel goroutines unwind cleanly.

**C3 — \`waitForReady\` over-trusted DNS.** A stale DNS record pointing the tunnel hostname at some other origin that returns 2xx on \`/healthz\` would pass a naive status-only check. Server now mints a per-process random readiness token, embeds it in \`/healthz\` JSON, and \`waitForReady\` parses + matches before accepting the tunnel. \`MintReadyToken()\` exposed for \`cmd/serve.go\` which runs its own mux.

**I1 — \`pending\` map was an unbounded leak.** Dropped entirely. \`Wait()\` reworked as a convenience around explicit \`Register()\`/\`Deregister()\`; callers now register BEFORE publishing the external URL, eliminating the "event arrives before Wait" race that \`pending\` existed to cover.

**P1 — zero tests in \`internal/webhook/\`.** Added coverage for correlation-id uniqueness (10k no-dup), register-before-receive, ctx-cancel waiter cleanup, /webhook path guard, /healthz token contract, all four auth types including env-ref resolution and JWT expired/issuer/signature paths.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all green including 12 new webhook cases
- [ ] Manual: verify Ctrl-C on \`buttons webhook listen\` during an in-flight drawer press drains cleanly
- [ ] Manual: verify the tunnel-readiness check rejects a stale-DNS origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)