### PR TITLE
feat(store): buttons publish — the inverse of install (#276 client)

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var publishSource string
+
+var publishCmd = &cobra.Command{
+	Use:   "publish <name>",
+	Short: "Publish a local button to a source so others can install it",
+	Long: `Publish a button — the inverse of 'buttons install'. The button folder
+(button.json + code + AGENT.md, never its run history) is content-hashed and
+written to a source, where 'buttons install <name> --source <dir>' can fetch it.
+
+The registry source (buttons.co, #275/#276) is not built yet; for now publish
+to a local source directory with --source (or $BUTTONS_SOURCE). That directory
+is a valid install source, so publish + install round-trip end-to-end today.
+
+Examples:
+  buttons publish deploy --source ./pack
+  BUTTONS_SOURCE=./pack buttons publish deploy`,
+	Args: exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		srcDir := publishSource
+		if srcDir == "" {
+			srcDir = os.Getenv("BUTTONS_SOURCE")
+		}
+		if srcDir == "" {
+			msg := "no source: pass --source <dir> or set $BUTTONS_SOURCE (the registry publish target lands in #276)"
+			if jsonOutput {
+				_ = config.WriteJSONError("VALIDATION_ERROR", msg)
+				return errSilent
+			}
+			return fmt.Errorf("%s", msg)
+		}
+
+		dst := &store.LocalSource{Root: srcDir}
+		res, err := store.Publish(dst, args[0])
+		if err != nil {
+			if jsonOutput {
+				_ = config.WriteJSONError("PUBLISH_ERROR", err.Error())
+				return errSilent
+			}
+			return err
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(res)
+		}
+		fmt.Fprintf(os.Stderr, "Published %s (%d files, sha256 %s) to %s\n", res.Name, res.Files, res.SHA256[:12], srcDir)
+		printNextHint("buttons install %s --source %s", res.Name, srcDir)
+		return nil
+	},
+}
+
+func init() {
+	publishCmd.Flags().StringVar(&publishSource, "source", "", "source directory to publish to (until the registry lands, #276)")
+	rootCmd.AddCommand(publishCmd)
+}

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+)
+
+// Publisher accepts a button Bundle for distribution — the write-side mirror of
+// Source.Fetch. LocalSource implements it (publish to a directory); the
+// registry HTTPSource implements it over `POST /v1/buttons` (#276/#275).
+type Publisher interface {
+	Publish(b *Bundle) error
+}
+
+// PublishResult reports what a publish produced.
+type PublishResult struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+	SHA256  string `json:"sha256"`
+	Files   int    `json:"files"`
+}
+
+// Publish reads an installed/local button and hands it to dst. It's the inverse
+// of InstallSpec: gather the button folder (button.json + main.* + AGENT.md,
+// never pressed/ history), content-hash it, and publish.
+func Publish(dst Publisher, name string) (*PublishResult, error) {
+	dir, err := config.ButtonDir(button.Slugify(name))
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("button %q not found: %w", name, err)
+	}
+
+	files := map[string][]byte{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue // skip pressed/ — run history isn't part of the artifact
+		}
+		// #nosec G304 -- dir is config.ButtonDir (rooted, slugified) + an enumerated entry.
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		files[e.Name()] = data
+	}
+	specData, ok := files["button.json"]
+	if !ok {
+		return nil, fmt.Errorf("button %q has no button.json", name)
+	}
+	var spec button.Button
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return nil, fmt.Errorf("button %q: invalid button.json: %w", name, err)
+	}
+
+	bundle := &Bundle{Name: spec.Name, Version: spec.Version, SHA256: hashFiles(files), Files: files}
+	if err := dst.Publish(bundle); err != nil {
+		return nil, err
+	}
+	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(files)}, nil
+}
+
+// Publish writes a bundle into the LocalSource directory as <Root>/<name>/…,
+// making it installable by `buttons install <name> --source <Root>`. Immutable
+// in spirit: a re-publish overwrites the folder (the registry enforces true
+// version immutability; a dir source is dev-grade).
+func (s *LocalSource) Publish(b *Bundle) error {
+	dir := filepath.Join(s.Root, b.Name)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create publish dir: %w", err)
+	}
+	for rel, data := range b.Files {
+		// #nosec G306 -- published button files are user-owned content in a user dir.
+		if err := os.WriteFile(filepath.Join(dir, rel), data, 0600); err != nil {
+			return fmt.Errorf("write %s: %w", rel, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+// writeInstalledButton drops a local button into BUTTONS_HOME (as if created).
+func writeInstalledButton(t *testing.T, home string, b button.Button, body string) {
+	t.Helper()
+	dir := filepath.Join(home, "buttons", b.Name)
+	if err := os.MkdirAll(filepath.Join(dir, "pressed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.MarshalIndent(&b, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.sh"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A run-history file that must NOT be published.
+	if err := os.WriteFile(filepath.Join(dir, "pressed", "run1.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishThenInstallRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledButton(t, home, button.Button{SchemaVersion: 1, Name: "deploy", Runtime: "shell", Version: "1.2.0", Tags: []string{"ops"}}, "#!/bin/sh\necho deploy\n")
+
+	pack := t.TempDir()
+	dst := &LocalSource{Root: pack}
+
+	res, err := Publish(dst, "deploy")
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if res.Name != "deploy" || res.Version != "1.2.0" || res.SHA256 == "" {
+		t.Fatalf("unexpected publish result: %+v", res)
+	}
+	// pressed/ history is not part of the artifact (button.json + main.sh only).
+	if res.Files != 2 {
+		t.Fatalf("expected 2 published files (button.json, main.sh), got %d", res.Files)
+	}
+	if _, err := os.Stat(filepath.Join(pack, "deploy", "pressed")); !os.IsNotExist(err) {
+		t.Fatal("pressed/ history must not be published")
+	}
+
+	// The published button is now installable into a fresh home.
+	home2 := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home2)
+	if _, err := InstallSpec(dst, "deploy", "local:"+pack); err != nil {
+		t.Fatalf("install of published button: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home2, "buttons", "deploy", "button.json"))
+	if err != nil {
+		t.Fatalf("installed button missing: %v", err)
+	}
+	var got button.Button
+	_ = json.Unmarshal(data, &got)
+	if got.Version != "1.2.0" || got.ContentHash == "" {
+		t.Fatalf("round-trip lost metadata: version=%q hash=%q", got.Version, got.ContentHash)
+	}
+	// The hash the installer pinned equals the hash publish reported.
+	if got.ContentHash != res.SHA256 {
+		t.Fatalf("install hash %q != publish hash %q", got.ContentHash, res.SHA256)
+	}
+}
+
+func TestPublishMissingButton(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	if _, err := Publish(&LocalSource{Root: t.TempDir()}, "ghost"); err == nil {
+		t.Fatal("publishing a missing button should error")
+	}
+}


### PR DESCRIPTION
## What

`buttons publish <name>` distributes a local button to a **source** so others can `buttons install` it —
the write-side mirror of #190. This is the **buildable client half of #276**; the registry *server*
transport is the infra-blocked remainder.

```
buttons publish deploy --source ./pack      # then, elsewhere:
buttons install deploy --source ./pack
```

## How

- **`internal/store/publish.go`**
  - `Publisher` — the write-side of `Source` (`Publish(*Bundle) error`).
  - `Publish(dst, name)` gathers a button's folder (`button.json` + code + `AGENT.md`, **never** `pressed/`
    run history), content-hashes it with the **same** `hashFiles` install verifies against, and hands it to
    the `Publisher`.
  - `LocalSource.Publish` writes it to `<root>/<name>/`, which is itself a valid **install source** — so
    publish + install round-trip end-to-end **today**, no registry needed.
  - The registry `HTTPSource.Publish` (`POST /v1/buttons`) lands with #275/#276.
- **`cmd/publish.go`** — `buttons publish <name> --source <dir>` (or `$BUTTONS_SOURCE`); clear error when no
  source until the registry lands.

## Testing

`publish → install` round-trip: the `content_hash` the installer pins **equals** the sha256 `publish`
reported, and `pressed/` history is excluded from the artifact; missing-button error. Full suite green.
**E2E smoke:** `publish deploy` (sha256, 2 files) → `install` into a fresh home → `press` → runs.

## Why this is in the "infra-blocked" batch but still real code

Per the marathon plan, #276 was filed as needs-infra (the registry). But the **client + local source** half is
fully functional and testable without any infra — only the registry *transport* is blocked on #275. So this
ships as working code, not a stub; the registry `Publisher` impl is a drop-in once the server exists.

## Stacking

Stacked on **#190** (`feat/store-install`) — needs `internal/store`'s `Source`/`Bundle`/`hashFiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)