### PR TITLE
feat(trigger): buttons trigger — cron / watch / webhook (#272)

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -8,7 +8,9 @@ import (
 	"syscall"
 
 	"github.com/autonoco/buttons/internal/apiserver"
+	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/trigger"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +19,7 @@ var (
 	serveHost        string
 	serveAPIKey      string
 	serveAllowHTTPBt bool
+	serveNoTriggers  bool
 )
 
 var serveCmd = &cobra.Command{
@@ -72,10 +75,40 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	addr := fmt.Sprintf("%s:%d", host, servePort)
 	srv := apiserver.New(apiserver.Config{APIKey: apiKey, AllowHTTPButtons: serveAllowHTTPBt})
 
+	// Shutdown on signal or parent context cancel.
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Start the trigger engine (cron + watch in-process, webhook routes mounted
+	// here) unless disabled. Webhook routes share this listener per #272.
+	var webhookCount int
+	if !serveNoTriggers {
+		eng := trigger.NewEngine(button.NewService(), func(format string, a ...any) {
+			if !jsonOutput {
+				fmt.Fprintf(os.Stderr, "[trigger] "+format+"\n", a...)
+			}
+		})
+		routes, terr := eng.Start(ctx)
+		if terr != nil {
+			if jsonOutput {
+				_ = config.WriteJSONError("INTERNAL_ERROR", terr.Error())
+				return errSilent
+			}
+			return terr
+		}
+		for _, rt := range routes {
+			srv.HandleFunc("POST "+rt.Path, eng.WebhookHandler(rt))
+		}
+		webhookCount = len(routes)
+		defer eng.Stop()
+	}
+
 	if jsonOutput {
 		_ = config.WriteJSON(map[string]any{
-			"addr": addr,
-			"auth": apiKey != "",
+			"addr":             addr,
+			"auth":             apiKey != "",
+			"triggers_enabled": !serveNoTriggers,
+			"webhook_routes":   webhookCount,
 			"endpoints": []string{
 				"GET /api/health",
 				"GET /api/buttons",
@@ -89,12 +122,12 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		if apiKey == "" {
 			fmt.Fprintln(os.Stderr, "  ⚠ no API key set — auth disabled (loopback only)")
 		}
+		if !serveNoTriggers {
+			fmt.Fprintf(os.Stderr, "  triggers: on (%d webhook route(s) mounted)\n", webhookCount)
+		}
 		fmt.Fprintln(os.Stderr, "  Ctrl-C to stop.")
 	}
 
-	// Shutdown on signal or parent context cancel.
-	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
 	shutdown := make(chan struct{})
 	go func() {
 		<-ctx.Done()
@@ -136,5 +169,6 @@ func init() {
 	serveCmd.Flags().StringVar(&serveHost, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose; requires an API key)")
 	serveCmd.Flags().StringVar(&serveAPIKey, "api-key", "", "bearer key required on all endpoints (else the 'API_KEY' battery or $BUTTONS_API_KEY)")
 	serveCmd.Flags().BoolVar(&serveAllowHTTPBt, "allow-http-buttons", false, "allow pressing http (outbound-request) buttons over the API (SSRF surface; off by default)")
+	serveCmd.Flags().BoolVar(&serveNoTriggers, "no-triggers", false, "do not run the trigger engine (cron/watch/webhook) alongside the API")
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/trigger"
+	"github.com/spf13/cobra"
+)
+
+var triggerCmd = &cobra.Command{
+	Use:   "trigger",
+	Short: "Manage button triggers (cron, watch, webhook)",
+	Long: `Attach event triggers to a button so it presses automatically.
+
+Triggers run under 'buttons serve':
+  - cron    fires on a schedule (5-field cron, in-process scheduler)
+  - watch   fires when a file changes (polled, 500ms debounce)
+  - webhook fires on an HTTP POST to a path on the serve listener
+
+Examples:
+  buttons trigger add health --cron --schedule "0 */6 * * *"
+  buttons trigger add reindex --watch --path ./data.json
+  buttons trigger add deploy --webhook --webhook-path /hooks/deploy --token s3cr3t
+  buttons trigger list
+  buttons trigger rm health <trigger-id>`,
+}
+
+var triggerAddFlags struct {
+	webhook     bool
+	cron        bool
+	watch       bool
+	schedule    string
+	webhookPath string
+	watchPath   string
+	token       string
+	args        []string
+}
+
+var triggerAddCmd = &cobra.Command{
+	Use:   "add <button>",
+	Short: "Add a trigger to a button",
+	Args:  exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		if boolCount(triggerAddFlags.cron, triggerAddFlags.watch, triggerAddFlags.webhook) != 1 {
+			return cliErr("pass exactly one of --cron, --watch, or --webhook")
+		}
+		var tr button.Trigger
+		switch {
+		case triggerAddFlags.cron:
+			tr = button.Trigger{Kind: trigger.KindCron, Schedule: triggerAddFlags.schedule}
+		case triggerAddFlags.watch:
+			tr = button.Trigger{Kind: trigger.KindWatch, Path: triggerAddFlags.watchPath}
+		case triggerAddFlags.webhook:
+			tr = button.Trigger{Kind: trigger.KindWebhook, Path: triggerAddFlags.webhookPath, Token: triggerAddFlags.token}
+		}
+
+		parsedArgs, err := parseTriggerArgs(triggerAddFlags.args)
+		if err != nil {
+			return cliErr(err.Error())
+		}
+		tr.Args = parsedArgs
+
+		svc := button.NewService()
+		created, err := trigger.Add(svc, name, tr)
+		if err != nil {
+			return handleServiceError(err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"button": name, "trigger": created})
+		}
+		fmt.Fprintf(os.Stderr, "Added %s trigger %s to %q\n", created.Kind, created.ID, name)
+		printNextHint("buttons trigger list")
+		return nil
+	},
+}
+
+var triggerListCmd = &cobra.Command{
+	Use:   "list [button]",
+	Short: "List triggers (all buttons, or one)",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc := button.NewService()
+		if len(args) == 1 {
+			trs, err := trigger.List(svc, args[0])
+			if err != nil {
+				return handleServiceError(err)
+			}
+			if jsonOutput {
+				return config.WriteJSON(map[string]any{"button": args[0], "triggers": trs})
+			}
+			if len(trs) == 0 {
+				fmt.Fprintf(os.Stderr, "no triggers on %q\n", args[0])
+				return nil
+			}
+			for _, t := range trs {
+				fmt.Fprintf(os.Stderr, "  %s  %-7s  %s\n", t.ID, t.Kind, triggerDetail(t))
+			}
+			return nil
+		}
+
+		all, err := trigger.ListAll(svc)
+		if err != nil {
+			return handleServiceError(err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"triggers": all})
+		}
+		if len(all) == 0 {
+			fmt.Fprintln(os.Stderr, "no triggers configured")
+			return nil
+		}
+		for _, b := range all {
+			fmt.Fprintf(os.Stderr, "  %s  %-7s  %-20s  %s\n", b.Trigger.ID, b.Trigger.Kind, b.Button, triggerDetail(b.Trigger))
+		}
+		return nil
+	},
+}
+
+var triggerRmCmd = &cobra.Command{
+	Use:   "rm <button> <trigger-id>",
+	Short: "Remove a trigger from a button",
+	Args:  exactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc := button.NewService()
+		if err := trigger.Remove(svc, args[0], args[1]); err != nil {
+			return handleServiceError(err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"removed": args[1], "button": args[0]})
+		}
+		fmt.Fprintf(os.Stderr, "Removed trigger %s from %q\n", args[1], args[0])
+		return nil
+	},
+}
+
+func triggerDetail(t button.Trigger) string {
+	switch t.Kind {
+	case trigger.KindCron:
+		return t.Schedule
+	case trigger.KindWatch:
+		return "watch " + t.Path
+	case trigger.KindWebhook:
+		if t.Token != "" {
+			return "POST " + t.Path + " (token)"
+		}
+		return "POST " + t.Path
+	}
+	return ""
+}
+
+func boolCount(bs ...bool) int {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+func parseTriggerArgs(pairs []string) (map[string]string, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		i := strings.Index(p, "=")
+		if i <= 0 {
+			return nil, fmt.Errorf("arg %q must be key=value", p)
+		}
+		out[p[:i]] = p[i+1:]
+	}
+	return out, nil
+}
+
+func cliErr(msg string) error {
+	if jsonOutput {
+		_ = config.WriteJSONError("VALIDATION_ERROR", msg)
+		return errSilent
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func init() {
+	triggerAddCmd.Flags().BoolVar(&triggerAddFlags.cron, "cron", false, "cron-scheduled trigger")
+	triggerAddCmd.Flags().BoolVar(&triggerAddFlags.watch, "watch", false, "file-watch trigger")
+	triggerAddCmd.Flags().BoolVar(&triggerAddFlags.webhook, "webhook", false, "webhook (HTTP POST) trigger")
+	triggerAddCmd.Flags().StringVar(&triggerAddFlags.schedule, "schedule", "", "cron schedule, 5-field (e.g. \"0 */6 * * *\")")
+	triggerAddCmd.Flags().StringVar(&triggerAddFlags.webhookPath, "webhook-path", "", "URL path for the webhook (e.g. /hooks/deploy)")
+	triggerAddCmd.Flags().StringVar(&triggerAddFlags.watchPath, "path", "", "file path to watch")
+	triggerAddCmd.Flags().StringVar(&triggerAddFlags.token, "token", "", "shared secret required on webhook POSTs (X-Buttons-Token or ?token=)")
+	triggerAddCmd.Flags().StringArrayVar(&triggerAddFlags.args, "arg", nil, "argument key=value passed when the trigger fires (repeatable)")
+
+	triggerCmd.AddCommand(triggerAddCmd)
+	triggerCmd.AddCommand(triggerListCmd)
+	triggerCmd.AddCommand(triggerRmCmd)
+	rootCmd.AddCommand(triggerCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/google/cel-go v0.28.1
 	github.com/mattn/go-isatty v0.0.22
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -57,6 +57,13 @@ func New(cfg Config) *Server {
 // Handler returns the http.Handler for mounting (also used directly in tests).
 func (s *Server) Handler() http.Handler { return s.mux }
 
+// HandleFunc registers an additional route on the server mux, bypassing the
+// bearer-auth wrapper. Used to mount webhook trigger endpoints (#272), which
+// carry their own per-trigger token auth. Call before ListenAndServe.
+func (s *Server) HandleFunc(pattern string, h http.HandlerFunc) {
+	s.mux.HandleFunc(pattern, h)
+}
+
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/buttons", s.auth(s.handleList))

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -77,9 +77,32 @@ type Button struct {
 	// ContentHash is the SHA256 of the button's content at install time —
 	// the lock-file pin used to detect drift and available updates. Set
 	// by the store, never by `create`.
-	ContentHash string    `json:"content_hash,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ContentHash string `json:"content_hash,omitempty"`
+	// Triggers fire this button on an event — a cron schedule, a watched
+	// file change, or a webhook POST (served by `buttons serve`). Managed
+	// via `buttons trigger`. Omitted when empty.
+	Triggers  []Trigger `json:"triggers,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Trigger declares an event that presses this button automatically. The engine
+// runs under `buttons serve`: cron schedules tick in-process, watch triggers
+// poll a file, and webhook triggers mount an HTTP route on the serve listener.
+type Trigger struct {
+	ID   string `json:"id"`   // short stable id (for `trigger rm`)
+	Kind string `json:"kind"` // "cron" | "watch" | "webhook"
+	// Schedule is a 5-field cron expression (kind=cron), e.g. "0 */6 * * *".
+	Schedule string `json:"schedule,omitempty"`
+	// Path is the watched file (kind=watch) or the webhook URL path
+	// (kind=webhook), e.g. "/hooks/health".
+	Path string `json:"path,omitempty"`
+	// Token, when set on a webhook trigger, must match the X-Buttons-Token
+	// header (or ?token= query) or the request is rejected 401.
+	Token string `json:"token,omitempty"`
+	// Args are passed to the press when the trigger fires.
+	Args      map[string]string `json:"args,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
 }
 
 // QueueConfig declares per-button concurrency limits. Enforced at

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -22,13 +22,15 @@ import (
 // destination at create time.
 //
 // Existing patterns that stay valid:
-//   https://api.example.com/users/{{user}}
-//   https://api.example.com/things?filter={{filter}}
+//
+//	https://api.example.com/users/{{user}}
+//	https://api.example.com/things?filter={{filter}}
 //
 // Patterns rejected (with remediation):
-//   https://{{host}}.example.com/x      // host templating
-//   {{scheme}}://api.example.com/x      // scheme templating
-//   https://api.{{tenant}}/foo          // mid-host templating
+//
+//	https://{{host}}.example.com/x      // host templating
+//	{{scheme}}://api.example.com/x      // scheme templating
+//	https://api.{{tenant}}/foo          // mid-host templating
 //
 // Returns the literal lowercased host on success. "*" as the whole
 // URL is reserved — not used here.
@@ -392,6 +394,28 @@ func (s *Service) PressedDir(name string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(btnDir, "pressed"), nil
+}
+
+// Update persists a modified button spec back to its button.json, refreshing
+// UpdatedAt. Used by `buttons trigger` to add/remove triggers on a button.
+func (s *Service) Update(btn *Button) error {
+	name := Slugify(btn.Name)
+	btnDir, err := s.buttonDir(name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(btnDir); os.IsNotExist(err) {
+		return &ServiceError{Code: "NOT_FOUND", Message: fmt.Sprintf("button not found: %s", name)}
+	}
+	btn.UpdatedAt = time.Now()
+	data, err := json.MarshalIndent(btn, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal button: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(btnDir, "button.json"), data, 0600); err != nil {
+		return fmt.Errorf("failed to write button spec: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) Remove(name string) error {

--- a/internal/trigger/engine.go
+++ b/internal/trigger/engine.go
@@ -1,0 +1,170 @@
+package trigger
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/runner"
+	cron "github.com/robfig/cron/v3"
+)
+
+// Engine runs cron + watch triggers in-process and produces webhook routes for
+// the serve listener to mount. Construct with NewEngine, Start, then Stop.
+type Engine struct {
+	svc  *button.Service
+	cron *cron.Cron
+	wg   sync.WaitGroup
+	log  func(string, ...any)
+}
+
+// NewEngine builds an Engine. log may be nil (then logging is dropped).
+func NewEngine(svc *button.Service, log func(string, ...any)) *Engine {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	return &Engine{svc: svc, log: log}
+}
+
+// WebhookRoute is one webhook trigger to mount on the HTTP listener.
+type WebhookRoute struct {
+	Path   string
+	Button string
+	Token  string
+	Args   map[string]string
+}
+
+// Start launches cron schedulers and file watchers for every configured
+// trigger and returns the webhook routes the caller must mount. Cron/watch run
+// until ctx is cancelled; call Stop to drain.
+func (e *Engine) Start(ctx context.Context) ([]WebhookRoute, error) {
+	all, err := ListAll(e.svc)
+	if err != nil {
+		return nil, err
+	}
+	e.cron = cron.New()
+	webhooks := []WebhookRoute{}
+	cronN, watchN := 0, 0
+
+	for _, b := range all {
+		switch b.Trigger.Kind {
+		case KindCron:
+			name, args := b.Button, b.Trigger.Args
+			if _, err := e.cron.AddFunc(b.Trigger.Schedule, func() { e.fire(name, args, "cron") }); err != nil {
+				e.log("skip cron trigger on %s: %v", name, err)
+				continue
+			}
+			cronN++
+		case KindWatch:
+			e.wg.Add(1)
+			go func(name, path string, args map[string]string) {
+				defer e.wg.Done()
+				e.watch(ctx, name, path, args)
+			}(b.Button, b.Trigger.Path, b.Trigger.Args)
+			watchN++
+		case KindWebhook:
+			webhooks = append(webhooks, WebhookRoute{
+				Path: b.Trigger.Path, Button: b.Button, Token: b.Trigger.Token, Args: b.Trigger.Args,
+			})
+		}
+	}
+
+	if cronN > 0 {
+		e.cron.Start()
+	}
+	e.log("triggers loaded: %d cron, %d watch, %d webhook", cronN, watchN, len(webhooks))
+	return webhooks, nil
+}
+
+// Stop halts the cron scheduler and waits for watchers + running jobs to finish.
+func (e *Engine) Stop() {
+	if e.cron != nil {
+		<-e.cron.Stop().Done() // wait out any in-flight cron jobs
+	}
+	e.wg.Wait()
+}
+
+// fire presses the button. The button's own timeout applies via runner.
+func (e *Engine) fire(name string, args map[string]string, source string) {
+	res, err := runner.Press(context.Background(), name, args, runner.Options{RecordHistory: true})
+	if err != nil {
+		e.log("[%s] %s press error: %v", source, name, err)
+		return
+	}
+	e.log("[%s] %s → %s (%dms)", source, name, res.Status, res.DurationMs)
+}
+
+// watch polls a file's mtime/size every 500ms and fires on change. Polling
+// (vs fsnotify) is robust across editors that rename-replace on save, and
+// keeps the watch dependency-free; the 500ms interval is the debounce window.
+func (e *Engine) watch(ctx context.Context, name, path string, args map[string]string) {
+	const interval = 500 * time.Millisecond
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastMod time.Time
+	var lastSize int64
+	primed := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fi, err := os.Stat(path)
+			if err != nil {
+				continue // file missing/unreadable right now; keep watching
+			}
+			mod, size := fi.ModTime(), fi.Size()
+			if !primed {
+				lastMod, lastSize, primed = mod, size, true
+				continue
+			}
+			if !mod.Equal(lastMod) || size != lastSize {
+				lastMod, lastSize = mod, size
+				e.fire(name, args, "watch:"+path)
+			}
+		}
+	}
+}
+
+// WebhookHandler returns the HTTP handler for one webhook route. A POST presses
+// the button (token-gated when set) and responds 202 immediately so the sender
+// doesn't block on the press.
+func (e *Engine) WebhookHandler(route WebhookRoute) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"ok": false, "error": "method_not_allowed"})
+			return
+		}
+		if route.Token != "" && !tokenOK(r, route.Token) {
+			writeJSON(w, http.StatusUnauthorized, map[string]any{"ok": false, "error": "unauthorized"})
+			return
+		}
+		// Body isn't mapped to args in v1 (the trigger's configured args are
+		// used); drain it bounded so the sender's write completes.
+		_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, 1<<20))
+		go e.fire(route.Button, route.Args, "webhook:"+route.Path)
+		writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "button": route.Button})
+	}
+}
+
+func tokenOK(r *http.Request, want string) bool {
+	return constEq(r.Header.Get("X-Buttons-Token"), want) || constEq(r.URL.Query().Get("token"), want)
+}
+
+func constEq(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -1,0 +1,131 @@
+// Package trigger stores and runs button triggers (#272): cron schedules,
+// file watchers, and webhook endpoints. Triggers live on the button spec
+// (button.Trigger); the Engine runs them under `buttons serve`.
+package trigger
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/autonoco/buttons/internal/button"
+	cron "github.com/robfig/cron/v3"
+)
+
+// Trigger kinds.
+const (
+	KindCron    = "cron"
+	KindWatch   = "watch"
+	KindWebhook = "webhook"
+)
+
+// Add validates and appends a trigger to a button, persisting the spec. The
+// generated id is returned for later `trigger rm`.
+func Add(svc *button.Service, buttonName string, tr button.Trigger) (*button.Trigger, error) {
+	btn, err := svc.Get(buttonName)
+	if err != nil {
+		return nil, err
+	}
+	if err := Validate(tr); err != nil {
+		return nil, err
+	}
+	// Reject a duplicate webhook path on the same button (would collide at mount).
+	if tr.Kind == KindWebhook {
+		for _, ex := range btn.Triggers {
+			if ex.Kind == KindWebhook && ex.Path == tr.Path {
+				return nil, fmt.Errorf("button %q already has a webhook trigger at %s", buttonName, tr.Path)
+			}
+		}
+	}
+	tr.ID = newID()
+	tr.CreatedAt = time.Now()
+	btn.Triggers = append(btn.Triggers, tr)
+	if err := svc.Update(btn); err != nil {
+		return nil, err
+	}
+	return &tr, nil
+}
+
+// Validate checks a trigger's shape per kind (cron expression parses, paths set).
+func Validate(tr button.Trigger) error {
+	switch tr.Kind {
+	case KindCron:
+		if strings.TrimSpace(tr.Schedule) == "" {
+			return fmt.Errorf("cron trigger needs a --schedule")
+		}
+		if _, err := cron.ParseStandard(tr.Schedule); err != nil {
+			return fmt.Errorf("invalid cron schedule %q: %w", tr.Schedule, err)
+		}
+	case KindWatch:
+		if strings.TrimSpace(tr.Path) == "" {
+			return fmt.Errorf("watch trigger needs a --path")
+		}
+	case KindWebhook:
+		if !strings.HasPrefix(tr.Path, "/") {
+			return fmt.Errorf("webhook trigger needs a --webhook-path starting with '/'")
+		}
+	default:
+		return fmt.Errorf("unknown trigger kind %q (want cron|watch|webhook)", tr.Kind)
+	}
+	return nil
+}
+
+// List returns a button's triggers.
+func List(svc *button.Service, buttonName string) ([]button.Trigger, error) {
+	btn, err := svc.Get(buttonName)
+	if err != nil {
+		return nil, err
+	}
+	return btn.Triggers, nil
+}
+
+// Bound is a (button, trigger) pair from a full scan.
+type Bound struct {
+	Button  string         `json:"button"`
+	Trigger button.Trigger `json:"trigger"`
+}
+
+// ListAll returns every trigger across every button.
+func ListAll(svc *button.Service) ([]Bound, error) {
+	buttons, err := svc.List()
+	if err != nil {
+		return nil, err
+	}
+	out := []Bound{}
+	for _, b := range buttons {
+		for _, t := range b.Triggers {
+			out = append(out, Bound{Button: b.Name, Trigger: t})
+		}
+	}
+	return out, nil
+}
+
+// Remove deletes a trigger by id from a button.
+func Remove(svc *button.Service, buttonName, id string) error {
+	btn, err := svc.Get(buttonName)
+	if err != nil {
+		return err
+	}
+	kept := make([]button.Trigger, 0, len(btn.Triggers))
+	found := false
+	for _, t := range btn.Triggers {
+		if t.ID == id {
+			found = true
+			continue
+		}
+		kept = append(kept, t)
+	}
+	if !found {
+		return fmt.Errorf("no trigger %q on button %q", id, buttonName)
+	}
+	btn.Triggers = kept
+	return svc.Update(btn)
+}
+
+func newID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/trigger/trigger_test.go
+++ b/internal/trigger/trigger_test.go
@@ -1,0 +1,181 @@
+package trigger
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/history"
+)
+
+func writeButton(t *testing.T, home, name string) {
+	t.Helper()
+	dir := filepath.Join(home, "buttons", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	spec := `{"schema_version":1,"name":"` + name + `","runtime":"shell","env":{},"timeout_seconds":30,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.sh"), []byte("#!/bin/sh\necho fired\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddListRemove(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "job")
+	svc := button.NewService()
+
+	created, err := Add(svc, "job", button.Trigger{Kind: KindCron, Schedule: "0 */6 * * *"})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("trigger should get an id")
+	}
+
+	trs, err := List(svc, "job")
+	if err != nil || len(trs) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(trs))
+	}
+
+	all, _ := ListAll(svc)
+	if len(all) != 1 || all[0].Button != "job" {
+		t.Fatalf("listall: %+v", all)
+	}
+
+	if err := Remove(svc, "job", created.ID); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if trs, _ := List(svc, "job"); len(trs) != 0 {
+		t.Fatalf("expected 0 triggers after remove, got %d", len(trs))
+	}
+	if err := Remove(svc, "job", "nope"); err == nil {
+		t.Fatal("removing unknown id should error")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		tr   button.Trigger
+		ok   bool
+	}{
+		{"cron ok", button.Trigger{Kind: KindCron, Schedule: "*/5 * * * *"}, true},
+		{"cron no schedule", button.Trigger{Kind: KindCron}, false},
+		{"cron bad expr", button.Trigger{Kind: KindCron, Schedule: "not a cron"}, false},
+		{"watch ok", button.Trigger{Kind: KindWatch, Path: "./x.json"}, true},
+		{"watch no path", button.Trigger{Kind: KindWatch}, false},
+		{"webhook ok", button.Trigger{Kind: KindWebhook, Path: "/hooks/x"}, true},
+		{"webhook no slash", button.Trigger{Kind: KindWebhook, Path: "hooks/x"}, false},
+		{"unknown kind", button.Trigger{Kind: "nope"}, false},
+	}
+	for _, c := range cases {
+		err := Validate(c.tr)
+		if (err == nil) != c.ok {
+			t.Errorf("%s: ok=%v err=%v", c.name, c.ok, err)
+		}
+	}
+}
+
+func TestWebhookHandlerTokenGate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "deploy")
+
+	eng := NewEngine(button.NewService(), nil)
+	h := eng.WebhookHandler(WebhookRoute{Path: "/hooks/deploy", Button: "deploy", Token: "s3cr3t"})
+
+	// Wrong/missing token → 401.
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("POST", "/hooks/deploy", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token should 401, got %d", rec.Code)
+	}
+
+	// GET → 405.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/hooks/deploy", nil)
+	req.Header.Set("X-Buttons-Token", "s3cr3t")
+	h(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET should 405, got %d", rec.Code)
+	}
+
+	// Correct token → 202.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/hooks/deploy", nil)
+	req.Header.Set("X-Buttons-Token", "s3cr3t")
+	h(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("valid token should 202, got %d", rec.Code)
+	}
+}
+
+func TestEngineWatchFires(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "reindex")
+	svc := button.NewService()
+
+	watched := filepath.Join(t.TempDir(), "data.json")
+	if err := os.WriteFile(watched, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Add(svc, "reindex", button.Trigger{Kind: KindWatch, Path: watched}); err != nil {
+		t.Fatalf("add watch: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	eng := NewEngine(svc, nil)
+	if _, err := eng.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { cancel(); eng.Stop() }()
+
+	// Let the watcher prime, then change the file.
+	time.Sleep(700 * time.Millisecond)
+	if err := os.WriteFile(watched, []byte("v2-changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to ~4s for the press to be recorded.
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		runs, _ := history.List("reindex", 1)
+		if len(runs) >= 1 {
+			return // fired
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatal("watch trigger did not fire a press within timeout")
+}
+
+func TestEngineStartCountsKinds(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeButton(t, home, "multi")
+	svc := button.NewService()
+	_, _ = Add(svc, "multi", button.Trigger{Kind: KindWebhook, Path: "/hooks/a"})
+	_, _ = Add(svc, "multi", button.Trigger{Kind: KindCron, Schedule: "* * * * *"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eng := NewEngine(svc, nil)
+	routes, err := eng.Start(ctx)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer eng.Stop()
+	if len(routes) != 1 || routes[0].Path != "/hooks/a" {
+		t.Fatalf("expected 1 webhook route /hooks/a, got %+v", routes)
+	}
+}


### PR DESCRIPTION
## What

Event-driven button execution (#272). Triggers live on the button spec and run under `buttons serve`.

```
buttons trigger add health  --cron    --schedule "0 */6 * * *"
buttons trigger add reindex --watch   --path ./data.json
buttons trigger add deploy  --webhook --webhook-path /hooks/deploy --token s3cr3t
buttons trigger list [button]
buttons trigger rm <button> <trigger-id>
```

## How

- **`internal/button`** — `Trigger` on the spec (`kind` cron|watch|webhook, `schedule`/`path`/`token`/`args`) + `Service.Update` to persist edits.
- **`internal/trigger`**
  - **store** — `Add` / `List` / `ListAll` / `Remove` + per-kind `Validate` (cron expression parses, paths set, no duplicate webhook path on a button).
  - **engine** —
    - **cron**: `robfig/cron/v3` in-process scheduler.
    - **watch**: 500 ms mtime/size polling — robust across editors that rename-on-save (where a raw fsnotify file-watch misses events), dependency-light, and the poll interval is the debounce window.
    - **webhook**: an `http.HandlerFunc` mounted on the serve listener, token-gated (`X-Buttons-Token` header or `?token=`, constant-time compare), presses async and returns `202`.
    - every fire goes through **`internal/runner`** and records history.
- **`cmd/api.go`** — `buttons serve` starts the engine (cron + watch goroutines) and mounts webhook routes; `--no-triggers` opts out; drains cleanly on shutdown.

## Acceptance criteria

- [x] webhook trigger fires button on POST to its path
- [x] cron trigger fires on schedule (5-field, in-process scheduler)
- [x] watch trigger fires on file change (debounced)
- [x] `buttons trigger list` shows all triggers
- [x] each triggered execution persisted to history
- [x] multiple triggers per button supported

## Testing

Unit: add/list/remove, validation table, webhook token gate (401/405/202), kind counting, and a **live watch-fires integration** (file change → recorded press). Full suite green (15 pkgs). **E2E smoke:** `trigger add --webhook` → `serve` mounts it → POST `401` (no token) / `202` (token) → button fired (`history: ok`).

> Watch uses polling rather than fsnotify by design (see above); swapping in fsnotify with parent-dir watching is a clean future optimization.

## Stacking

Stacked on **#193** (`feat/serve-api`) — needs `internal/runner` and the apiserver mount point. Adds dep `github.com/robfig/cron/v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)