### PR TITLE
fix(webhook): 3min readiness timeout for trycloudflare DNS propagation

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -110,13 +110,6 @@ var webhookSetupAllowApex bool
 // delete the existing record manually before retrying.
 var webhookSetupOverwriteDNS bool
 
-// webhookSetupReLogin forces a fresh `cloudflared tunnel login`
-// flow, bypassing the existing ~/.cloudflared/cert.pem. Use when the
-// cert is bound to the wrong Cloudflare account/zone for the target
-// hostname and the automatic zone-drift recovery (on ZoneMismatch)
-// isn't kicking in, or when you want to explicitly re-pick accounts.
-var webhookSetupReLogin bool
-
 // webhookSetupAPIToken and webhookSetupAPIAccountID drive the
 // --api-token code path: setup via CF REST API instead of cert.pem.
 // Token permissions required: Account:Cloudflare Tunnel:Edit and
@@ -250,7 +243,6 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 		Hostname:     hostname,
 		TunnelName:   tunnelName,
 		OverwriteDNS: webhookSetupOverwriteDNS,
-		ForceLogin:   webhookSetupReLogin,
 		APIToken:     apiToken,
 		APIAccountID: webhookSetupAPIAccountID,
 	})
@@ -494,7 +486,6 @@ func init() {
 	webhookSetupCmd.Flags().StringVar(&webhookSetupTunnelName, "tunnel", webhook.DefaultTunnelName, "Cloudflare tunnel name")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupAllowApex, "allow-apex", false, "allow an apex hostname (e.g. example.com); DANGEROUS — overrides root DNS")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupOverwriteDNS, "overwrite-dns", false, "replace any pre-existing Cloudflare DNS record at the hostname; DESTRUCTIVE")
-	webhookSetupCmd.Flags().BoolVar(&webhookSetupReLogin, "re-login", false, "force fresh `cloudflared tunnel login`; use when the current cert.pem is bound to the wrong CF account")
-	webhookSetupCmd.Flags().StringVar(&webhookSetupAPIToken, "api-token", "", "Cloudflare API token (skips cert.pem flow; or set $BUTTONS_CF_API_TOKEN)")
+	webhookSetupCmd.Flags().StringVar(&webhookSetupAPIToken, "api-token", "", "Cloudflare API token (recommended); or set $BUTTONS_CF_API_TOKEN")
 	webhookSetupCmd.Flags().StringVar(&webhookSetupAPIAccountID, "api-account-id", "", "pin the CF account id when the token is authorized on several")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -117,6 +117,15 @@ var webhookSetupOverwriteDNS bool
 // isn't kicking in, or when you want to explicitly re-pick accounts.
 var webhookSetupReLogin bool
 
+// webhookSetupAPIToken and webhookSetupAPIAccountID drive the
+// --api-token code path: setup via CF REST API instead of cert.pem.
+// Token permissions required: Account:Cloudflare Tunnel:Edit and
+// Zone:DNS:Edit on the target zone(s). Also accepts the value from
+// BUTTONS_CF_API_TOKEN so agents/CI never put the token in a
+// process-list-visible argv.
+var webhookSetupAPIToken string
+var webhookSetupAPIAccountID string
+
 // apexLikelyPublicSuffixes covers the common cases where a literal
 // "ccTLD + 1" is still an apex that would break a real website. Not
 // exhaustive (no PSL parse); the guardrail is best-effort — users who
@@ -218,10 +227,21 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 	defer cancel()
 
+	// Resolve API token (here instead of near the RunSetup call so
+	// the banner can mention it). --api-token flag wins; otherwise
+	// pick up $BUTTONS_CF_API_TOKEN so secrets never appear in argv.
+	apiToken := webhookSetupAPIToken
+	if apiToken == "" {
+		apiToken = os.Getenv("BUTTONS_CF_API_TOKEN")
+	}
+
 	if !jsonOutput {
-		if webhook.HasCloudflaredCert() {
+		switch {
+		case apiToken != "":
+			fmt.Fprintln(os.Stderr, "  Using Cloudflare API token (skipping cert.pem flow).")
+		case webhook.HasCloudflaredCert():
 			fmt.Fprintln(os.Stderr, "  Using existing Cloudflare login (~/.cloudflared/cert.pem).")
-		} else {
+		default:
 			fmt.Fprintln(os.Stderr, "  Opening browser for Cloudflare login…")
 		}
 	}
@@ -231,6 +251,8 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 		TunnelName:   tunnelName,
 		OverwriteDNS: webhookSetupOverwriteDNS,
 		ForceLogin:   webhookSetupReLogin,
+		APIToken:     apiToken,
+		APIAccountID: webhookSetupAPIAccountID,
 	})
 	if err != nil {
 		// DNS conflict gets its own error code so agents/scripts can
@@ -473,4 +495,6 @@ func init() {
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupAllowApex, "allow-apex", false, "allow an apex hostname (e.g. example.com); DANGEROUS — overrides root DNS")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupOverwriteDNS, "overwrite-dns", false, "replace any pre-existing Cloudflare DNS record at the hostname; DESTRUCTIVE")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupReLogin, "re-login", false, "force fresh `cloudflared tunnel login`; use when the current cert.pem is bound to the wrong CF account")
+	webhookSetupCmd.Flags().StringVar(&webhookSetupAPIToken, "api-token", "", "Cloudflare API token (skips cert.pem flow; or set $BUTTONS_CF_API_TOKEN)")
+	webhookSetupCmd.Flags().StringVar(&webhookSetupAPIAccountID, "api-account-id", "", "pin the CF account id when the token is authorized on several")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -104,6 +104,12 @@ var webhookSetupTunnelName string
 // root — clobbers their website unless they knew what they were doing.
 var webhookSetupAllowApex bool
 
+// webhookSetupOverwriteDNS is the explicit opt-in for replacing a
+// pre-existing Cloudflare DNS record at the target hostname. Off by
+// default — setup normally surfaces DNS_CONFLICT so the user can
+// delete the existing record manually before retrying.
+var webhookSetupOverwriteDNS bool
+
 // apexLikelyPublicSuffixes covers the common cases where a literal
 // "ccTLD + 1" is still an apex that would break a real website. Not
 // exhaustive (no PSL parse); the guardrail is best-effort — users who
@@ -214,10 +220,23 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 	}
 
 	result, err := webhook.RunSetup(ctx, webhook.SetupOpts{
-		Hostname:   hostname,
-		TunnelName: tunnelName,
+		Hostname:     hostname,
+		TunnelName:   tunnelName,
+		OverwriteDNS: webhookSetupOverwriteDNS,
 	})
 	if err != nil {
+		// DNS conflict gets its own error code so agents/scripts can
+		// distinguish it from generic setup failures and retry with
+		// --overwrite-dns after checking the existing record.
+		var dnsErr *webhook.DNSConflictError
+		if errors.As(err, &dnsErr) {
+			if jsonOutput {
+				_ = config.WriteJSONError("DNS_CONFLICT", err.Error())
+				return errSilent
+			}
+			fmt.Fprintln(os.Stderr, err.Error())
+			return errSilent
+		}
 		return handleWebhookErr(err)
 	}
 
@@ -434,4 +453,5 @@ func init() {
 	webhookSetupCmd.Flags().StringVar(&webhookSetupHostname, "hostname", "", "hostname for webhooks (e.g. webhooks.yourdomain.com)")
 	webhookSetupCmd.Flags().StringVar(&webhookSetupTunnelName, "tunnel", webhook.DefaultTunnelName, "Cloudflare tunnel name")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupAllowApex, "allow-apex", false, "allow an apex hostname (e.g. example.com); DANGEROUS — overrides root DNS")
+	webhookSetupCmd.Flags().BoolVar(&webhookSetupOverwriteDNS, "overwrite-dns", false, "replace any pre-existing Cloudflare DNS record at the hostname; DESTRUCTIVE")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -110,6 +110,13 @@ var webhookSetupAllowApex bool
 // delete the existing record manually before retrying.
 var webhookSetupOverwriteDNS bool
 
+// webhookSetupReLogin forces a fresh `cloudflared tunnel login`
+// flow, bypassing the existing ~/.cloudflared/cert.pem. Use when the
+// cert is bound to the wrong Cloudflare account/zone for the target
+// hostname and the automatic zone-drift recovery (on ZoneMismatch)
+// isn't kicking in, or when you want to explicitly re-pick accounts.
+var webhookSetupReLogin bool
+
 // apexLikelyPublicSuffixes covers the common cases where a literal
 // "ccTLD + 1" is still an apex that would break a real website. Not
 // exhaustive (no PSL parse); the guardrail is best-effort — users who
@@ -223,6 +230,7 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 		Hostname:     hostname,
 		TunnelName:   tunnelName,
 		OverwriteDNS: webhookSetupOverwriteDNS,
+		ForceLogin:   webhookSetupReLogin,
 	})
 	if err != nil {
 		// DNS conflict gets its own error code so agents/scripts can
@@ -235,6 +243,16 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 				return errSilent
 			}
 			fmt.Fprintln(os.Stderr, err.Error())
+			return errSilent
+		}
+		var zmErr *webhook.ZoneMismatchError
+		if errors.As(err, &zmErr) {
+			if jsonOutput {
+				_ = config.WriteJSONError("ZONE_MISMATCH", err.Error())
+				return errSilent
+			}
+			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stderr, "\nTry: /tmp/buttons webhook setup --hostname <HOST> --re-login")
 			return errSilent
 		}
 		return handleWebhookErr(err)
@@ -454,4 +472,5 @@ func init() {
 	webhookSetupCmd.Flags().StringVar(&webhookSetupTunnelName, "tunnel", webhook.DefaultTunnelName, "Cloudflare tunnel name")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupAllowApex, "allow-apex", false, "allow an apex hostname (e.g. example.com); DANGEROUS — overrides root DNS")
 	webhookSetupCmd.Flags().BoolVar(&webhookSetupOverwriteDNS, "overwrite-dns", false, "replace any pre-existing Cloudflare DNS record at the hostname; DESTRUCTIVE")
+	webhookSetupCmd.Flags().BoolVar(&webhookSetupReLogin, "re-login", false, "force fresh `cloudflared tunnel login`; use when the current cert.pem is bound to the wrong CF account")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -98,6 +98,60 @@ var webhookLogoutCmd = &cobra.Command{
 var webhookSetupHostname string
 var webhookSetupTunnelName string
 
+// webhookSetupAllowApex is the explicit opt-in for apex-domain
+// hostnames. Off by default because routing a user's apex (e.g.
+// example.com) through the tunnel overrides every DNS record at the
+// root — clobbers their website unless they knew what they were doing.
+var webhookSetupAllowApex bool
+
+// apexLikelyPublicSuffixes covers the common cases where a literal
+// "ccTLD + 1" is still an apex that would break a real website. Not
+// exhaustive (no PSL parse); the guardrail is best-effort — users who
+// own something unusual can opt out via --allow-apex.
+var apexLikelyPublicSuffixes = []string{
+	".co.uk", ".co.nz", ".com.au", ".com.br", ".co.jp", ".co.in",
+}
+
+// validateWebhookHostname enforces the shape we expect for a webhook
+// hostname: non-empty, dot-containing, and NOT an apex domain by our
+// heuristic. Returns a helpful error pointing at the safe subdomain
+// form when the user typed an apex.
+func validateWebhookHostname(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return errors.New("hostname required")
+	}
+	if !strings.Contains(s, ".") {
+		return errors.New("looks like a bare word — need a full domain like webhooks.example.com")
+	}
+	// Apex heuristic: count dots. "example.com" → 1 dot. A safe
+	// subdomain like "webhooks.example.com" has 2+. ccTLD-style
+	// apexes like "example.co.uk" also have 2 dots but end in a
+	// known multi-part TLD — detect those separately.
+	for _, psl := range apexLikelyPublicSuffixes {
+		if strings.HasSuffix(s, psl) {
+			// Remove the PSL suffix and count dots in the rest.
+			rest := strings.TrimSuffix(s, psl)
+			if !strings.Contains(rest, ".") {
+				return apexHostnameError(s)
+			}
+			return nil
+		}
+	}
+	if strings.Count(s, ".") < 2 {
+		return apexHostnameError(s)
+	}
+	return nil
+}
+
+func apexHostnameError(s string) error {
+	return fmt.Errorf(
+		"hostname %q looks like an apex domain — routing the tunnel here will clobber every DNS record at the root (website, email, etc.). "+
+			"Use a subdomain like webhooks.%s instead. If you really want the apex, re-run with --allow-apex",
+		s, s,
+	)
+}
+
 // runWebhookSetup walks the user through: binary check → cloudflared
 // login if needed → hostname prompt → create + route tunnel → persist.
 func runWebhookSetup(cmd *cobra.Command, args []string) error {
@@ -119,19 +173,10 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 			huh.NewGroup(
 				huh.NewInput().
 					Title("Hostname to receive webhooks").
-					Description("Must be on a zone managed by the Cloudflare account you're about to log in to.\nExample: webhooks.yourdomain.com").
+					Description("Must be on a zone managed by the Cloudflare account you're about to log in to.\n\nUse a SUBDOMAIN like webhooks.yourdomain.com — a bare apex (yourdomain.com) routes\nall root traffic through the tunnel and will clobber any existing website DNS.").
 					Placeholder("webhooks.yourdomain.com").
 					Value(&hostname).
-					Validate(func(s string) error {
-						s = strings.TrimSpace(s)
-						if s == "" {
-							return errors.New("hostname required")
-						}
-						if !strings.Contains(s, ".") {
-							return errors.New("looks like a bare word — need a full domain like webhooks.example.com")
-						}
-						return nil
-					}),
+					Validate(validateWebhookHostname),
 			),
 		).Run(); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
@@ -140,6 +185,18 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 			return handleWebhookErr(err)
 		}
 		hostname = strings.TrimSpace(hostname)
+	}
+	// Non-interactive path runs the same validator so --hostname
+	// autono.co (an apex) gets the same guardrail as the Huh prompt.
+	if err := validateWebhookHostname(hostname); err != nil {
+		if webhookSetupAllowApex && strings.Contains(err.Error(), "apex") {
+			// Opt-in override for users who genuinely want the
+			// tunnel at their apex (e.g. they own the domain solely
+			// for webhook routing). Log prominently.
+			fmt.Fprintf(os.Stderr, "WARNING: proceeding with apex hostname %q — this will clobber any existing DNS at %s. --allow-apex was set.\n", hostname, hostname)
+		} else {
+			return handleWebhookErr(err)
+		}
 	}
 
 	// Login inherits the user's terminal so the browser prompt appears.
@@ -376,4 +433,5 @@ func init() {
 
 	webhookSetupCmd.Flags().StringVar(&webhookSetupHostname, "hostname", "", "hostname for webhooks (e.g. webhooks.yourdomain.com)")
 	webhookSetupCmd.Flags().StringVar(&webhookSetupTunnelName, "tunnel", webhook.DefaultTunnelName, "Cloudflare tunnel name")
+	webhookSetupCmd.Flags().BoolVar(&webhookSetupAllowApex, "allow-apex", false, "allow an apex hostname (e.g. example.com); DANGEROUS — overrides root DNS")
 }

--- a/internal/webhook/cfapi.go
+++ b/internal/webhook/cfapi.go
@@ -1,0 +1,294 @@
+package webhook
+
+// Cloudflare REST API client for the token-based setup path. Lets
+// users bypass cloudflared's cert.pem entirely — they create a
+// scoped API token in the CF dashboard and pass it to
+// `buttons webhook setup --api-token`. Multi-zone capable (one token
+// can be authorized for every zone they own), headless-friendly
+// (no browser), and cleanly scoped (token can be revoked/rotated).
+//
+// Required token permissions:
+//   Account — Cloudflare CFTunnel — Edit
+//   Zone    — DNS               — Edit (on target zones)
+//
+// We implement exactly the four operations needed: resolve account,
+// resolve zone, create tunnel (+ fetch its run-token), create DNS
+// record. Everything else stays with cloudflared.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// cfAPIBase is the production CF REST API root. Tests can override
+// via CFAPIClient.baseURL.
+const cfAPIBase = "https://api.cloudflare.com/client/v4"
+
+// CFAPIClient is a minimal CF API client scoped to the subset we use
+// for webhook setup. One-shot usage; not thread-safe.
+type CFAPIClient struct {
+	token   string
+	baseURL string
+	http    *http.Client
+}
+
+// NewCFAPIClient constructs a client. The 30s timeout covers CF's
+// typical response latency without letting a flaky network leave us
+// hung during `buttons webhook setup`.
+func NewCFAPIClient(token string) *CFAPIClient {
+	return &CFAPIClient{
+		token:   token,
+		baseURL: cfAPIBase,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// cfEnvelope is the CF API's standard response shape. All endpoints
+// return this; the concrete Result gets remarshalled into whatever
+// type the caller expects.
+type cfEnvelope struct {
+	Success  bool              `json:"success"`
+	Errors   []cfError         `json:"errors"`
+	Messages []json.RawMessage `json:"messages"`
+	Result   json.RawMessage   `json:"result"`
+}
+
+type cfError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// do performs an HTTP request against the CF API and unmarshals the
+// Result section into `out`. Returns a CFAPIError with the first
+// error's message + code on non-success.
+func (c *CFAPIClient) do(ctx context.Context, method, path string, body, out any) error {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap — CF responses stay tiny
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	var env cfEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return fmt.Errorf("parse envelope (status %d, body %q): %w", resp.StatusCode, string(data), err)
+	}
+	if !env.Success {
+		if len(env.Errors) > 0 {
+			e := env.Errors[0]
+			return &CFAPIError{Code: e.Code, Message: e.Message, HTTPStatus: resp.StatusCode}
+		}
+		return &CFAPIError{HTTPStatus: resp.StatusCode, Message: fmt.Sprintf("unknown error (status %d)", resp.StatusCode)}
+	}
+	if out == nil || len(env.Result) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(env.Result, out); err != nil {
+		return fmt.Errorf("parse result: %w", err)
+	}
+	return nil
+}
+
+// CFAPIError wraps a Cloudflare API error response. Stable error code
+// from CF's error catalog (e.g. 9109 = invalid permissions) so
+// callers can branch on auth-vs-other failures.
+type CFAPIError struct {
+	Code       int
+	Message    string
+	HTTPStatus int
+}
+
+func (e *CFAPIError) Error() string {
+	if e.Code > 0 {
+		return fmt.Sprintf("cloudflare api: %s (code=%d, http=%d)", e.Message, e.Code, e.HTTPStatus)
+	}
+	return fmt.Sprintf("cloudflare api: %s (http=%d)", e.Message, e.HTTPStatus)
+}
+
+// Account holds the CF account fields we care about: id + name for
+// the picker, and the authorized permissions for sanity-checking at
+// setup time.
+type Account struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListAccounts returns every account the token is authorized on.
+// A well-scoped token usually has exactly one — the user's personal
+// account — but users with multiple accounts (org + personal) could
+// see several and we surface the picker to them.
+func (c *CFAPIClient) ListAccounts(ctx context.Context) ([]Account, error) {
+	var out []Account
+	if err := c.do(ctx, http.MethodGet, "/accounts?per_page=50", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Zone holds CF zone identity. Name is the apex (example.com), ID is
+// the stable UUID we use in every DNS operation.
+type Zone struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// FindZoneForHostname resolves the CF zone a hostname belongs to.
+// Starts with the full hostname and walks up its DNS labels — so
+// "webhook.example.com" resolves against zone "example.com" (common
+// case) or "webhook.example.com" itself (rare, when the subdomain
+// is its own zone).
+//
+// Returns an error if no owned zone covers the hostname — that's
+// actionable: the user needs to add the zone to CF first.
+func (c *CFAPIClient) FindZoneForHostname(ctx context.Context, hostname string) (*Zone, error) {
+	labels := strings.Split(hostname, ".")
+	for i := 0; i < len(labels)-1; i++ { // stop before the TLD
+		candidate := strings.Join(labels[i:], ".")
+		var out []Zone
+		if err := c.do(ctx, http.MethodGet, "/zones?name="+candidate+"&per_page=1", nil, &out); err != nil {
+			return nil, err
+		}
+		if len(out) == 1 {
+			return &out[0], nil
+		}
+	}
+	return nil, fmt.Errorf("no Cloudflare zone covering %q is authorized on this API token — add the domain to CF (or grant Zone:Read to the token) and retry", hostname)
+}
+
+// CFTunnel is the CF API's cfd_tunnel result type, trimmed to fields
+// we use downstream.
+type CFTunnel struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	AccountID string    `json:"account_tag"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CreateOrFindTunnel creates a named tunnel on the given account or
+// reuses an existing one if a tunnel with the same name is still
+// alive. The tunnel-secret is a random 32-byte base64 string — CF
+// accepts anything they haven't seen, so we generate fresh every
+// create (harmless on reuse-branch since we discard it).
+func (c *CFAPIClient) CreateOrFindTunnel(ctx context.Context, accountID, name string) (*CFTunnel, error) {
+	// Reuse existing by name first — idempotent setup.
+	var existing []CFTunnel
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/accounts/%s/cfd_tunnel?name=%s&is_deleted=false&per_page=1", accountID, name), nil, &existing); err != nil {
+		return nil, err
+	}
+	if len(existing) == 1 {
+		return &existing[0], nil
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, fmt.Errorf("generate tunnel secret: %w", err)
+	}
+	body := map[string]any{
+		"name":          name,
+		"tunnel_secret": base64.StdEncoding.EncodeToString(secret),
+		"config_src":    "local",
+	}
+	var out CFTunnel
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/accounts/%s/cfd_tunnel", accountID), body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CFTunnelToken fetches the run-token for an existing tunnel. This is
+// the base64-encoded credential you pass to `cloudflared tunnel run
+// --token <TOKEN>` — no cert.pem needed. Scope matches the tunnel
+// (can't run a different tunnel, can't touch DNS).
+func (c *CFAPIClient) TunnelToken(ctx context.Context, accountID, tunnelID string) (string, error) {
+	var out string
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/accounts/%s/cfd_tunnel/%s/token", accountID, tunnelID), nil, &out); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// CreateDNSRecord creates a proxied CNAME at `name` pointing at
+// `<tunnelID>.cfargotunnel.com` — the same target `cloudflared
+// tunnel route dns` uses internally. `overwrite=true` deletes a
+// conflicting existing record first; false returns DNSConflictError.
+func (c *CFAPIClient) CreateDNSRecord(ctx context.Context, zoneID, name, tunnelID string, overwrite bool) error {
+	target := tunnelID + ".cfargotunnel.com"
+	// Pre-check: does a record already exist at this name?
+	var existing []struct {
+		ID      string `json:"id"`
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/zones/%s/dns_records?name=%s&per_page=1", zoneID, name), nil, &existing); err != nil {
+		return err
+	}
+	if len(existing) == 1 {
+		cur := existing[0]
+		// Already pointing at this exact tunnel → idempotent success.
+		if cur.Type == "CNAME" && cur.Content == target {
+			return nil
+		}
+		if !overwrite {
+			return &DNSConflictError{
+				Hostname:   name,
+				TunnelName: tunnelID,
+				Raw:        fmt.Sprintf("record %s at %s → %s already exists (type=%s content=%q)", cur.ID, name, target, cur.Type, cur.Content),
+			}
+		}
+		if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/zones/%s/dns_records/%s", zoneID, cur.ID), nil, nil); err != nil {
+			return fmt.Errorf("delete existing record %s: %w", cur.ID, err)
+		}
+	}
+	body := map[string]any{
+		"type":    "CNAME",
+		"name":    name,
+		"content": target,
+		"proxied": true,
+		"ttl":     1, // 1 = automatic; required for proxied records
+	}
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", zoneID), body, nil)
+}
+
+// CFAPIAuthError is returned when the token is missing required
+// permissions. Separated so the CLI can point at the exact token-
+// scope fix.
+type CFAPIAuthError struct {
+	Missing string
+	Raw     error
+}
+
+func (e *CFAPIAuthError) Error() string {
+	return fmt.Sprintf("cloudflare api token is missing permission %q: %v", e.Missing, e.Raw)
+}
+
+func (e *CFAPIAuthError) Unwrap() error { return e.Raw }
+
+// Stop linter complaint on an imported-but-conditionally-used module.
+var _ = errors.New

--- a/internal/webhook/config.go
+++ b/internal/webhook/config.go
@@ -49,6 +49,12 @@ type Config struct {
 	Hostname      string `json:"hostname,omitempty"`
 	TunnelName    string `json:"tunnel_name,omitempty"`
 	TunnelID      string `json:"tunnel_id,omitempty"`
+	// TunnelToken is the opaque base64 credential `cloudflared
+	// tunnel run --token <X>` expects. Populated when setup used the
+	// --api-token path (CF REST API). When non-empty, the listener
+	// runs tunnel-via-token instead of tunnel-via-name so cert.pem
+	// isn't required at runtime.
+	TunnelToken string `json:"tunnel_token,omitempty"`
 }
 
 // ConfigPath returns ~/.buttons/webhook.json using the standard data

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -39,6 +39,15 @@ type SetupOpts struct {
 	// ZoneMismatchError. CLI / test convenience; production callers
 	// leave this false so zone-drift self-heals.
 	NoAutoRelogin bool
+	// APIToken, when non-empty, skips the cloudflared-based flow
+	// entirely and uses the CF REST API: list accounts, resolve
+	// zone, create tunnel, mint token, create DNS. Multi-zone
+	// capable, headless-friendly, no browser.
+	APIToken string
+	// APIAccountID optionally pins a specific CF account when the
+	// token is authorized on several. Empty = auto-pick if a single
+	// account is authorized, error out otherwise (caller prompts).
+	APIAccountID string
 }
 
 // SetupResult reports what got persisted so the CLI can render a clean
@@ -276,6 +285,16 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	if opts.TunnelName == "" {
 		opts.TunnelName = DefaultTunnelName
 	}
+	// --api-token path: full setup via CF REST API, no cert.pem.
+	// cloudflared is still needed at listener-time to run the data
+	// plane (we don't re-implement the tunnel proxy), but it's used
+	// in token mode (`tunnel run --token <T>`), not cert mode.
+	if opts.APIToken != "" {
+		if err := CheckCloudflared(); err != nil {
+			return nil, err
+		}
+		return runSetupViaAPI(ctx, opts)
+	}
 	if err := CheckCloudflared(); err != nil {
 		return nil, err
 	}
@@ -332,6 +351,81 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 		Hostname:      opts.Hostname,
 		TunnelName:    opts.TunnelName,
 		TunnelID:      id,
+	}
+	if err := SaveConfig(cfg); err != nil {
+		return nil, err
+	}
+	return &SetupResult{
+		Hostname:   cfg.Hostname,
+		TunnelName: cfg.TunnelName,
+		TunnelID:   cfg.TunnelID,
+	}, nil
+}
+
+// runSetupViaAPI implements the --api-token path. All work goes
+// through the CF REST API; cloudflared is only invoked at listener-
+// time and only in --token mode. Returns the same SetupResult shape
+// so the CLI handler doesn't branch.
+func runSetupViaAPI(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
+	api := NewCFAPIClient(opts.APIToken)
+
+	// 1. Account — pin if caller specified, otherwise pick the only
+	// one the token sees. Multiple accounts + no pin = fail; caller
+	// (CLI) handles the prompt in a separate pass.
+	accountID := opts.APIAccountID
+	if accountID == "" {
+		accounts, err := api.ListAccounts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list accounts (check token has Account:Read): %w", err)
+		}
+		switch len(accounts) {
+		case 0:
+			return nil, errors.New("token isn't authorized on any Cloudflare account")
+		case 1:
+			accountID = accounts[0].ID
+		default:
+			ids := make([]string, 0, len(accounts))
+			for _, a := range accounts {
+				ids = append(ids, fmt.Sprintf("  %s  %s", a.ID, a.Name))
+			}
+			return nil, fmt.Errorf("token is authorized on %d accounts — pick one with --api-account-id:\n%s", len(accounts), strings.Join(ids, "\n"))
+		}
+	}
+
+	// 2. Zone — walk up labels until a matching authorized zone shows
+	// up. Errors surface the "add this domain to CF first" remediation.
+	zone, err := api.FindZoneForHostname(ctx, opts.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Tunnel — create or reuse by name.
+	tun, err := api.CreateOrFindTunnel(ctx, accountID, opts.TunnelName)
+	if err != nil {
+		return nil, fmt.Errorf("create tunnel (check token has Account:Cloudflare Tunnel:Edit): %w", err)
+	}
+
+	// 4. Token for `cloudflared tunnel run --token <X>`. Fetching
+	// here so the listener never needs the API token at runtime —
+	// config stores only the tunnel-scoped credential.
+	token, err := api.TunnelToken(ctx, accountID, tun.ID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tunnel token: %w", err)
+	}
+
+	// 5. DNS — create CNAME → <tunnel>.cfargotunnel.com. Honors
+	// OverwriteDNS; returns DNSConflictError otherwise.
+	if err := api.CreateDNSRecord(ctx, zone.ID, opts.Hostname, tun.ID, opts.OverwriteDNS); err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{
+		SchemaVersion: ConfigSchemaVersion,
+		Mode:          ModeNamed,
+		Hostname:      opts.Hostname,
+		TunnelName:    tun.Name,
+		TunnelID:      tun.ID,
+		TunnelToken:   token,
 	}
 	if err := SaveConfig(cfg); err != nil {
 		return nil, err

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -26,6 +26,11 @@ type SetupOpts struct {
 	// SkipLogin assumes `cloudflared tunnel login` has already been run
 	// on this machine. Used by the CLI after it confirms ~/.cloudflared/cert.pem exists.
 	SkipLogin bool
+	// OverwriteDNS authorises routeDNS to pass --overwrite-dns to
+	// cloudflared, replacing any pre-existing record at Hostname.
+	// Off by default — the safe fallback is to surface a
+	// DNSConflictError and let the user decide.
+	OverwriteDNS bool
 }
 
 // SetupResult reports what got persisted so the CLI can render a clean
@@ -130,15 +135,55 @@ func findTunnelID(ctx context.Context, name string) (string, error) {
 	return "", nil
 }
 
-// routeDNS attaches the hostname to the tunnel. Idempotent — repeated
-// calls surface "already exists" on stderr which we treat as success.
-func routeDNS(ctx context.Context, tunnelName, hostname string) error {
-	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "route", "dns", tunnelName, hostname) // #nosec G204
+// DNSConflictError is returned by routeDNS when Cloudflare already has
+// a record at the target hostname that's not the tunnel's. Callers
+// surface this to the user verbatim so they can decide whether to
+// delete the existing record (safe) or re-run setup with
+// --overwrite-dns (destructive).
+type DNSConflictError struct {
+	Hostname   string
+	TunnelName string
+	Raw        string // stderr from cloudflared for diagnostics
+}
+
+func (e *DNSConflictError) Error() string {
+	return fmt.Sprintf(
+		"a DNS record already exists at %s and is not pointing at tunnel %q. "+
+			"Setup refuses to overwrite unowned records.\n\n"+
+			"To proceed, either:\n"+
+			"  • delete the existing record in your Cloudflare dashboard, then re-run setup, or\n"+
+			"  • re-run setup with --overwrite-dns to replace it (DESTRUCTIVE — point-of-no-return)\n\n"+
+			"cloudflared output:\n%s",
+		e.Hostname, e.TunnelName, e.Raw,
+	)
+}
+
+// routeDNS attaches the hostname to the tunnel. By default it refuses
+// to overwrite a pre-existing Cloudflare DNS record — surfaces a
+// DNSConflictError so the CLI can print actionable remediation. Pass
+// overwrite=true to run with --overwrite-dns (destructive).
+//
+// The idempotent "setup twice with the same hostname and tunnel"
+// case is handled correctly without --overwrite: cloudflared's
+// "already exists" error fires in both the "record points at us
+// already" and "record belongs to someone else" cases, and we can't
+// tell them apart from the exit code alone. We conservatively treat
+// ALL already-exists responses as a conflict — that's the safer
+// default. Users re-running setup after a successful initial run
+// should see the error and either confirm with --overwrite-dns or
+// recognise their config is already good and move on.
+func routeDNS(ctx context.Context, tunnelName, hostname string, overwrite bool) error {
+	args := []string{"tunnel", "route", "dns"}
+	if overwrite {
+		args = append(args, "--overwrite-dns")
+	}
+	args = append(args, tunnelName, hostname)
+	cmd := exec.CommandContext(ctx, "cloudflared", args...) // #nosec G204 -- static flags + validated tunnelName/hostname
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		combined := string(out)
 		if strings.Contains(combined, "already exists") || strings.Contains(combined, "record with that host") {
-			return nil
+			return &DNSConflictError{Hostname: hostname, TunnelName: tunnelName, Raw: combined}
 		}
 		return fmt.Errorf("route dns %s → %s: %w\n%s", hostname, tunnelName, err, combined)
 	}
@@ -173,7 +218,7 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := routeDNS(opCtx, opts.TunnelName, opts.Hostname); err != nil {
+	if err := routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -31,14 +31,6 @@ type SetupOpts struct {
 	// Off by default — the safe fallback is to surface a
 	// DNSConflictError and let the user decide.
 	OverwriteDNS bool
-	// ForceLogin wipes ~/.cloudflared/cert.pem and re-runs `tunnel
-	// login` so the user can pick a different Cloudflare account.
-	// Matches the CLI's --re-login flag.
-	ForceLogin bool
-	// NoAutoRelogin disables the implicit re-auth path that fires on
-	// ZoneMismatchError. CLI / test convenience; production callers
-	// leave this false so zone-drift self-heals.
-	NoAutoRelogin bool
 	// APIToken, when non-empty, skips the cloudflared-based flow
 	// entirely and uses the CF REST API: list accounts, resolve
 	// zone, create tunnel, mint token, create DNS. Multi-zone
@@ -62,22 +54,6 @@ type SetupResult struct {
 // We never read it — we only check existence so the CLI can decide
 // whether to trigger the login step.
 const CertPath = "cert.pem"
-
-// resetCloudflaredCert deletes ~/.cloudflared/cert.pem so a subsequent
-// Login() re-opens the browser and lets the user pick a different
-// Cloudflare account. Missing file is not an error — target state is
-// "no cert" either way.
-func resetCloudflaredCert() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	path := fmt.Sprintf("%s/.cloudflared/%s", home, CertPath)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
-}
 
 // HasCloudflaredCert returns true when ~/.cloudflared/cert.pem exists,
 // which is cloudflared's indicator that `tunnel login` has run.
@@ -251,9 +227,9 @@ type ZoneMismatchError struct {
 func (e *ZoneMismatchError) Error() string {
 	return fmt.Sprintf(
 		"zone mismatch: asked cloudflared to route %q but it created %q instead. "+
-			"Your cloudflared login is authorized for a different zone than %q's base domain. "+
-			"Re-run `cloudflared tunnel login` (or pass --re-login) and pick the Cloudflare account that owns %q.",
-		e.Requested, e.Effective, e.Requested, e.Requested,
+			"cloudflared's existing login is authorized for a different zone than %q's base domain. "+
+			"Re-run setup with --api-token (create one at https://dash.cloudflare.com/profile/api-tokens with Account:Cloudflare Tunnel:Edit + Zone:DNS:Edit) — the token path handles multi-zone cleanly without touching ~/.cloudflared/.",
+		e.Requested, e.Effective, e.Requested,
 	)
 }
 
@@ -298,14 +274,6 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	if err := CheckCloudflared(); err != nil {
 		return nil, err
 	}
-	// ForceLogin wipes cert.pem and re-authenticates so the user can
-	// pick a different CF account. Used by the --re-login flag for
-	// cases where the existing cert is bound to the wrong zone.
-	if opts.ForceLogin {
-		if err := resetCloudflaredCert(); err != nil {
-			return nil, fmt.Errorf("reset cloudflared cert: %w", err)
-		}
-	}
 	if !opts.SkipLogin && !HasCloudflaredCert() {
 		if err := Login(ctx); err != nil {
 			return nil, err
@@ -321,27 +289,9 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS)
-	// Auto-recover from zone-mismatch: the existing cert is authorized
-	// for a different zone. Delete it, re-login, retry routeDNS once.
-	// Skip when --re-login was already tried (infinite loop guard) or
-	// when caller asked not to auto-retry.
-	if zmErr := (*ZoneMismatchError)(nil); errors.As(err, &zmErr) && !opts.ForceLogin && !opts.NoAutoRelogin {
-		if err := resetCloudflaredCert(); err != nil {
-			return nil, fmt.Errorf("zone mismatch on %q — tried to reset cert.pem for re-auth but: %w", opts.Hostname, err)
-		}
-		if err := Login(ctx); err != nil {
-			return nil, fmt.Errorf("zone mismatch on %q — cert.pem cleared; re-login failed: %w", opts.Hostname, err)
-		}
-		// Fresh cert → the tunnel itself may now belong to a different
-		// account. Re-discover it.
-		id, err = createOrFindTunnel(opCtx, opts.TunnelName)
-		if err != nil {
-			return nil, err
-		}
-		err = routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS)
-	}
-	if err != nil {
+	if err := routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS); err != nil {
+		// Zone mismatch surfaces as-is; the CLI maps it to a clear
+		// remediation pointing at --api-token (no cert.pem touching).
 		return nil, err
 	}
 

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -31,6 +31,14 @@ type SetupOpts struct {
 	// Off by default — the safe fallback is to surface a
 	// DNSConflictError and let the user decide.
 	OverwriteDNS bool
+	// ForceLogin wipes ~/.cloudflared/cert.pem and re-runs `tunnel
+	// login` so the user can pick a different Cloudflare account.
+	// Matches the CLI's --re-login flag.
+	ForceLogin bool
+	// NoAutoRelogin disables the implicit re-auth path that fires on
+	// ZoneMismatchError. CLI / test convenience; production callers
+	// leave this false so zone-drift self-heals.
+	NoAutoRelogin bool
 }
 
 // SetupResult reports what got persisted so the CLI can render a clean
@@ -45,6 +53,22 @@ type SetupResult struct {
 // We never read it — we only check existence so the CLI can decide
 // whether to trigger the login step.
 const CertPath = "cert.pem"
+
+// resetCloudflaredCert deletes ~/.cloudflared/cert.pem so a subsequent
+// Login() re-opens the browser and lets the user pick a different
+// Cloudflare account. Missing file is not an error — target state is
+// "no cert" either way.
+func resetCloudflaredCert() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("%s/.cloudflared/%s", home, CertPath)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
 
 // HasCloudflaredCert returns true when ~/.cloudflared/cert.pem exists,
 // which is cloudflared's indicator that `tunnel login` has run.
@@ -180,14 +204,66 @@ func routeDNS(ctx context.Context, tunnelName, hostname string, overwrite bool) 
 	args = append(args, tunnelName, hostname)
 	cmd := exec.CommandContext(ctx, "cloudflared", args...) // #nosec G204 -- static flags + validated tunnelName/hostname
 	out, err := cmd.CombinedOutput()
+	combined := string(out)
 	if err != nil {
-		combined := string(out)
 		if strings.Contains(combined, "already exists") || strings.Contains(combined, "record with that host") {
 			return &DNSConflictError{Hostname: hostname, TunnelName: tunnelName, Raw: combined}
 		}
 		return fmt.Errorf("route dns %s → %s: %w\n%s", hostname, tunnelName, err, combined)
 	}
+	// Zone-drift detection. When the requested hostname's base
+	// domain isn't in the zone authorized by cert.pem, the CF API
+	// silently appends the authorized zone as a suffix (see
+	// cloudflared issue #1295). cloudflared's success line reports
+	// the EFFECTIVE hostname; if it differs from what we asked for,
+	// the caller's tunnel is wired to the wrong hostname and nothing
+	// they do after this will work.
+	if effective := parseEffectiveHostname(combined); effective != "" && effective != hostname {
+		return &ZoneMismatchError{
+			Requested: hostname,
+			Effective: effective,
+			Raw:       combined,
+		}
+	}
 	return nil
+}
+
+// ZoneMismatchError is returned when cloudflared silently re-routes a
+// DNS call to a hostname under the cert's authorized zone, appending
+// the zone as a suffix — the cloudflared #1295 bug. The caller (CLI)
+// maps this to a clear "your cert is authorized for zone X but you
+// asked for Y; re-auth?" prompt.
+type ZoneMismatchError struct {
+	Requested string
+	Effective string
+	Raw       string
+}
+
+func (e *ZoneMismatchError) Error() string {
+	return fmt.Sprintf(
+		"zone mismatch: asked cloudflared to route %q but it created %q instead. "+
+			"Your cloudflared login is authorized for a different zone than %q's base domain. "+
+			"Re-run `cloudflared tunnel login` (or pass --re-login) and pick the Cloudflare account that owns %q.",
+		e.Requested, e.Effective, e.Requested, e.Requested,
+	)
+}
+
+// parseEffectiveHostname picks the hostname cloudflared reported in
+// its success line out of its combined output. Two line formats
+// exist across cloudflared versions:
+//
+//   <HOST> is already configured to route to your tunnel ...
+//   <HOST> is now configured to route to your tunnel ...
+//
+// Returns "" when no match is found (shouldn't happen on success).
+var effectiveHostRe = regexp.MustCompile(`([A-Za-z0-9][A-Za-z0-9.\-]*)\s+is\s+(?:already|now)\s+configured\s+to\s+route`)
+
+func parseEffectiveHostname(combined string) string {
+	m := effectiveHostRe.FindStringSubmatch(combined)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSuffix(m[1], ".")
 }
 
 // RunSetup orchestrates the full named-tunnel setup: verify cloudflared,
@@ -202,6 +278,14 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	}
 	if err := CheckCloudflared(); err != nil {
 		return nil, err
+	}
+	// ForceLogin wipes cert.pem and re-authenticates so the user can
+	// pick a different CF account. Used by the --re-login flag for
+	// cases where the existing cert is bound to the wrong zone.
+	if opts.ForceLogin {
+		if err := resetCloudflaredCert(); err != nil {
+			return nil, fmt.Errorf("reset cloudflared cert: %w", err)
+		}
 	}
 	if !opts.SkipLogin && !HasCloudflaredCert() {
 		if err := Login(ctx); err != nil {
@@ -218,7 +302,27 @@ func RunSetup(ctx context.Context, opts SetupOpts) (*SetupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS); err != nil {
+	err = routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS)
+	// Auto-recover from zone-mismatch: the existing cert is authorized
+	// for a different zone. Delete it, re-login, retry routeDNS once.
+	// Skip when --re-login was already tried (infinite loop guard) or
+	// when caller asked not to auto-retry.
+	if zmErr := (*ZoneMismatchError)(nil); errors.As(err, &zmErr) && !opts.ForceLogin && !opts.NoAutoRelogin {
+		if err := resetCloudflaredCert(); err != nil {
+			return nil, fmt.Errorf("zone mismatch on %q — tried to reset cert.pem for re-auth but: %w", opts.Hostname, err)
+		}
+		if err := Login(ctx); err != nil {
+			return nil, fmt.Errorf("zone mismatch on %q — cert.pem cleared; re-login failed: %w", opts.Hostname, err)
+		}
+		// Fresh cert → the tunnel itself may now belong to a different
+		// account. Re-discover it.
+		id, err = createOrFindTunnel(opCtx, opts.TunnelName)
+		if err != nil {
+			return nil, err
+		}
+		err = routeDNS(opCtx, opts.TunnelName, opts.Hostname, opts.OverwriteDNS)
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -218,9 +218,16 @@ func runTunnel(
 	// warm. Poll /healthz until it answers 200 so the URL we return to
 	// the caller is actually usable. Without this, the first request a
 	// drawer step makes often fails with "no such host" or 502.
-	if err := waitForReady(ctx, publicURL, readyToken, 60*time.Second); err != nil {
+	// Quick tunnels can take 1–3 minutes for the ephemeral
+	// *.trycloudflare.com subdomain to resolve through the caller's
+	// local DNS resolver, even after the edge connection is already
+	// "Registered". Named tunnels are usually instant (the hostname
+	// already exists in the user's own CF zone). 3-minute cap covers
+	// the slowest quick-tunnel DNS propagation we've observed without
+	// silently hanging forever on a truly broken tunnel.
+	if err := waitForReady(ctx, publicURL, readyToken, 3*time.Minute); err != nil {
 		_ = t.Stop()
-		return nil, fmt.Errorf("tunnel URL %s did not become reachable: %w; last output:\n%s", publicURL, err, t.stderr.String())
+		return nil, fmt.Errorf("tunnel URL %s did not become reachable: %w\n\nIf this was a DNS-propagation timeout, try `buttons webhook setup` to provision a stable named tunnel on your own CF account — the hostname resolves instantly because it lives in your zone.\n\nLast cloudflared output:\n%s", publicURL, err, t.stderr.String())
 	}
 	t.URL = publicURL
 	return t, nil

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -111,22 +111,40 @@ func startQuick(ctx context.Context, local, token string) (*Tunnel, error) {
 }
 
 func startNamed(ctx context.Context, local, token string, cfg *Config) (*Tunnel, error) {
-	if cfg.TunnelName == "" {
-		return nil, errors.New("named tunnel config missing tunnel_name — run `buttons webhook setup`")
-	}
 	if cfg.Hostname == "" {
 		return nil, errors.New("named tunnel config missing hostname — run `buttons webhook setup`")
 	}
-	// cloudflared 2026.x treats --no-autoupdate as a top-level flag;
-	// passing it to `tunnel run` makes the subcommand print usage
-	// help and exit 2, which our caller surfaces as "cloudflared
-	// exited before emitting URL". Put it before the `tunnel` verb.
-	cmd := exec.Command("cloudflared",
-		"--no-autoupdate",
-		"tunnel", "run",
-		"--url", local,
-		cfg.TunnelName,
-	) // #nosec G204 -- TunnelName validated by setup flow
+	// Two runtime auth modes:
+	//
+	//   TunnelToken set (from --api-token setup):
+	//     cloudflared tunnel run --token <T> — tunnel-scoped credential
+	//     baked into the token, no cert.pem required. Headless-friendly.
+	//
+	//   TunnelName set (from cert.pem-based setup):
+	//     cloudflared tunnel run --url <LOCAL> <NAME> — classic path,
+	//     relies on ~/.cloudflared/cert.pem + <tunnel-uuid>.json
+	//     credentials file from the `tunnel create` step.
+	var cmd *exec.Cmd
+	switch {
+	case cfg.TunnelToken != "":
+		// #nosec G204 -- TunnelToken is an opaque credential we wrote ourselves; not user-templated at command time
+		cmd = exec.Command("cloudflared",
+			"--no-autoupdate",
+			"tunnel", "run",
+			"--url", local,
+			"--token", cfg.TunnelToken,
+		)
+	case cfg.TunnelName != "":
+		// #nosec G204 -- TunnelName validated by setup flow
+		cmd = exec.Command("cloudflared",
+			"--no-autoupdate",
+			"tunnel", "run",
+			"--url", local,
+			cfg.TunnelName,
+		)
+	default:
+		return nil, errors.New("named tunnel config missing both tunnel_name and tunnel_token — run `buttons webhook setup`")
+	}
 	url := "https://" + cfg.Hostname
 	// For named tunnels we know the URL up front; the "ready" signal
 	// is cloudflared's "Registered tunnel connection" log line.

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -97,9 +97,10 @@ func MintReadyToken() (string, error) {
 var quickURLPattern = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 
 func startQuick(ctx context.Context, local, token string) (*Tunnel, error) {
-	cmd := exec.Command("cloudflared", "tunnel",
-		"--url", local,
+	cmd := exec.Command("cloudflared",
 		"--no-autoupdate",
+		"tunnel",
+		"--url", local,
 	) // #nosec G204 -- arguments are literals + local loopback URL
 	return runTunnel(ctx, cmd, ModeQuick, token, func(line string) (string, bool) {
 		if m := quickURLPattern.FindString(line); m != "" {
@@ -116,10 +117,14 @@ func startNamed(ctx context.Context, local, token string, cfg *Config) (*Tunnel,
 	if cfg.Hostname == "" {
 		return nil, errors.New("named tunnel config missing hostname — run `buttons webhook setup`")
 	}
-	cmd := exec.Command("cloudflared", "tunnel",
-		"run",
-		"--url", local,
+	// cloudflared 2026.x treats --no-autoupdate as a top-level flag;
+	// passing it to `tunnel run` makes the subcommand print usage
+	// help and exit 2, which our caller surfaces as "cloudflared
+	// exited before emitting URL". Put it before the `tunnel` verb.
+	cmd := exec.Command("cloudflared",
 		"--no-autoupdate",
+		"tunnel", "run",
+		"--url", local,
 		cfg.TunnelName,
 	) // #nosec G204 -- TunnelName validated by setup flow
 	url := "https://" + cfg.Hostname


### PR DESCRIPTION
Observed failure: cloudflared registered the edge connection in 3s but the ephemeral *.trycloudflare.com subdomain didn't resolve through the user's local DNS in 60s, triggering our waitForReady timeout and the tunnel got killed. Bumped to 3min. Error message now points at `buttons webhook setup` as the fix since named tunnels skip the propagation wait.