### PR TITLE
feat(store): buttons update — refresh installed buttons + binary (#274)

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -24,134 +25,198 @@ const (
 	repoName    = "buttons"
 )
 
-var updateCheck bool
+var (
+	updateCheck   bool
+	updateBinary  bool
+	updateContent bool
+)
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update buttons to the latest version",
-	Long: `Check for and install the latest version of buttons from GitHub Releases.
+	Short: "Update buttons — the CLI binary and installed buttons",
+	Long: `Bring everything current: the buttons CLI binary (from GitHub Releases)
+and the content of any installed buttons (re-fetched from the source each
+was installed from, when it has drifted).
 
-Downloads the correct archive for your OS and architecture, verifies
-the SHA256 checksum, and atomically replaces the running binary.
+By default both are updated. Scope with --binary or --content. The binary
+download verifies its SHA256 and atomically replaces the running binary;
+button content is re-verified against its install-time content hash and only
+rewritten when it changed.
 
 Examples:
-  buttons update              # download and install the latest version
-  buttons update --check      # just check, don't install
+  buttons update              # binary + installed buttons
+  buttons update --check      # report what would change, install nothing
+  buttons update --binary     # only the CLI binary
+  buttons update --content    # only installed buttons
   buttons update --json       # structured output`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		current := normalizeVersion(version)
+		// Default (neither flag) = do both.
+		doBinary := updateBinary || !updateContent
+		doContent := updateContent || !updateBinary
 
-		latest, err := fetchLatestRelease()
-		if err != nil {
-			if jsonOutput {
-				_ = config.WriteJSONError("INTERNAL_ERROR", fmt.Sprintf("failed to check for updates: %v", err))
-				return errSilent
+		out := map[string]any{}
+
+		if doBinary {
+			bin, err := runBinaryUpdate(updateCheck)
+			if err != nil {
+				if jsonOutput {
+					_ = config.WriteJSONError("INTERNAL_ERROR", err.Error())
+					return errSilent
+				}
+				return err
 			}
-			return fmt.Errorf("failed to check for updates: %w", err)
+			out["binary"] = bin
 		}
 
-		latestVersion := normalizeVersion(latest.TagName)
-		upToDate := current == latestVersion
-
-		if upToDate {
-			if jsonOutput {
-				return config.WriteJSON(map[string]any{
-					"current":    current,
-					"latest":     latestVersion,
-					"up_to_date": true,
-				})
+		if doContent {
+			content, err := store.UpdateInstalled(store.DefaultSourceResolver, updateCheck)
+			if err != nil {
+				if jsonOutput {
+					_ = config.WriteJSONError("INTERNAL_ERROR", err.Error())
+					return errSilent
+				}
+				return err
 			}
-			fmt.Fprintf(os.Stderr, "Already up to date (%s)\n", current)
-			return nil
-		}
-
-		if updateCheck {
-			if jsonOutput {
-				return config.WriteJSON(map[string]any{
-					"current":    current,
-					"latest":     latestVersion,
-					"up_to_date": false,
-				})
+			if !jsonOutput {
+				printContentSummary(content, updateCheck)
 			}
-			fmt.Fprintf(os.Stderr, "Update available: %s → %s\n", current, latestVersion)
-			fmt.Fprintf(os.Stderr, "Run 'buttons update' to install.\n")
-			return nil
-		}
-
-		// Resolve the path to the currently running binary.
-		execPath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("cannot determine executable path: %w", err)
-		}
-		execPath, err = filepath.EvalSymlinks(execPath)
-		if err != nil {
-			return fmt.Errorf("cannot resolve executable path: %w", err)
-		}
-
-		if isHomebrewManaged(execPath) {
-			if jsonOutput {
-				_ = config.WriteJSONError("VALIDATION_ERROR", "this binary is managed by Homebrew — run 'brew upgrade buttons' instead")
-				return errSilent
-			}
-			return fmt.Errorf("this binary is managed by Homebrew — run 'brew upgrade buttons' instead")
-		}
-
-		// Find the right archive for this platform.
-		archiveName := archiveNameForPlatform(latestVersion)
-		archiveAsset := latest.findAsset(archiveName)
-		if archiveAsset == nil {
-			return fmt.Errorf("no release asset found for %s (looked for %s)", runtime.GOOS+"/"+runtime.GOARCH, archiveName)
-		}
-		checksumsAsset := latest.findAsset("checksums.txt")
-		if checksumsAsset == nil {
-			return fmt.Errorf("checksums.txt not found in release %s", latest.TagName)
-		}
-
-		fmt.Fprintf(os.Stderr, "Updating %s → %s\n", current, latestVersion)
-
-		// Download the archive.
-		fmt.Fprintf(os.Stderr, "  downloading %s\n", archiveName)
-		archiveData, err := downloadAsset(archiveAsset.URL)
-		if err != nil {
-			return fmt.Errorf("failed to download archive: %w", err)
-		}
-
-		// Download and verify checksum.
-		fmt.Fprintf(os.Stderr, "  verifying checksum\n")
-		checksumsData, err := downloadAsset(checksumsAsset.URL)
-		if err != nil {
-			return fmt.Errorf("failed to download checksums: %w", err)
-		}
-		if err := verifyChecksum(archiveData, archiveName, checksumsData); err != nil {
-			return fmt.Errorf("checksum verification failed: %w", err)
-		}
-
-		// Extract the binary from the tarball.
-		fmt.Fprintf(os.Stderr, "  extracting binary\n")
-		binaryData, err := extractBinaryFromTarGz(archiveData, "buttons")
-		if err != nil {
-			return fmt.Errorf("failed to extract binary: %w", err)
-		}
-
-		// Atomically swap the binary.
-		fmt.Fprintf(os.Stderr, "  replacing %s\n", execPath)
-		if err := atomicReplace(execPath, binaryData); err != nil {
-			return fmt.Errorf("failed to replace binary: %w", err)
+			out["content"] = content
 		}
 
 		if jsonOutput {
-			return config.WriteJSON(map[string]any{
-				"current":    current,
-				"latest":     latestVersion,
-				"up_to_date": true,
-				"updated":    true,
-				"path":       execPath,
-			})
+			return config.WriteJSON(out)
 		}
-		fmt.Fprintf(os.Stderr, "Updated to %s\n", latestVersion)
 		return nil
 	},
+}
+
+// binaryUpdate is the structured result of the self-update half.
+type binaryUpdate struct {
+	Current  string `json:"current"`
+	Latest   string `json:"latest"`
+	UpToDate bool   `json:"up_to_date"`
+	Updated  bool   `json:"updated,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Skipped  string `json:"skipped,omitempty"` // reason the binary was not replaced
+}
+
+// runBinaryUpdate checks GitHub Releases and, unless check is set, downloads,
+// verifies, and atomically swaps the running binary. A Homebrew-managed binary
+// is reported as skipped (not a hard error) so a combined run can still update
+// button content.
+func runBinaryUpdate(check bool) (*binaryUpdate, error) {
+	current := normalizeVersion(version)
+
+	latest, err := fetchLatestRelease()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for updates: %w", err)
+	}
+	latestVersion := normalizeVersion(latest.TagName)
+	bu := &binaryUpdate{Current: current, Latest: latestVersion, UpToDate: current == latestVersion}
+
+	if bu.UpToDate {
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Binary already up to date (%s)\n", current)
+		}
+		return bu, nil
+	}
+
+	if check {
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Binary update available: %s → %s (run 'buttons update')\n", current, latestVersion)
+		}
+		return bu, nil
+	}
+
+	// Resolve the path to the currently running binary.
+	execPath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve executable path: %w", err)
+	}
+
+	if isHomebrewManaged(execPath) {
+		bu.Skipped = "homebrew-managed"
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Binary is managed by Homebrew — run 'brew upgrade buttons' (skipping binary)\n")
+		}
+		return bu, nil
+	}
+
+	// Find the right archive for this platform.
+	archiveName := archiveNameForPlatform(latestVersion)
+	archiveAsset := latest.findAsset(archiveName)
+	if archiveAsset == nil {
+		return nil, fmt.Errorf("no release asset found for %s (looked for %s)", runtime.GOOS+"/"+runtime.GOARCH, archiveName)
+	}
+	checksumsAsset := latest.findAsset("checksums.txt")
+	if checksumsAsset == nil {
+		return nil, fmt.Errorf("checksums.txt not found in release %s", latest.TagName)
+	}
+
+	fmt.Fprintf(os.Stderr, "Updating binary %s → %s\n", current, latestVersion)
+
+	fmt.Fprintf(os.Stderr, "  downloading %s\n", archiveName)
+	archiveData, err := downloadAsset(archiveAsset.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download archive: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  verifying checksum\n")
+	checksumsData, err := downloadAsset(checksumsAsset.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download checksums: %w", err)
+	}
+	if err := verifyChecksum(archiveData, archiveName, checksumsData); err != nil {
+		return nil, fmt.Errorf("checksum verification failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  extracting binary\n")
+	binaryData, err := extractBinaryFromTarGz(archiveData, "buttons")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract binary: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  replacing %s\n", execPath)
+	if err := atomicReplace(execPath, binaryData); err != nil {
+		return nil, fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	bu.Updated = true
+	bu.Path = execPath
+	if !jsonOutput {
+		fmt.Fprintf(os.Stderr, "Updated binary to %s\n", latestVersion)
+	}
+	return bu, nil
+}
+
+// printContentSummary renders the installed-button half for humans.
+func printContentSummary(res *store.UpdateResult, check bool) {
+	counts := res.Counts()
+	if len(res.Buttons) == 0 {
+		fmt.Fprintln(os.Stderr, "No installed buttons to update.")
+		return
+	}
+	for _, b := range res.Buttons {
+		switch b.Action {
+		case "updated":
+			fmt.Fprintf(os.Stderr, "  ✓ %s %s → %s\n", b.Name, b.From, b.To)
+		case "available":
+			fmt.Fprintf(os.Stderr, "  ↑ %s %s → %s (available)\n", b.Name, b.From, b.To)
+		case "error":
+			fmt.Fprintf(os.Stderr, "  ✗ %s: %s\n", b.Name, b.Reason)
+		}
+	}
+	verb := "updated"
+	if check {
+		verb = "available"
+	}
+	fmt.Fprintf(os.Stderr, "Buttons: %d %s, %d unchanged, %d skipped, %d errors\n",
+		counts["updated"]+counts["available"], verb, counts["unchanged"], counts["skipped"], counts["error"])
 }
 
 // ghRelease is a minimal representation of a GitHub API release.
@@ -327,6 +392,8 @@ func isHomebrewManaged(path string) bool {
 }
 
 func init() {
-	updateCmd.Flags().BoolVar(&updateCheck, "check", false, "check for updates without installing")
+	updateCmd.Flags().BoolVar(&updateCheck, "check", false, "report what would change without installing")
+	updateCmd.Flags().BoolVar(&updateBinary, "binary", false, "update only the CLI binary")
+	updateCmd.Flags().BoolVar(&updateContent, "content", false, "update only installed buttons")
 	rootCmd.AddCommand(updateCmd)
 }

--- a/internal/store/update.go
+++ b/internal/store/update.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+)
+
+// UpdateStatus is one installed button's outcome in an update run.
+type UpdateStatus struct {
+	Name   string `json:"name"`
+	Action string `json:"action"` // updated | available | unchanged | skipped | error
+	From   string `json:"from,omitempty"`
+	To     string `json:"to,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// UpdateResult is the full content-update report.
+type UpdateResult struct {
+	Buttons []UpdateStatus `json:"buttons"`
+}
+
+// Counts returns a {action: n} summary for human/JSON output.
+func (r *UpdateResult) Counts() map[string]int {
+	out := map[string]int{}
+	for _, b := range r.Buttons {
+		out[b.Action]++
+	}
+	return out
+}
+
+// SourceResolver reconstructs a Source from an installed button's stamped
+// `source` ref so update knows where to re-fetch from. Injectable for tests.
+type SourceResolver func(ref string) (Source, error)
+
+// DefaultSourceResolver understands the source refs install stamps today.
+// Only "local:<dir>" is wired; registry refs ("https://…", "registry:…")
+// land with the HTTPSource in #275/#276.
+func DefaultSourceResolver(ref string) (Source, error) {
+	if dir, ok := strings.CutPrefix(ref, "local:"); ok {
+		return &LocalSource{Root: dir}, nil
+	}
+	return nil, fmt.Errorf("unsupported source %q (only local: is wired today; the registry source lands in #275)", ref)
+}
+
+// UpdateInstalled reconciles every installed button against its source. When
+// check is true it reports what would change without writing (action
+// "available"); otherwise it re-installs drifted buttons (action "updated").
+//
+// Buttons with no source (hand-authored) or an unresolvable source are
+// "skipped", never an error — one un-sourced or registry-pinned button can't
+// fail the whole run. A source that resolves but fails to fetch is an "error"
+// for that button alone.
+//
+// Drift is detected by content hash: the installed button.json records the
+// SHA256 of its source files at install time (#190), and Fetch recomputes that
+// same hash from the current source — equal means unchanged.
+func UpdateInstalled(resolve SourceResolver, check bool) (*UpdateResult, error) {
+	if resolve == nil {
+		resolve = DefaultSourceResolver
+	}
+	installed, err := listInstalled()
+	if err != nil {
+		return nil, err
+	}
+	res := &UpdateResult{}
+	for _, b := range installed {
+		res.Buttons = append(res.Buttons, reconcile(b, resolve, check))
+	}
+	sort.Slice(res.Buttons, func(i, j int) bool { return res.Buttons[i].Name < res.Buttons[j].Name })
+	return res, nil
+}
+
+func reconcile(b button.Button, resolve SourceResolver, check bool) UpdateStatus {
+	st := UpdateStatus{Name: b.Name, From: b.Version}
+	if b.Source == "" {
+		st.Action = "skipped"
+		st.Reason = "no source (locally created)"
+		return st
+	}
+	src, err := resolve(b.Source)
+	if err != nil {
+		st.Action = "skipped"
+		st.Reason = err.Error()
+		return st
+	}
+	bundle, err := src.Fetch(b.Name, "")
+	if err != nil {
+		st.Action = "error"
+		st.Reason = err.Error()
+		return st
+	}
+	if bundle.SHA256 == b.ContentHash {
+		st.Action = "unchanged"
+		return st
+	}
+	st.To = bundle.Version
+	if check {
+		st.Action = "available"
+		return st
+	}
+	// Re-install re-fetches, re-verifies the hash, re-stamps, and writes the
+	// button folder from the same source ref it was installed from.
+	if _, err := install(src, b.Name, "", b.Source); err != nil {
+		st.Action = "error"
+		st.Reason = err.Error()
+		return st
+	}
+	st.Action = "updated"
+	return st
+}
+
+// listInstalled reads every installed button.json from the buttons dir.
+// Unparseable folders are skipped (consistent with button.Service.List).
+func listInstalled() ([]button.Button, error) {
+	dir, err := config.ButtonsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []button.Button
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// #nosec G304 -- rooted in ButtonsDir + an enumerated DirEntry name.
+		data, err := os.ReadFile(filepath.Join(dir, e.Name(), "button.json"))
+		if err != nil {
+			continue
+		}
+		var b button.Button
+		if json.Unmarshal(data, &b) != nil {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}

--- a/internal/store/update_test.go
+++ b/internal/store/update_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+// bumpSourceButton rewrites a source button's version and main.sh so its
+// content hash changes — simulating an upstream release.
+func bumpSourceButton(t *testing.T, root, name, version, body string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	b := button.Button{SchemaVersion: 1, Name: name, Runtime: "shell", Version: version, Tags: []string{"demo"}}
+	data, _ := json.MarshalIndent(&b, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.sh"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateDetectsAndAppliesDrift(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	src := t.TempDir()
+	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "alpha", Runtime: "shell", Version: "1.0.0", Tags: []string{"demo"}})
+
+	srcRef := "local:" + src
+	if _, err := InstallSpec(&LocalSource{Root: src}, "alpha", srcRef); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// No upstream change yet → unchanged.
+	res, err := UpdateInstalled(DefaultSourceResolver, false)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if len(res.Buttons) != 1 || res.Buttons[0].Action != "unchanged" {
+		t.Fatalf("want [unchanged], got %+v", res.Buttons)
+	}
+
+	// Bump the source → check reports it available without writing.
+	bumpSourceButton(t, src, "alpha", "2.0.0", "#!/bin/sh\necho v2\n")
+	res, err = UpdateInstalled(DefaultSourceResolver, true)
+	if err != nil {
+		t.Fatalf("update --check: %v", err)
+	}
+	if res.Buttons[0].Action != "available" || res.Buttons[0].To != "2.0.0" {
+		t.Fatalf("want available→2.0.0, got %+v", res.Buttons[0])
+	}
+	if got := installedSpec(t, home, "alpha").Version; got != "1.0.0" {
+		t.Fatalf("--check must not write; installed version = %q", got)
+	}
+
+	// Apply → updated, and the installed copy is now v2 with a fresh hash.
+	before := installedSpec(t, home, "alpha")
+	res, err = UpdateInstalled(DefaultSourceResolver, false)
+	if err != nil {
+		t.Fatalf("update apply: %v", err)
+	}
+	if res.Buttons[0].Action != "updated" || res.Buttons[0].From != "1.0.0" || res.Buttons[0].To != "2.0.0" {
+		t.Fatalf("want updated 1.0.0→2.0.0, got %+v", res.Buttons[0])
+	}
+	after := installedSpec(t, home, "alpha")
+	if after.Version != "2.0.0" {
+		t.Fatalf("installed version after update = %q", after.Version)
+	}
+	if after.ContentHash == before.ContentHash || after.ContentHash == "" {
+		t.Fatalf("content hash should change on update: before=%q after=%q", before.ContentHash, after.ContentHash)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, "buttons", "alpha", "main.sh"))
+	if string(body) != "#!/bin/sh\necho v2\n" {
+		t.Fatalf("main.sh not refreshed: %q", body)
+	}
+
+	// A second run is now a no-op.
+	res, _ = UpdateInstalled(DefaultSourceResolver, false)
+	if res.Buttons[0].Action != "unchanged" {
+		t.Fatalf("re-run should be unchanged, got %+v", res.Buttons[0])
+	}
+}
+
+func TestUpdateSkipsUnsourcedAndUnresolvable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+
+	// A locally-created button (no source) lands directly in the buttons dir.
+	local := filepath.Join(home, "buttons", "handmade")
+	if err := os.MkdirAll(local, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.MarshalIndent(&button.Button{SchemaVersion: 1, Name: "handmade", Runtime: "shell"}, "", "  ")
+	if err := os.WriteFile(filepath.Join(local, "button.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A button stamped with a registry source we can't resolve yet.
+	reg := filepath.Join(home, "buttons", "remote")
+	if err := os.MkdirAll(reg, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = json.MarshalIndent(&button.Button{SchemaVersion: 1, Name: "remote", Runtime: "shell", Source: "https://buttons.co", ContentHash: "abc"}, "", "  ")
+	if err := os.WriteFile(filepath.Join(reg, "button.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := UpdateInstalled(DefaultSourceResolver, false)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	byName := map[string]UpdateStatus{}
+	for _, b := range res.Buttons {
+		byName[b.Name] = b
+	}
+	if byName["handmade"].Action != "skipped" {
+		t.Fatalf("handmade should be skipped, got %+v", byName["handmade"])
+	}
+	if byName["remote"].Action != "skipped" {
+		t.Fatalf("remote (registry source) should be skipped until #275, got %+v", byName["remote"])
+	}
+}
+
+func TestDefaultSourceResolver(t *testing.T) {
+	if _, err := DefaultSourceResolver("local:/tmp/pack"); err != nil {
+		t.Fatalf("local: should resolve, got %v", err)
+	}
+	if _, err := DefaultSourceResolver("https://buttons.co"); err == nil {
+		t.Fatal("registry source should not resolve yet")
+	}
+}


### PR DESCRIPTION
## What

`buttons update` now does **both halves** of "bring me current" in one command:
the CLI binary (existing self-updater) **and** the content of installed buttons,
re-fetched from the `Source` each was installed from.

This is the client half of the distribution plan's *sync/materialization* step
(`context/plans/buttons-as-skill-runtime.md`) and closes the `update` part of #274.

## How

- **`internal/store/update.go`** — `UpdateInstalled(resolve, check)` reconciles every
  installed button against its stamped `source`:
  - **Drift via content hash** — compares the install-time SHA256 (`content_hash`, #186/#190)
    against a fresh `Source.Fetch`. Equal ⇒ `unchanged`.
  - **Apply** ⇒ re-install (re-verify hash, re-stamp, rewrite folder) ⇒ `updated`.
  - **`--check`** ⇒ report `available` (from→to) and write nothing.
  - **Resilient**: un-sourced (hand-authored) or not-yet-resolvable (registry) buttons are
    `skipped`; a resolvable source that fails to fetch is an `error` for *that button only* —
    one bad button never fails the run.
  - `SourceResolver` is injectable; `DefaultSourceResolver` wires `local:<dir>` today; registry
    refs resolve when the `HTTPSource` lands (#275/#276).
- **`cmd/update.go`** — factor the binary path into `runBinaryUpdate`; add `--binary` / `--content`
  scoping (default = both); `--check` now also reports available content updates. A Homebrew-managed
  binary is a **soft skip** (was a hard error) so content still updates in a combined run; `--binary`
  on brew still surfaces the "use brew upgrade" guidance.

## Testing

- `internal/store/update_test.go`: drift detect→apply, `--check` is read-only, second run is a no-op,
  skip un-sourced + registry-pinned, resolver.
- Full suite green (13 pkgs). End-to-end smoke: install `hello@1.0.0` → `unchanged` → bump source →
  `available 1.0.0→2.0.0` → apply → installed `button.json` is `2.0.0` and `main.sh` refreshed.

## Stacking

Stacked on **#190** (`feat/store-install`) — needs `internal/store`'s `Source`/`LocalSource`/`install`.
Review/merge #190 first; this retargets to `main` automatically once #190 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)