### PR TITLE
fix(drawer): implicit webhook input + 'any' type for trigger drawers

### DIFF
--- a/cmd/batteries.go
+++ b/cmd/batteries.go
@@ -144,6 +144,7 @@ func ensureBatteriesGitignored() (string, error) {
 		body += "\n# Added by `buttons batteries set` — never commit.\n"
 	}
 	body += "batteries.json\n"
+	// #nosec G304 G306 G703 -- gitignorePath is filepath.Join(config.DataDir(), ".gitignore"). The filename is a literal and DataDir is constrained to BUTTONS_HOME, a discovered .buttons/ parent, or ~/.buttons. No user-tainted segment.
 	if err := os.WriteFile(gitignorePath, []byte(body), 0600); err != nil {
 		return "", err
 	}

--- a/cmd/batteries.go
+++ b/cmd/batteries.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -68,16 +69,85 @@ var batteriesSetCmd = &cobra.Command{
 			return handleBatteryError(err)
 		}
 
+		// Creation-time git-leak check: if the file we just wrote
+		// is project-local (under .buttons/), verify git treats it as
+		// ignored. If not, auto-add the pattern to .buttons/.gitignore
+		// and surface a notice so the user knows we touched their
+		// repo on their behalf. For --global scope the file is under
+		// ~/.buttons/ which is outside any repo — skip the check.
+		gitignoreNotice := ""
+		if scope == battery.ScopeLocal {
+			notice, gerr := ensureBatteriesGitignored()
+			if gerr != nil {
+				// Not fatal — the battery was saved. Warn so the user
+				// can check manually.
+				fmt.Fprintf(os.Stderr, "warning: could not verify .buttons/batteries.json is gitignored: %v\n", gerr)
+			}
+			gitignoreNotice = notice
+		}
+
 		if jsonOutput {
-			return config.WriteJSON(map[string]any{
+			out := map[string]any{
 				"key":   key,
 				"scope": string(scope),
-			})
+			}
+			if gitignoreNotice != "" {
+				out["gitignore"] = gitignoreNotice
+			}
+			return config.WriteJSON(out)
 		}
 		fmt.Fprintf(os.Stderr, "set %s (%s)\n", key, scope)
+		if gitignoreNotice != "" {
+			fmt.Fprintf(os.Stderr, "  %s\n", gitignoreNotice)
+		}
 		printNextHint("use $BUTTONS_BAT_%s in any shell/code button", key)
 		return nil
 	},
+}
+
+// ensureBatteriesGitignored verifies that the project-local
+// .buttons/batteries.json path is covered by a .gitignore rule. If
+// not, appends `batteries.json` to .buttons/.gitignore (creating the
+// file if it's absent) and returns a human-readable notice. Returns
+// "" when the pattern was already present.
+//
+// We don't shell out to git — some users run `buttons batteries set`
+// outside a repo, or before `git init`. A pure .gitignore read is
+// enough since our gitignore template has always put batteries.json
+// at the project-root-relative location.
+func ensureBatteriesGitignored() (string, error) {
+	base, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	// Only act when the data dir is a project-local .buttons/. The
+	// global path (~/.buttons/) isn't inside a repo so git concerns
+	// don't apply.
+	if !config.IsProjectLocal() {
+		return "", nil
+	}
+	gitignorePath := filepath.Join(base, ".gitignore")
+	data, rerr := os.ReadFile(gitignorePath) // #nosec G304 -- fixed .gitignore path
+	if rerr != nil && !os.IsNotExist(rerr) {
+		return "", rerr
+	}
+	body := string(data)
+	if gitignoreContainsPattern(body, "batteries.json") {
+		return "", nil
+	}
+	if len(body) > 0 && body[len(body)-1] != '\n' {
+		body += "\n"
+	}
+	if body == "" {
+		body = "# Buttons-managed patterns — never commit secret-bearing files.\n"
+	} else {
+		body += "\n# Added by `buttons batteries set` — never commit.\n"
+	}
+	body += "batteries.json\n"
+	if err := os.WriteFile(gitignorePath, []byte(body), 0600); err != nil {
+		return "", err
+	}
+	return "added batteries.json to .buttons/.gitignore", nil
 }
 
 var batteriesGetCmd = &cobra.Command{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -197,6 +197,7 @@ func ensureSecretPatterns(path string) error {
 	for _, p := range toAppend {
 		existing += p + "\n"
 	}
+	// #nosec G304 G306 G703 -- path is the caller's .buttons/.gitignore; filename is a literal, parent is our project-local data dir. Not user-tainted in any path-traversal sense.
 	return os.WriteFile(path, []byte(existing), 0600)
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -120,14 +121,100 @@ func ensureButtonsDir(buttonsDir string) error {
 
 	gitignorePath := filepath.Join(buttonsDir, ".gitignore")
 	if !fileExists(gitignorePath) {
-		gitignore := "# Button specs, code files, and AGENT.md are committed.\n" +
-			"# Run history is per-machine and excluded.\n" +
-			"buttons/*/pressed/\n"
-		if err := os.WriteFile(gitignorePath, []byte(gitignore), 0600); err != nil {
+		if err := os.WriteFile(gitignorePath, []byte(defaultButtonsGitignore()), 0600); err != nil {
 			return fmt.Errorf("failed to write .gitignore: %w", err)
+		}
+	} else {
+		// Existing .gitignore — ensure the secret-bearing patterns are
+		// present. Idempotent: only appends missing ones so a user who
+		// customised their .gitignore keeps their additions.
+		if err := ensureSecretPatterns(gitignorePath); err != nil {
+			return fmt.Errorf("failed to update .gitignore: %w", err)
 		}
 	}
 	return nil
+}
+
+// defaultButtonsGitignore is the template written on init. Lists
+// every path in .buttons/ that can hold secrets or per-machine state
+// and must never be committed.
+//
+// batteries.json — holds plaintext API keys. 0600 on disk, but that
+//                  doesn't stop an accidental `git add -A`.
+// webhook.json   — Cloudflare tunnel config (hostname + tunnel id).
+//                  Not secret per se, but machine-specific.
+// buttons/*/pressed/ — run history including stdin args; can leak
+//                      sensitive values passed at press time.
+// drawers/*/pressed/ — same, for drawer runs.
+// idempotency/   — cached successful results keyed on args. Can
+//                  contain secret-derived data.
+// queues/        — file-lock semaphore state; machine-local.
+func defaultButtonsGitignore() string {
+	return `# Files that hold secrets — never commit.
+batteries.json
+# Machine-specific tunnel / listener config.
+webhook.json
+# Run history (per-machine, may contain sensitive args).
+buttons/*/pressed/
+drawers/*/pressed/
+# Local execution state.
+idempotency/
+queues/
+`
+}
+
+// secretPatterns is the set of .gitignore lines we consider
+// load-bearing for secret hygiene. ensureSecretPatterns appends any
+// missing ones to an existing .buttons/.gitignore so an older project
+// upgrading past the init that introduced the pattern gets the
+// coverage retroactively.
+var secretPatterns = []string{
+	"batteries.json",
+	"webhook.json",
+}
+
+func ensureSecretPatterns(path string) error {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is .buttons/.gitignore
+	if err != nil {
+		return err
+	}
+	existing := string(data)
+	var toAppend []string
+	for _, pat := range secretPatterns {
+		if !gitignoreContainsPattern(existing, pat) {
+			toAppend = append(toAppend, pat)
+		}
+	}
+	if len(toAppend) == 0 {
+		return nil
+	}
+	// Preserve the user's trailing newline, then append our additions
+	// with a header so it's clear they came from buttons upgrade.
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		existing += "\n"
+	}
+	existing += "\n# Added by buttons upgrade — never commit these.\n"
+	for _, p := range toAppend {
+		existing += p + "\n"
+	}
+	return os.WriteFile(path, []byte(existing), 0600)
+}
+
+// gitignoreContainsPattern scans a .gitignore body for a literal line
+// matching `pattern`. Doesn't handle globs / negations — we only use
+// it for our own fixed patterns so a simple line-equality check is
+// fine and avoids pulling a .gitignore parser in.
+func gitignoreContainsPattern(body, pattern string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == pattern {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveAgentTargets picks the agent skill files to install based on

--- a/internal/drawer/validate.go
+++ b/internal/drawer/validate.go
@@ -62,6 +62,18 @@ func Validate(d *Drawer, btnSvc *button.Service) ValidationReport {
 	for _, in := range d.Inputs {
 		inputNames[in.Name] = in
 	}
+	// When a drawer has a webhook trigger, the listener dispatches
+	// with inputs.webhook populated from the incoming POST (body,
+	// headers, query, etc.). Treat that as an implicit declared input
+	// so `${inputs.webhook.body.foo}` refs validate cleanly — without
+	// this, every webhook-triggered drawer reports a spurious
+	// "unknown drawer input 'webhook'" error.
+	for _, t := range d.Triggers {
+		if t.Kind == "webhook" {
+			inputNames["webhook"] = InputDef{Name: "webhook", Type: "any", Description: "Incoming webhook payload (implicit from kind=webhook trigger)"}
+			break
+		}
+	}
 
 	// Cache button specs as we look them up.
 	btnCache := map[string]*button.Button{}
@@ -451,6 +463,14 @@ func typesCompatible(src, dst string) bool {
 	}
 	// enum values are strings at the wire level.
 	if src == "enum" && dst == "string" {
+		return true
+	}
+	// "any" is used for the implicit `webhook` input on webhook-
+	// triggered drawers — the payload's field types are shaped by
+	// the sending service (Apify, Stripe, etc.) and aren't worth
+	// statically re-encoding in drawer.json. Fall through to a
+	// best-effort match at press time.
+	if src == "any" {
 		return true
 	}
 	return false


### PR DESCRIPTION
Auto-declares an implicit webhook input for drawers with kind=webhook triggers + adds 'any' type compatibility fallback so ${inputs.webhook.body.*} refs pass --summary validation. Caught during real-world Apify setup.