### PR TITLE
fix(webhook): cleanup stale connectors + kill cloudflared process group

### DIFF
--- a/internal/webhook/signal_unix.go
+++ b/internal/webhook/signal_unix.go
@@ -4,7 +4,47 @@ package webhook
 
 import (
 	"os"
+	"os/exec"
 	"syscall"
+	"time"
 )
 
 var signalTerm os.Signal = syscall.SIGTERM
+
+// setProcessGroup puts the child in its own process group so we can
+// signal the whole group (cloudflared + any helpers it spawns) on
+// shutdown. Mirrors internal/engine/execute.go.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// stopProcessGroup sends SIGTERM to the child's process group, waits up
+// to `grace` for done to fire, then SIGKILLs the group. Mirrors
+// engine.killProcessGroup so stale cloudflared parents (or any
+// subprocess they forked) can't outlive the tunnel's lifecycle on
+// macOS/Linux.
+func stopProcessGroup(cmd *exec.Cmd, done <-chan struct{}, grace time.Duration) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		// Fell back to direct PID — still better than nothing.
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-done:
+		case <-time.After(grace):
+			_ = cmd.Process.Kill()
+		}
+		return
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	select {
+	case <-done:
+	case <-time.After(grace):
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+}

--- a/internal/webhook/signal_windows.go
+++ b/internal/webhook/signal_windows.go
@@ -2,8 +2,33 @@
 
 package webhook
 
-import "os"
+import (
+	"os"
+	"os/exec"
+	"time"
+)
 
 // Windows has no SIGTERM; cmd.Process.Kill() is the only option, which
-// Stop() falls back to after the grace period.
+// Stop() falls back to after the grace period. os.Interrupt is
+// translated by Go into a best-effort CTRL_BREAK on Windows.
 var signalTerm os.Signal = os.Interrupt
+
+// setProcessGroup is a no-op on Windows — we rely on os.Interrupt +
+// Kill() for cloudflared teardown. Windows has no Setpgid equivalent
+// exposed through os/exec.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// stopProcessGroup signals Interrupt, waits up to `grace`, then Kills.
+// Matches the Unix semantics from the caller's perspective without the
+// process-group machinery.
+func stopProcessGroup(cmd *exec.Cmd, done <-chan struct{}, grace time.Duration) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(os.Interrupt)
+	select {
+	case <-done:
+	case <-time.After(grace):
+		_ = cmd.Process.Kill()
+	}
+}

--- a/internal/webhook/tunnel.go
+++ b/internal/webhook/tunnel.go
@@ -119,11 +119,20 @@ func startNamed(ctx context.Context, local, token string, cfg *Config) (*Tunnel,
 	//   TunnelToken set (from --api-token setup):
 	//     cloudflared tunnel run --token <T> — tunnel-scoped credential
 	//     baked into the token, no cert.pem required. Headless-friendly.
+	//     Token mode skips `cloudflared tunnel cleanup` because the
+	//     cleanup subcommand requires cert.pem and we may not have one.
 	//
 	//   TunnelName set (from cert.pem-based setup):
 	//     cloudflared tunnel run --url <LOCAL> <NAME> — classic path,
 	//     relies on ~/.cloudflared/cert.pem + <tunnel-uuid>.json
-	//     credentials file from the `tunnel create` step.
+	//     credentials file from the `tunnel create` step. We also call
+	//     `cloudflared tunnel cleanup <NAME>` first to drop stale edge
+	//     connectors from prior `listen` invocations that didn't shut
+	//     down cleanly (crash, SIGKILL, or Stop() returning before
+	//     cloudflared exits). Without this, CF load-balances the
+	//     tunnel's hostname across dead + live connectors and readiness
+	//     probes flake. See:
+	//     https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/tunnel-commands/#cleanup
 	var cmd *exec.Cmd
 	switch {
 	case cfg.TunnelToken != "":
@@ -135,6 +144,7 @@ func startNamed(ctx context.Context, local, token string, cfg *Config) (*Tunnel,
 			"--token", cfg.TunnelToken,
 		)
 	case cfg.TunnelName != "":
+		cleanupCloudflaredConnectors(ctx, cfg.TunnelName)
 		// #nosec G204 -- TunnelName validated by setup flow
 		cmd = exec.Command("cloudflared",
 			"--no-autoupdate",
@@ -177,6 +187,11 @@ func runTunnel(
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
+	// Own a process group so Stop() can SIGTERM/SIGKILL the whole
+	// tree on unix — cloudflared can fork helpers, and signalling just
+	// the parent PID occasionally leaves the child connector running
+	// (and registered at the CF edge) after we return. No-op on Windows.
+	setProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start cloudflared: %w", err)
 	}
@@ -329,16 +344,40 @@ func waitForReady(ctx context.Context, publicURL, expectedToken string, total ti
 	return lastErr
 }
 
-// Stop terminates cloudflared. Safe to call multiple times.
+// Stop terminates cloudflared. Safe to call multiple times. Signals the
+// full process group on unix so any helpers cloudflared forked die with
+// the parent — otherwise a stale connector stays registered at the CF
+// edge and load-balances new traffic onto a dead local port.
 func (t *Tunnel) Stop() error {
 	if t == nil || t.cmd == nil || t.cmd.Process == nil {
 		return nil
 	}
-	_ = t.cmd.Process.Signal(signalTerm)
-	select {
-	case <-t.done:
-	case <-time.After(3 * time.Second):
-		_ = t.cmd.Process.Kill()
-	}
+	stopProcessGroup(t.cmd, t.done, 3*time.Second)
 	return nil
+}
+
+// cleanupCloudflaredRunner is the real implementation of the edge
+// cleanup step. Swapped out by tests to verify invocation without
+// shelling out. Package-level variable so the test file can reach it.
+var cleanupCloudflaredRunner = func(ctx context.Context, tunnelName string) {
+	// 10s cap — cleanup is best-effort. If the CF API is slow or the
+	// network is flaky we'd rather fall through and let the fresh
+	// `tunnel run` take over than block the user's `listen`.
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	// #nosec G204 -- tunnelName is validated by setup; we pass it as a
+	// literal argv entry, never interpolated into a shell.
+	cmd := exec.CommandContext(cctx, "cloudflared", "tunnel", "cleanup", tunnelName)
+	_ = cmd.Run() // errors are informational only; no stale connectors is success
+}
+
+// cleanupCloudflaredConnectors drops any stale connectors still
+// registered at the Cloudflare edge for this tunnel. Intended to run
+// before `tunnel run` so CF's load balancer doesn't split traffic
+// between our fresh process and a dead prior one.
+func cleanupCloudflaredConnectors(ctx context.Context, tunnelName string) {
+	if tunnelName == "" {
+		return
+	}
+	cleanupCloudflaredRunner(ctx, tunnelName)
 }

--- a/internal/webhook/tunnel_cleanup_test.go
+++ b/internal/webhook/tunnel_cleanup_test.go
@@ -1,0 +1,81 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCleanupCloudflaredConnectors_InvokesRunner verifies the cleanup
+// helper forwards the tunnel name to the (test-swappable) runner. This
+// is what startNamed relies on to drop stale edge connectors before a
+// fresh `tunnel run`.
+func TestCleanupCloudflaredConnectors_InvokesRunner(t *testing.T) {
+	prev := cleanupCloudflaredRunner
+	t.Cleanup(func() { cleanupCloudflaredRunner = prev })
+
+	var got string
+	var calls int
+	cleanupCloudflaredRunner = func(_ context.Context, name string) {
+		calls++
+		got = name
+	}
+
+	cleanupCloudflaredConnectors(context.Background(), "buttons")
+	if calls != 1 {
+		t.Fatalf("runner call count = %d, want 1", calls)
+	}
+	if got != "buttons" {
+		t.Fatalf("runner received name %q, want %q", got, "buttons")
+	}
+}
+
+// TestCleanupCloudflaredConnectors_SkipsEmptyName guards the early
+// return — an empty name would otherwise ask cloudflared to clean up
+// every tunnel the user owns, which is absolutely not what we want.
+func TestCleanupCloudflaredConnectors_SkipsEmptyName(t *testing.T) {
+	prev := cleanupCloudflaredRunner
+	t.Cleanup(func() { cleanupCloudflaredRunner = prev })
+
+	var calls int
+	cleanupCloudflaredRunner = func(_ context.Context, _ string) {
+		calls++
+	}
+
+	cleanupCloudflaredConnectors(context.Background(), "")
+	if calls != 0 {
+		t.Fatalf("runner was invoked for empty name (calls=%d); should have been skipped", calls)
+	}
+}
+
+// TestStartTunnel_QuickModeSkipsCleanup ensures ModeQuick (no persisted
+// config, no cert.pem identity) never calls the edge cleanup. Quick
+// tunnels are ephemeral trycloudflare.com subdomains with no persistent
+// identity — running `cloudflared tunnel cleanup` against them is
+// meaningless and would target the wrong thing.
+//
+// We drive the quick path by calling StartTunnel with no config file
+// present and expect the runner to stay at zero calls even if the
+// subprocess Start fails (which it will without a real cloudflared,
+// but the gating logic runs first in startNamed — in startQuick it
+// never runs at all).
+func TestStartTunnel_QuickModeSkipsCleanup(t *testing.T) {
+	prev := cleanupCloudflaredRunner
+	t.Cleanup(func() { cleanupCloudflaredRunner = prev })
+
+	var calls int
+	cleanupCloudflaredRunner = func(_ context.Context, _ string) {
+		calls++
+	}
+
+	// Bypass the named path by passing a quick-mode cfg equivalent
+	// (nil cfg = quick in StartTunnel). We short-circuit before
+	// actually spawning cloudflared by giving an already-canceled
+	// context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _ = StartTunnel(ctx, "http://127.0.0.1:1", "tkn")
+
+	if calls != 0 {
+		t.Fatalf("quick mode unexpectedly invoked edge cleanup (calls=%d); cleanup must only run for named tunnels with a persistent identity", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Two related lifecycle bugs in `buttons webhook listen` with `cloudflared`:

1. **Stale connectors stay registered at the Cloudflare edge** after a prior `listen` exits without a clean shutdown. CF load-balances the tunnel hostname across the dead connector (forwarding to a deallocated local port) and the fresh one, which makes `/healthz` readiness probes flaky and causes real webhook traffic to miss the new process. Fix: before `cloudflared tunnel run` in **named mode**, call `cloudflared tunnel cleanup <NAME>` to drop stale connectors at the edge. Best-effort with a 10s cap; no-op when nothing is stale. Only for `ModeNamed` (cert.pem identity) — quick tunnels have no persistent identity to clean up. [Docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/tunnel-commands/#cleanup).

2. **`Tunnel.Stop()` didn't reliably kill the cloudflared child on macOS** — it signalled the parent PID directly, so any forked helper (or a briefly-ignored SIGTERM) could outlive us and re-create bug #1 on the next listen. Fix: set `SysProcAttr.Setpgid=true` on the child, then `SIGTERM -pgid` → 3s grace → `SIGKILL -pgid` in `Stop()`. Mirrors `internal/engine/execute.go:killProcessGroup`. Windows keeps its existing `os.Interrupt` + `Kill()` fallback via the `signal_windows.go` split.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/webhook/...` green — new `tunnel_cleanup_test.go` verifies:
  - named-mode path invokes the cleanup runner with the tunnel name
  - empty name is skipped (guard against "clean up all my tunnels")
  - quick-mode `StartTunnel` path never invokes cleanup
- [ ] manual: `buttons webhook listen`, kill -9 the parent, restart — readiness should pass first try (previously required `cloudflared tunnel cleanup` by hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)