### PR TITLE
feat(mcp): buttons mcp — stdio MCP server with meta-tools (#265)

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/autonoco/buttons/internal/mcpserver"
+	"github.com/spf13/cobra"
+)
+
+var mcpAllowCreate bool
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Run an MCP server over stdio (expose buttons to agents)",
+	Long: `Start a Model Context Protocol server on stdio so an agent (e.g. Claude
+Code) can discover and press buttons as tools.
+
+Uses a thin meta-tool surface — buttons_list, buttons_press, buttons_inspect
+(and buttons_create with --allow-create) — instead of one tool per button, so
+large button sets don't degrade the MCP client.
+
+Security:
+  - Only buttons with "mcp_enabled": true are listed, pressable, or inspectable.
+  - Args are validated against the button's spec and passed as BUTTONS_ARG_<NAME>
+    env vars — never substituted into shell text.
+  - Per button: max 10 calls/min, 1 concurrent press, hard 120s timeout cap.
+  - buttons_create is OFF unless --allow-create is passed.
+
+stdout carries only protocol messages; logs go to stderr. Register with an
+agent, e.g. Claude Code:
+  claude mcp add buttons -- buttons mcp`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		srv := mcpserver.New(mcpserver.Config{
+			AllowCreate: mcpAllowCreate,
+			Version:     version,
+		})
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+		return srv.Serve(ctx, os.Stdin, os.Stdout)
+	},
+}
+
+func init() {
+	mcpCmd.Flags().BoolVar(&mcpAllowCreate, "allow-create", false, "expose the buttons_create tool (off by default)")
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1,0 +1,244 @@
+// Package mcpserver implements `buttons mcp` — a Model Context Protocol server
+// over stdio (newline-delimited JSON-RPC 2.0). It exposes buttons to agents via
+// a thin *meta-tool* surface (buttons_list / buttons_press / buttons_inspect,
+// and optionally buttons_create) rather than one MCP tool per button, so large
+// button sets don't degrade MCP clients that struggle past a few dozen tools.
+//
+// Protocol notes: MCP's stdio transport frames each JSON-RPC message on its own
+// line — messages MUST NOT contain embedded newlines. stdout therefore carries
+// ONLY protocol messages; all diagnostics go to stderr.
+package mcpserver
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+const (
+	// defaultProtocolVersion is what we advertise if the client doesn't pin one.
+	defaultProtocolVersion = "2024-11-05"
+	// MaxTimeoutSeconds is the hard ceiling on any MCP-triggered press.
+	MaxTimeoutSeconds = 120
+	// defaultRateLimitPerMin caps calls to a single button per rolling minute.
+	defaultRateLimitPerMin = 10
+)
+
+// Config tunes the server.
+type Config struct {
+	AllowCreate     bool   // expose buttons_create (off by default per security review)
+	RateLimitPerMin int    // 0 → default 10
+	Version         string // reported in serverInfo
+}
+
+// Server is a stdio MCP server. One per `buttons mcp` process.
+type Server struct {
+	cfg     Config
+	svc     *button.Service
+	mu      sync.Mutex
+	calls   map[string][]time.Time // button → recent call times (rate limit window)
+	running map[string]bool        // button → currently executing (1-concurrent guard)
+	writeMu sync.Mutex             // serializes stdout writes across handler goroutines
+}
+
+// New builds a Server.
+func New(cfg Config) *Server {
+	if cfg.RateLimitPerMin <= 0 {
+		cfg.RateLimitPerMin = defaultRateLimitPerMin
+	}
+	if cfg.Version == "" {
+		cfg.Version = "dev"
+	}
+	return &Server{
+		cfg:     cfg,
+		svc:     button.NewService(),
+		calls:   map[string][]time.Time{},
+		running: map[string]bool{},
+	}
+}
+
+func logf(format string, a ...any) { fmt.Fprintf(os.Stderr, "[mcp] "+format+"\n", a...) }
+
+// --- JSON-RPC 2.0 wire types -------------------------------------------------
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// JSON-RPC standard error codes we use.
+const (
+	codeParseError    = -32700
+	codeInvalidReq    = -32600
+	codeMethodNotFnd  = -32601
+	codeInvalidParams = -32602
+	codeInternal      = -32603
+)
+
+// Serve reads JSON-RPC messages from in and writes responses to out until EOF
+// or ctx cancellation. Each request is handled in its own goroutine so a long
+// press doesn't block list/inspect; stdout writes are serialized.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	r := bufio.NewReaderSize(in, 1<<20)
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		line, err := r.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			var req rpcRequest
+			if jerr := json.Unmarshal(bytes.TrimSpace(line), &req); jerr != nil {
+				s.send(out, &rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: codeParseError, Message: "parse error"}})
+			} else if isNotification(&req) {
+				// Notifications (no id) get no response. We just observe them.
+				s.handleNotification(&req)
+			} else {
+				wg.Add(1)
+				go func(req rpcRequest) {
+					defer wg.Done()
+					resp := s.handle(ctx, &req)
+					s.send(out, resp)
+				}(req)
+			}
+		}
+
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func isNotification(req *rpcRequest) bool {
+	return len(req.ID) == 0 || string(req.ID) == "null"
+}
+
+func (s *Server) send(out io.Writer, resp *rpcResponse) {
+	resp.JSONRPC = "2.0"
+	data, err := json.Marshal(resp)
+	if err != nil {
+		logf("marshal response: %v", err)
+		return
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, _ = out.Write(data)
+	_, _ = out.Write([]byte("\n"))
+}
+
+func (s *Server) handleNotification(req *rpcRequest) {
+	// initialized / cancelled / progress — nothing to do for our surface.
+	logf("notification: %s", req.Method)
+}
+
+func (s *Server) handle(ctx context.Context, req *rpcRequest) *rpcResponse {
+	switch req.Method {
+	case "initialize":
+		return s.ok(req, s.initializeResult(req))
+	case "ping":
+		return s.ok(req, map[string]any{})
+	case "tools/list":
+		return s.ok(req, map[string]any{"tools": s.toolDefs()})
+	case "tools/call":
+		return s.handleToolsCall(ctx, req)
+	default:
+		return s.fail(req, codeMethodNotFnd, "method not found: "+req.Method)
+	}
+}
+
+func (s *Server) initializeResult(req *rpcRequest) map[string]any {
+	// Echo the client's requested protocol version when present; else default.
+	protocol := defaultProtocolVersion
+	if len(req.Params) > 0 {
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(req.Params, &p) == nil && p.ProtocolVersion != "" {
+			protocol = p.ProtocolVersion
+		}
+	}
+	return map[string]any{
+		"protocolVersion": protocol,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": "buttons", "version": s.cfg.Version},
+	}
+}
+
+func (s *Server) ok(req *rpcRequest, result any) *rpcResponse {
+	return &rpcResponse{ID: req.ID, Result: result}
+}
+
+func (s *Server) fail(req *rpcRequest, code int, message string) *rpcResponse {
+	return &rpcResponse{ID: req.ID, Error: &rpcError{Code: code, Message: message}}
+}
+
+// --- rate limit + concurrency guard -----------------------------------------
+
+// checkRate records a call against the rolling-minute window, returning false
+// if the button is over its per-minute budget.
+func (s *Server) checkRate(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-time.Minute)
+	kept := s.calls[name][:0]
+	for _, t := range s.calls[name] {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) >= s.cfg.RateLimitPerMin {
+		s.calls[name] = kept
+		return false
+	}
+	s.calls[name] = append(kept, now)
+	return true
+}
+
+// acquire marks a button as running; returns false if it already is.
+func (s *Server) acquire(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running[name] {
+		return false
+	}
+	s.running[name] = true
+	return true
+}
+
+func (s *Server) release(name string) {
+	s.mu.Lock()
+	delete(s.running, name)
+	s.mu.Unlock()
+}

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1,0 +1,181 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeButton(t *testing.T, home, name string, mcpEnabled bool, body string) {
+	t.Helper()
+	dir := filepath.Join(home, "buttons", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	enabled := "false"
+	if mcpEnabled {
+		enabled = "true"
+	}
+	spec := `{"schema_version":1,"name":"` + name + `","runtime":"shell","env":{},"timeout_seconds":30,"mcp_enabled":` + enabled + `,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.sh"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// resultText pulls the first content text block out of a tool result map.
+func resultText(t *testing.T, res map[string]any) (string, bool) {
+	t.Helper()
+	content, _ := res["content"].([]map[string]any)
+	if len(content) == 0 {
+		t.Fatalf("no content in result: %v", res)
+	}
+	isErr, _ := res["isError"].(bool)
+	return content[0]["text"].(string), isErr
+}
+
+func TestToolsListOnlyMCPEnabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "exposed", true, "#!/bin/sh\necho hi\n")
+	writeButton(t, home, "hidden", false, "#!/bin/sh\necho no\n")
+
+	s := New(Config{})
+	text, isErr := resultText(t, s.toolList(nil))
+	if isErr {
+		t.Fatalf("list errored: %s", text)
+	}
+	if !strings.Contains(text, "exposed") || strings.Contains(text, "hidden") {
+		t.Fatalf("list must include only mcp_enabled buttons, got: %s", text)
+	}
+}
+
+func TestPressForbiddenWhenNotEnabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "hidden", false, "#!/bin/sh\necho no\n")
+
+	s := New(Config{})
+	text, isErr := resultText(t, s.toolPress(context.Background(), json.RawMessage(`{"name":"hidden"}`)))
+	if !isErr || !strings.Contains(text, "FORBIDDEN") {
+		t.Fatalf("expected FORBIDDEN, got isErr=%v text=%s", isErr, text)
+	}
+}
+
+func TestPressExecutesEnabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "echo", true, "#!/bin/sh\necho pressed\n")
+
+	s := New(Config{})
+	text, isErr := resultText(t, s.toolPress(context.Background(), json.RawMessage(`{"name":"echo"}`)))
+	if isErr || !strings.Contains(text, "pressed") {
+		t.Fatalf("press should succeed with stdout, got isErr=%v text=%s", isErr, text)
+	}
+}
+
+func TestPressRateLimited(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "echo", true, "#!/bin/sh\necho ok\n")
+
+	s := New(Config{RateLimitPerMin: 2})
+	_, _ = resultText(t, s.toolPress(context.Background(), json.RawMessage(`{"name":"echo"}`)))
+	_, _ = resultText(t, s.toolPress(context.Background(), json.RawMessage(`{"name":"echo"}`)))
+	text, isErr := resultText(t, s.toolPress(context.Background(), json.RawMessage(`{"name":"echo"}`)))
+	if !isErr || !strings.Contains(text, "RATE_LIMITED") {
+		t.Fatalf("3rd call under limit 2 should be RATE_LIMITED, got isErr=%v text=%s", isErr, text)
+	}
+}
+
+func TestConcurrencyGuard(t *testing.T) {
+	s := New(Config{})
+	if !s.acquire("x") {
+		t.Fatal("first acquire should succeed")
+	}
+	if s.acquire("x") {
+		t.Fatal("second acquire should fail (busy)")
+	}
+	s.release("x")
+	if !s.acquire("x") {
+		t.Fatal("acquire after release should succeed")
+	}
+}
+
+func TestInspectReturnsSpec(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "echo", true, "#!/bin/sh\necho ok\n")
+
+	s := New(Config{})
+	text, isErr := resultText(t, s.toolInspect(json.RawMessage(`{"name":"echo"}`)))
+	if isErr || !strings.Contains(text, `"recent_runs"`) || !strings.Contains(text, "echo") {
+		t.Fatalf("inspect should return spec+runs, got isErr=%v text=%s", isErr, text)
+	}
+}
+
+func TestCreateGatedByFlag(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	// Without --allow-create the tool isn't even listed, and a call is rejected.
+	s := New(Config{})
+	resp := s.handleToolsCall(context.Background(), &rpcRequest{
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"buttons_create","arguments":{"name":"x","code":"echo hi"}}`),
+	})
+	res := resp.Result.(map[string]any)
+	text, isErr := resultText(t, res)
+	if !isErr || !strings.Contains(text, "FORBIDDEN") {
+		t.Fatalf("create should be forbidden without --allow-create, got %s", text)
+	}
+}
+
+// TestServeWire drives the full stdio loop with newline-delimited JSON-RPC and
+// checks initialize + tools/list responses come back id-matched.
+func TestServeWire(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "exposed", true, "#!/bin/sh\necho hi\n")
+
+	in := strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	}, "\n") + "\n")
+	var out bytes.Buffer
+
+	if err := New(Config{}).Serve(context.Background(), in, &out); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+
+	byID := map[float64]map[string]any{}
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			t.Fatalf("bad response line %q: %v", line, err)
+		}
+		if id, ok := resp["id"].(float64); ok {
+			byID[id] = resp
+		}
+	}
+
+	if len(byID) != 2 {
+		t.Fatalf("want 2 id-matched responses (notification gets none), got %d: %s", len(byID), out.String())
+	}
+	initRes := byID[1]["result"].(map[string]any)
+	if initRes["protocolVersion"] != "2025-06-18" {
+		t.Fatalf("initialize should echo client protocol version, got %v", initRes["protocolVersion"])
+	}
+	tools := byID[2]["result"].(map[string]any)["tools"].([]any)
+	if len(tools) != 3 {
+		t.Fatalf("want 3 default tools, got %d", len(tools))
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -1,0 +1,281 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/history"
+	"github.com/autonoco/buttons/internal/runner"
+)
+
+// toolDefs is the meta-tool surface advertised via tools/list. Thin on purpose
+// (3, +1 optional) so MCP clients don't degrade under a tool-per-button blowup.
+func (s *Server) toolDefs() []map[string]any {
+	defs := []map[string]any{
+		{
+			"name":        "buttons_list",
+			"description": "List buttons exposed to MCP (mcp_enabled: true), with their declared args.",
+			"inputSchema": map[string]any{"type": "object", "properties": map[string]any{}},
+		},
+		{
+			"name":        "buttons_press",
+			"description": "Execute a button by name. Args are validated against the button's spec and passed to the script as BUTTONS_ARG_<NAME> environment variables (never substituted into shell text). Timeout is capped at 120s.",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":    map[string]any{"type": "string", "description": "button name"},
+					"args":    map[string]any{"type": "object", "description": "key→value string arguments", "additionalProperties": map[string]any{"type": "string"}},
+					"timeout": map[string]any{"type": "integer", "description": "override timeout in seconds (hard-capped at 120)"},
+				},
+				"required": []string{"name"},
+			},
+		},
+		{
+			"name":        "buttons_inspect",
+			"description": "Get a button's full spec plus its last 5 runs.",
+			"inputSchema": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"name": map[string]any{"type": "string"}},
+				"required":   []string{"name"},
+			},
+		},
+	}
+	if s.cfg.AllowCreate {
+		defs = append(defs, map[string]any{
+			"name":        "buttons_create",
+			"description": "Create a new shell/code button. Available only because the server was started with --allow-create.",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":        map[string]any{"type": "string"},
+					"runtime":     map[string]any{"type": "string", "enum": []string{"shell", "python", "node"}},
+					"code":        map[string]any{"type": "string"},
+					"description": map[string]any{"type": "string"},
+				},
+				"required": []string{"name", "code"},
+			},
+		})
+	}
+	return defs
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, req *rpcRequest) *rpcResponse {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return s.fail(req, codeInvalidParams, "invalid params: "+err.Error())
+		}
+	}
+
+	var result map[string]any
+	switch p.Name {
+	case "buttons_list":
+		result = s.toolList(p.Arguments)
+	case "buttons_press":
+		result = s.toolPress(ctx, p.Arguments)
+	case "buttons_inspect":
+		result = s.toolInspect(p.Arguments)
+	case "buttons_create":
+		if !s.cfg.AllowCreate {
+			result = toolError("FORBIDDEN", "buttons_create is disabled (start `buttons mcp --allow-create`)", "", 0)
+		} else {
+			result = s.toolCreate(p.Arguments)
+		}
+	default:
+		return s.fail(req, codeMethodNotFnd, "unknown tool: "+p.Name)
+	}
+	return s.ok(req, result)
+}
+
+func (s *Server) toolList(_ json.RawMessage) map[string]any {
+	buttons, err := s.svc.List()
+	if err != nil {
+		return toolError("INTERNAL", err.Error(), "", 0)
+	}
+	type entry struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description,omitempty"`
+		Args        []button.ArgDef `json:"args,omitempty"`
+		Tags        []string        `json:"tags,omitempty"`
+	}
+	out := []entry{}
+	for _, b := range buttons {
+		if !b.MCPEnabled {
+			continue
+		}
+		out = append(out, entry{Name: b.Name, Description: b.Description, Args: b.Args, Tags: b.Tags})
+	}
+	return toolJSON(map[string]any{"buttons": out, "count": len(out)})
+}
+
+func (s *Server) toolPress(ctx context.Context, raw json.RawMessage) map[string]any {
+	var p struct {
+		Name    string            `json:"name"`
+		Args    map[string]string `json:"args"`
+		Timeout int               `json:"timeout"`
+	}
+	if err := json.Unmarshal(nonEmpty(raw), &p); err != nil {
+		return toolError("INVALID_PARAMS", "invalid arguments: "+err.Error(), "", 0)
+	}
+	if p.Name == "" {
+		return toolError("INVALID_PARAMS", "missing required field: name", "", 0)
+	}
+
+	btn, err := s.svc.Get(p.Name)
+	if err != nil {
+		return toolError("NOT_FOUND", "button not found: "+p.Name, p.Name, 0)
+	}
+	if !btn.MCPEnabled {
+		return toolError("FORBIDDEN", "button not exposed to MCP (set mcp_enabled: true)", p.Name, 0)
+	}
+
+	// Rate limit, then single-concurrency guard — both per button.
+	if !s.checkRate(p.Name) {
+		return toolError("RATE_LIMITED", fmt.Sprintf("rate limit: max %d calls/min to %q", s.cfg.RateLimitPerMin, p.Name), p.Name, 0)
+	}
+	if !s.acquire(p.Name) {
+		return toolError("BUSY", "button is already executing (1 concurrent press per button)", p.Name, 0)
+	}
+	defer s.release(p.Name)
+
+	start := time.Now()
+	res, perr := runner.Press(ctx, p.Name, p.Args, runner.Options{
+		TimeoutSeconds:    p.Timeout,
+		MaxTimeoutSeconds: MaxTimeoutSeconds,
+		RecordHistory:     true,
+	})
+	if perr != nil {
+		code := "PRESS_ERROR"
+		var se *button.ServiceError
+		if errors.As(perr, &se) {
+			code = se.Code
+		}
+		return toolError(code, perr.Error(), p.Name, time.Since(start).Milliseconds())
+	}
+	if res.Status != "ok" {
+		code := res.ErrorType
+		if code == "" {
+			code = strings.ToUpper(res.Status)
+		}
+		msg := strings.TrimSpace(res.Stderr)
+		if msg == "" {
+			msg = "button " + res.Status
+		}
+		return toolError(code, msg, p.Name, res.DurationMs)
+	}
+	return toolJSON(map[string]any{
+		"button":      res.Button,
+		"status":      res.Status,
+		"exit_code":   res.ExitCode,
+		"stdout":      res.Stdout,
+		"stderr":      res.Stderr,
+		"duration_ms": res.DurationMs,
+	})
+}
+
+func (s *Server) toolInspect(raw json.RawMessage) map[string]any {
+	var p struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(nonEmpty(raw), &p); err != nil {
+		return toolError("INVALID_PARAMS", "invalid arguments: "+err.Error(), "", 0)
+	}
+	if p.Name == "" {
+		return toolError("INVALID_PARAMS", "missing required field: name", "", 0)
+	}
+	btn, err := s.svc.Get(p.Name)
+	if err != nil {
+		return toolError("NOT_FOUND", "button not found: "+p.Name, p.Name, 0)
+	}
+	if !btn.MCPEnabled {
+		return toolError("FORBIDDEN", "button not exposed to MCP (set mcp_enabled: true)", p.Name, 0)
+	}
+	runs, _ := history.List(p.Name, 5)
+	if runs == nil {
+		runs = []history.Run{}
+	}
+	return toolJSON(map[string]any{"button": btn, "recent_runs": runs})
+}
+
+func (s *Server) toolCreate(raw json.RawMessage) map[string]any {
+	var p struct {
+		Name        string `json:"name"`
+		Runtime     string `json:"runtime"`
+		Code        string `json:"code"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(nonEmpty(raw), &p); err != nil {
+		return toolError("INVALID_PARAMS", "invalid arguments: "+err.Error(), "", 0)
+	}
+	if p.Name == "" || p.Code == "" {
+		return toolError("INVALID_PARAMS", "name and code are required", "", 0)
+	}
+	runtime := p.Runtime
+	if runtime == "" {
+		runtime = "shell"
+	}
+	btn, err := s.svc.Create(button.CreateOpts{
+		Name:        p.Name,
+		Code:        p.Code,
+		Runtime:     runtime,
+		Description: p.Description,
+	})
+	if err != nil {
+		code := "CREATE_ERROR"
+		var se *button.ServiceError
+		if errors.As(err, &se) {
+			code = se.Code
+		}
+		return toolError(code, err.Error(), p.Name, 0)
+	}
+	return toolJSON(map[string]any{"created": btn.Name, "button": btn})
+}
+
+// --- tool result helpers (MCP content blocks) --------------------------------
+
+// toolText wraps text in the MCP tool-result content shape.
+func toolText(text string, isError bool) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": text}},
+		"isError": isError,
+	}
+}
+
+// toolJSON renders v as pretty JSON in a successful text result.
+func toolJSON(v any) map[string]any {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return toolError("INTERNAL", "could not encode result: "+err.Error(), "", 0)
+	}
+	return toolText(string(b), false)
+}
+
+// toolError renders the review-mandated structured error shape as an error result:
+// {"error":true,"code":"TIMEOUT","message":"…","button":"…","duration_ms":N}.
+func toolError(code, message, btn string, durationMs int64) map[string]any {
+	payload := map[string]any{"error": true, "code": code, "message": message}
+	if btn != "" {
+		payload["button"] = btn
+	}
+	if durationMs > 0 {
+		payload["duration_ms"] = durationMs
+	}
+	b, _ := json.Marshal(payload)
+	return toolText(string(b), true)
+}
+
+func nonEmpty(raw json.RawMessage) []byte {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return []byte("{}")
+	}
+	return raw
+}


### PR DESCRIPTION
## What

`buttons mcp` starts a **Model Context Protocol** server over **stdio** (newline-delimited
JSON-RPC 2.0, implemented directly — no external MCP dependency) so an agent like Claude Code
can discover and press buttons as tools.

> *"This is the killer feature."* — #265. Closes #265.

## Meta-tool surface (thin on purpose)

3 tools (+1 optional), not one-tool-per-button, so large button sets don't degrade the client:

| Tool | Does |
|---|---|
| `buttons_list` | lists only buttons with `mcp_enabled: true`, with their declared args |
| `buttons_press` | executes a button; args validated against the spec, passed as `BUTTONS_ARG_<NAME>` env (never substituted into shell text) |
| `buttons_inspect` | full spec + last 5 runs |
| `buttons_create` | **off** unless `buttons mcp --allow-create` |

## Security (per Review 3)

- **`mcp_enabled` gate** on every button-targeting tool — list, press, and inspect all refuse
  buttons that haven't opted in.
- **Rate limit** 10 calls/min per button → `RATE_LIMITED`.
- **Single concurrency** per button → second concurrent call returns `BUSY`.
- **Hard 120s cap** on any MCP press (via `runner.Options.MaxTimeoutSeconds`).
- **Structured errors**: `{"error":true,"code":"TIMEOUT","message":…,"button":…,"duration_ms":N}`.
- stdout carries **only** protocol messages; logs → stderr. Requests are handled concurrently with
  serialized writes, so a long press can't block `list`/`inspect`.

## How

- `internal/mcpserver/server.go` — JSON-RPC loop (initialize/ping/tools.list/tools.call), protocol
  framing, the rate-limit + concurrency guards.
- `internal/mcpserver/tools.go` — the four tool handlers, schemas, and the MCP content/`isError`
  result shape.
- `cmd/mcp.go` — `buttons mcp [--allow-create]`; reuses `internal/runner`.

## Acceptance criteria

- [x] `buttons mcp` starts an MCP server over stdio
- [x] `buttons_list` returns only `mcp_enabled: true` buttons
- [x] `buttons_press` executes with typed args
- [x] `buttons_press` validates args against the button's spec before exec
- [x] `buttons_inspect` returns spec + last 5 runs
- [x] >10 calls/min → rate-limit error
- [x] second concurrent call → busy error
- [x] hard 120s timeout cap
- [x] structured error responses
- [x] works over real stdio (smoke below); register with `claude mcp add buttons -- buttons mcp`

## Testing

Unit: list-gating, press forbidden-when-disabled, press executes, rate-limit, concurrency guard,
inspect, create-gated, and a full `Serve` wire test (initialize echoes the client's protocol
version; a notification gets no response). Full suite green (15 pkgs). **Live stdio smoke:**
`initialize` → `tools/list` (3 tools) → `buttons_press greet {who:cindy}` → `"hi cindy"`.

## Stacking

Stacked on **#193** (`feat/serve-api`) for `internal/runner`. Retargets to `main` once #193 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)