### PR TITLE
feat(import): buttons import — skill / code / url adapters (#277)

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/importer"
+	"github.com/spf13/cobra"
+)
+
+var (
+	importName string
+	importYes  bool
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Create buttons from external sources (skill, code, url)",
+	Long: `Import buttons from external sources:
+
+  buttons import code <file>     wrap a script as a button (runtime inferred)
+  buttons import skill <dir>     a button per script in an AgentSkills skill
+  buttons import url <url>       create a button from a fetched HTTP spec
+  buttons import mcp <server>    (planned) one button per MCP tool
+
+Every import prints what it will create and asks to confirm. Pass --yes to
+skip the prompt (required when running non-interactively).`,
+}
+
+var importCodeCmd = &cobra.Command{
+	Use:   "code <file>",
+	Short: "Wrap a script file as a button",
+	Args:  exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		plan, err := importer.PlanCode(args[0], importName)
+		if err != nil {
+			return importErr(err)
+		}
+		return runImport(plan)
+	},
+}
+
+var importSkillCmd = &cobra.Command{
+	Use:   "skill <dir>",
+	Short: "Create buttons from an AgentSkills skill directory",
+	Args:  exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		plan, err := importer.PlanSkill(args[0])
+		if err != nil {
+			return importErr(err)
+		}
+		return runImport(plan)
+	},
+}
+
+var importURLCmd = &cobra.Command{
+	Use:   "url <url>",
+	Short: "Create a button from a spec fetched over HTTP",
+	Args:  exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		plan, err := importer.PlanURL(args[0], importName)
+		if err != nil {
+			return importErr(err)
+		}
+		return runImport(plan)
+	},
+}
+
+var importMCPCmd = &cobra.Command{
+	Use:   "mcp <server>",
+	Short: "Create buttons from an MCP server's tools (planned)",
+	Args:  exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return importErr(fmt.Errorf("mcp import is not implemented yet — it needs an MCP client to enumerate the server's tools (tracked in #277 follow-up). Use `buttons import code|skill|url` today"))
+	},
+}
+
+// runImport shows the plan, confirms, and applies it.
+func runImport(plan *importer.Plan) error {
+	if len(plan.Items) == 0 {
+		return importErr(fmt.Errorf("nothing to import"))
+	}
+
+	if !jsonOutput {
+		fmt.Fprintf(os.Stderr, "Will create %d button(s) from %s:\n", len(plan.Items), plan.Kind)
+		for _, it := range plan.Items {
+			fmt.Fprintf(os.Stderr, "  • %-24s %-7s  %s\n", it.Name, it.Runtime, it.Source)
+		}
+	}
+
+	if !importYes {
+		if jsonOutput || config.IsNonTTY() {
+			return importErr(fmt.Errorf("confirmation required: re-run with --yes to import non-interactively"))
+		}
+		fmt.Fprintf(os.Stderr, "Proceed? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		if a := strings.ToLower(strings.TrimSpace(answer)); a != "y" && a != "yes" {
+			fmt.Fprintln(os.Stderr, "aborted")
+			return nil
+		}
+	}
+
+	res := importer.Apply(button.NewService(), plan)
+
+	if jsonOutput {
+		return config.WriteJSON(res)
+	}
+	for name, e := range res.Errors {
+		fmt.Fprintf(os.Stderr, "  ✗ %s: %s\n", name, e)
+	}
+	fmt.Fprintf(os.Stderr, "Imported %d button(s): %s\n", len(res.Created), strings.Join(res.Created, ", "))
+	if len(res.Created) > 0 {
+		printNextHint("buttons press %s", res.Created[0])
+	}
+	return nil
+}
+
+func importErr(err error) error {
+	if jsonOutput {
+		_ = config.WriteJSONError("IMPORT_ERROR", err.Error())
+		return errSilent
+	}
+	return err
+}
+
+func init() {
+	importCmd.PersistentFlags().StringVar(&importName, "name", "", "override the generated button name (code/url)")
+	importCmd.PersistentFlags().BoolVarP(&importYes, "yes", "y", false, "skip the confirmation prompt")
+	importCmd.AddCommand(importCodeCmd, importSkillCmd, importURLCmd, importMCPCmd)
+	rootCmd.AddCommand(importCmd)
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,0 +1,250 @@
+// Package importer turns external sources into buttons (#277): a script file
+// (code), an AgentSkills skill directory (skill), or a button spec at a URL.
+// Each adapter produces a Plan the caller can show + confirm before Apply
+// actually creates the buttons via button.Service.
+package importer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+const (
+	maxImportBytes = 64 * 1024 // matches the create inline-code limit
+	defaultTimeout = 300       // seconds; mirrors `buttons create`'s default
+)
+
+// Planned is one button an import would create.
+type Planned struct {
+	Name        string `json:"name"`
+	Runtime     string `json:"runtime"`
+	Source      string `json:"source"`
+	Description string `json:"description,omitempty"`
+	opts        button.CreateOpts
+}
+
+// Plan is the full set an import would create, with its kind for display.
+type Plan struct {
+	Kind  string    `json:"kind"`
+	Items []Planned `json:"items"`
+}
+
+// Result reports what Apply created and any per-item failures.
+type Result struct {
+	Created []string          `json:"created"`
+	Errors  map[string]string `json:"errors,omitempty"`
+}
+
+// Apply creates every planned button. A failure on one item is recorded and
+// the rest proceed, so a single bad script doesn't abort a skill import.
+func Apply(svc *button.Service, plan *Plan) *Result {
+	res := &Result{Errors: map[string]string{}}
+	for _, it := range plan.Items {
+		if _, err := svc.Create(it.opts); err != nil {
+			res.Errors[it.Name] = err.Error()
+			continue
+		}
+		res.Created = append(res.Created, it.Name)
+	}
+	if len(res.Errors) == 0 {
+		res.Errors = nil
+	}
+	return res
+}
+
+// PlanCode wraps a single script file as a button, inferring runtime from the
+// extension then the shebang. nameOverride wins when set.
+func PlanCode(file, nameOverride string) (*Plan, error) {
+	data, err := readFileLimited(file)
+	if err != nil {
+		return nil, err
+	}
+	name := nameOverride
+	if name == "" {
+		name = baseName(file)
+	}
+	rt := inferRuntime(file, string(data))
+	return &Plan{Kind: "code", Items: []Planned{{
+		Name:    name,
+		Runtime: rt,
+		Source:  file,
+		opts:    button.CreateOpts{Name: name, Code: string(data), Runtime: rt, TimeoutSeconds: defaultTimeout},
+	}}}, nil
+}
+
+// PlanSkill reads an AgentSkills skill directory. When a scripts/ dir exists,
+// each script becomes a button (named <skill>-<script>); otherwise the skill's
+// SKILL.md becomes a single prompt button.
+func PlanSkill(dir string) (*Plan, error) {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("not a skill directory: %s", dir)
+	}
+	skill := baseName(dir)
+	desc := skillDescription(dir)
+
+	scriptsDir := filepath.Join(dir, "scripts")
+	plan := &Plan{Kind: "skill"}
+	if entries, err := os.ReadDir(scriptsDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			path := filepath.Join(scriptsDir, e.Name())
+			data, err := readFileLimited(path)
+			if err != nil {
+				continue // skip oversized/unreadable scripts; Apply reports nothing for them
+			}
+			name := skill + "-" + baseName(path)
+			rt := inferRuntime(path, string(data))
+			plan.Items = append(plan.Items, Planned{
+				Name:        name,
+				Runtime:     rt,
+				Source:      path,
+				Description: desc,
+				opts:        button.CreateOpts{Name: name, Code: string(data), Runtime: rt, Description: desc, TimeoutSeconds: defaultTimeout},
+			})
+		}
+	}
+	if len(plan.Items) == 0 {
+		// No scripts/ — treat SKILL.md as a prompt button.
+		md, err := readSkillMD(dir)
+		if err != nil {
+			return nil, fmt.Errorf("skill %q has no scripts/ and no SKILL.md", skill)
+		}
+		plan.Items = append(plan.Items, Planned{
+			Name:        skill,
+			Runtime:     "prompt",
+			Source:      filepath.Join(dir, "SKILL.md"),
+			Description: desc,
+			opts:        button.CreateOpts{Name: skill, Prompt: md, Description: desc},
+		})
+	}
+	return plan, nil
+}
+
+// PlanURL fetches a button spec from a URL. Supports self-contained HTTP/API
+// button specs (the kind `create --url` produces); code/prompt buttons need
+// their bundle, so use `buttons install` (the registry) for those.
+func PlanURL(url, nameOverride string) (*Plan, error) {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return nil, fmt.Errorf("url must start with http:// or https://")
+	}
+	resp, err := http.Get(url) // #nosec G107 -- user-supplied import URL, fetched read-only and size-capped
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImportBytes))
+	if err != nil {
+		return nil, err
+	}
+	var spec button.Button
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("not a button spec (invalid JSON): %w", err)
+	}
+	name := nameOverride
+	if name == "" {
+		name = spec.Name
+	}
+	if name == "" {
+		return nil, fmt.Errorf("spec has no name; pass --name")
+	}
+	if spec.URL == "" {
+		return nil, fmt.Errorf("url import supports HTTP/API button specs (spec.url set); for code/prompt buttons use `buttons install`")
+	}
+	return &Plan{Kind: "url", Items: []Planned{{
+		Name:        name,
+		Runtime:     "http",
+		Source:      url,
+		Description: spec.Description,
+		opts: button.CreateOpts{
+			Name: name, URL: spec.URL, Method: spec.Method, Headers: spec.Headers,
+			Body: spec.Body, Description: spec.Description, Args: spec.Args, TimeoutSeconds: defaultTimeout,
+		},
+	}}}, nil
+}
+
+// inferRuntime maps a script to a supported runtime (shell|python|node) by
+// extension first, then shebang, defaulting to shell.
+func inferRuntime(path, content string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".py":
+		return "python"
+	case ".js", ".mjs", ".cjs":
+		return "node"
+	case ".sh", ".bash":
+		return "shell"
+	}
+	first := content
+	if i := strings.IndexByte(content, '\n'); i >= 0 {
+		first = content[:i]
+	}
+	first = strings.ToLower(first)
+	switch {
+	case strings.Contains(first, "python"):
+		return "python"
+	case strings.Contains(first, "node"):
+		return "node"
+	default:
+		return "shell"
+	}
+}
+
+func readFileLimited(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", path)
+	}
+	if info.Size() > maxImportBytes {
+		return nil, fmt.Errorf("%s exceeds the %dKB import limit", path, maxImportBytes/1024)
+	}
+	// #nosec G304 -- path is a user-specified import target, read-only.
+	return os.ReadFile(path)
+}
+
+// baseName returns the filename without directory or extension.
+func baseName(path string) string {
+	b := filepath.Base(path)
+	return strings.TrimSuffix(b, filepath.Ext(b))
+}
+
+// skillDescription returns a one-line description from SKILL.md's first heading
+// or first non-empty line, falling back to the skill directory name.
+func skillDescription(dir string) string {
+	md, err := readSkillMD(dir)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(md, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimLeft(line, "# "))
+	}
+	return ""
+}
+
+func readSkillMD(dir string) (string, error) {
+	for _, name := range []string{"SKILL.md", "skill.md", "Skill.md"} {
+		// #nosec G304 -- dir is a user-specified skill path; reading a known filename within it.
+		if data, err := os.ReadFile(filepath.Join(dir, name)); err == nil {
+			return string(data), nil
+		}
+	}
+	return "", fmt.Errorf("no SKILL.md in %s", dir)
+}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -1,0 +1,135 @@
+package importer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+func TestPlanCodeInfersRuntime(t *testing.T) {
+	dir := t.TempDir()
+	py := filepath.Join(dir, "deploy.py")
+	if err := os.WriteFile(py, []byte("print('hi')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanCode(py, "")
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Items) != 1 || plan.Items[0].Runtime != "python" || plan.Items[0].Name != "deploy" {
+		t.Fatalf("unexpected plan: %+v", plan.Items)
+	}
+
+	// Shebang inference for an extensionless file.
+	sh := filepath.Join(dir, "runme")
+	if err := os.WriteFile(sh, []byte("#!/usr/bin/env node\nconsole.log(1)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, _ = PlanCode(sh, "tool")
+	if plan.Items[0].Runtime != "node" || plan.Items[0].Name != "tool" {
+		t.Fatalf("shebang/override failed: %+v", plan.Items[0])
+	}
+}
+
+func TestPlanCodeApplyCreatesFunctionalButton(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "hello.sh")
+	if err := os.WriteFile(f, []byte("#!/bin/sh\necho hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanCode(f, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := Apply(button.NewService(), plan)
+	if len(res.Created) != 1 || res.Errors != nil {
+		t.Fatalf("apply: created=%v errors=%v", res.Created, res.Errors)
+	}
+	// The created button is real and carries the imported code.
+	if _, err := button.NewService().Get("hello"); err != nil {
+		t.Fatalf("imported button missing: %v", err)
+	}
+	code, _ := os.ReadFile(filepath.Join(home, "buttons", "hello", "main.sh"))
+	if string(code) != "#!/bin/sh\necho hi\n" {
+		t.Fatalf("code not imported: %q", code)
+	}
+}
+
+func TestPlanSkillScripts(t *testing.T) {
+	skill := t.TempDir()
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# Deploy Tools\n\nDeploy helpers.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scripts := filepath.Join(skill, "scripts")
+	if err := os.MkdirAll(scripts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.WriteFile(filepath.Join(scripts, "build.sh"), []byte("#!/bin/sh\necho build\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(scripts, "ship.py"), []byte("print('ship')\n"), 0o644)
+
+	plan, err := PlanSkill(skill)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Items) != 2 {
+		t.Fatalf("want 2 buttons from scripts, got %d", len(plan.Items))
+	}
+	byName := map[string]Planned{}
+	for _, it := range plan.Items {
+		byName[it.Name] = it
+		if it.Description != "Deploy Tools" {
+			t.Fatalf("description should come from SKILL.md heading, got %q", it.Description)
+		}
+	}
+	base := filepath.Base(skill)
+	if byName[base+"-ship"].Runtime != "python" {
+		t.Fatalf("ship.py should be python: %+v", byName)
+	}
+}
+
+func TestPlanSkillPromptFallback(t *testing.T) {
+	skill := filepath.Join(t.TempDir(), "writer")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# Writer\n\nDraft prose.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanSkill(skill)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Items) != 1 || plan.Items[0].Runtime != "prompt" || plan.Items[0].Name != "writer" {
+		t.Fatalf("expected single prompt button, got %+v", plan.Items)
+	}
+}
+
+func TestPlanURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"weather","runtime":"http","url":"https://api.example.com/w","method":"GET"}`))
+	}))
+	defer srv.Close()
+
+	plan, err := PlanURL(srv.URL, "")
+	if err != nil {
+		t.Fatalf("plan url: %v", err)
+	}
+	if plan.Items[0].Name != "weather" || plan.Items[0].Runtime != "http" {
+		t.Fatalf("unexpected url plan: %+v", plan.Items[0])
+	}
+
+	// A non-HTTP spec (no url) is rejected with guidance.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"local","runtime":"shell"}`))
+	}))
+	defer srv2.Close()
+	if _, err := PlanURL(srv2.URL, ""); err == nil {
+		t.Fatal("non-http spec should be rejected")
+	}
+}


### PR DESCRIPTION
## What

Turn external sources into buttons (#277):

```
buttons import code <file>    wrap a script as a button (runtime inferred)
buttons import skill <dir>    a button per script in an AgentSkills skill
buttons import url <url>      create a button from a fetched HTTP/API spec
buttons import mcp <server>   deferred (needs an MCP client) — see below
```

## How

- **`internal/importer`** — a `Plan` → `Apply` model. Each adapter returns a **plan** (the buttons it
  *would* create) so the command can show and confirm before anything is written.
  - **code**: reads the file, infers runtime (`shell`/`python`/`node`) from extension then shebang,
    creates via `button.Service` → fully functional via `press`. `--name` overrides.
  - **skill**: when the skill has a `scripts/` dir, one button per script (`<skill>-<script>`, description
    from `SKILL.md`); otherwise `SKILL.md` becomes a single prompt button.
  - **url**: fetches a button spec and creates it. Supports self-contained **HTTP/API** specs (what
    `create --url` produces); code/prompt buttons need their bundle, so it points those at `buttons install`.
  - Per-item failures are recorded without aborting the rest of a skill import.
- **`cmd/import.go`** — confirmation gate: prints the plan and prompts `y/N`; `--yes` skips it (and is
  **required** non-interactively / with `--json`, satisfying "requires confirmation").

## Acceptance criteria

- [x] `import skill /path` creates buttons from skill scripts
- [ ] `import mcp server` — **deferred**: enumerating an MCP server's tools needs an MCP *client* to
  launch + handshake the server; tracked as a #277 follow-up (this repo now has the MCP *server* in #194).
  The command returns a clear "not implemented yet, use code|skill|url" message rather than failing opaquely.
- [x] `import code ./deploy.sh` wraps as a button
- [x] imported buttons are fully functional via `buttons press`
- [x] import shows what will be created and requires confirmation

## Testing

Unit: runtime inference (ext + shebang), code-apply → real button carrying the imported code, skill
scripts → N buttons (description from `SKILL.md`), skill prompt-fallback, url plan + rejection of non-http
specs. **E2E smoke:** import a python script → `press` → `hi from py`; import a 2-script skill; the
confirmation gate refuses non-interactive import without `--yes`. Independent of the serve/mcp/trigger stack
(branches off `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `buttons import` command enabling users to import buttons from code files, skill directories, and HTTP URLs
  * Import workflow includes preview mode, interactive confirmation with optional auto-confirm, and JSON output support
  * Mcp import mode is not yet implemented

<!-- end of auto-generated comment: release notes by coderabbit.ai -->