### PR TITLE
ci: fix govulncheck (pin v1.3.0) + bump Go to 1.26.4

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          # Keep in sync with GO_VERSION in ci.yml.
+          go-version: "1.26.4"
           cache: true
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,11 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned so Dependabot (or a follow-up PR) can bump it intentionally.
+        # v1.4.0 bundles x/tools v0.46.0, which panics ("ForEachElement called
+        # on type containing *types.TypeParam") during symbol-level analysis of
+        # generics under Go 1.26. Bump once upstream ships the x/tools fix.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ permissions:
 
 env:
   # Pinned Go toolchain. Bumping this also resolves stdlib CVEs
-  # tracked in autonoco/autono#331. 1.26.2 adds fixes for four
-  # more vulnerabilities (GO-2026-4866 x509 auth bypass, -4870
-  # TLS 1.3 KeyUpdate DoS, -4946/-4947 x509 DoS) that 1.26.1
-  # is still exposed to.
-  GO_VERSION: "1.26.2"
+  # tracked in autonoco/autono#331. 1.26.4 clears four reachable
+  # vulnerabilities that 1.26.2 is exposed to: GO-2026-4918 (net/http
+  # HTTP/2 infinite loop) and GO-2026-4971 (net) fixed in 1.26.3, plus
+  # GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto) fixed
+  # in 1.26.4.
+  GO_VERSION: "1.26.4"
 
 jobs:
   test:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          # Keep in sync with GO_VERSION in ci.yml.
+          go-version: "1.26.4"
           cache: true
 
       - name: Regenerate CLI reference + SKILL.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          # Keep in sync with GO_VERSION in ci.yml.
+          go-version: "1.26.4"
           cache: true
 
       # QEMU + Buildx let us build the linux/arm64 image from an amd64


### PR DESCRIPTION
Fixes the `govulncheck` job, which has been failing on **`main` and every open PR** since early May. Two distinct problems — the second was hidden behind the first.

## 1. govulncheck was crashing (pin v1.3.0)

`go install ...@latest` floated to **govulncheck v1.4.0**, which bundles **x/tools v0.46.0**. That version panics during symbol-level call-graph analysis when it hits a generic type parameter under Go 1.26:

```
panic: ForEachElement called on type containing *types.TypeParam
  golang.org/x/tools@v0.46.0/internal/typesinternal/element.go:130
  → go/ssa.(*Program).RuntimeTypes
  → golang.org/x/vuln@v1.4.0/internal/vulncheck.callGraph
```

`GO_VERSION` and the `go` directive hadn't changed since the initial commit, so the floating tool version was the only moving part. Pinned to **v1.3.0** (x/tools v0.44.0), the last release before the regression — verified locally that v1.4.0 panics and v1.3.0 completes with full symbol-level reachability analysis. Matches the repo's existing pin convention (cf. gitleaks); Dependabot can bump it once upstream ships the x/tools fix.

## 2. Pinned Go was behind on security patches (bump 1.26.2 → 1.26.4)

Once govulncheck actually ran, it reported four **reachable** stdlib vulnerabilities that 1.26.2 is exposed to — the crash had been masking them:

| CVE | Package | Fixed in | Reachable via |
|-----|---------|----------|---------------|
| GO-2026-4918 | net/http (HTTP/2 infinite loop) | 1.26.3 | `engine.executeHTTP`, `cmd.downloadAsset` |
| GO-2026-4971 | net | 1.26.3 | `engine.executeHTTP`, `webhook.NewServer` |
| GO-2026-5037 | crypto/x509 | 1.26.4 | `webhook.NewServer` (TLS) |
| GO-2026-5039 | net/textproto | 1.26.4 | `webhook.NewServer` (header parsing) |

1.26.4 is the latest 1.26 patch and clears all four. This is the same bump-to-clear-stdlib-CVEs pattern already documented in the `GO_VERSION` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows (CI, auto-release, docs sync, and releases) to use Go **1.26.4** instead of **1.26.2** for continued security and consistency across pipelines.
  * Pinned the vulnerability scanning tool to a specific release (instead of using “latest”) to improve build reproducibility, while avoiding a known issue with that toolchain combination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->