### PR TITLE
docs: sync CLI reference + SKILL.md for all merged commands

### DIFF
--- a/.agents/skills/buttons/SKILL.md
+++ b/.agents/skills/buttons/SKILL.md
@@ -221,6 +221,51 @@ Keep a button or drawer out of git (writes .buttons/.gitignore)
 buttons ignore
 ```
 
+### `buttons import`
+
+Create buttons from external sources (skill, code, url)
+
+```
+buttons import [command]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--name` | string | override the generated button name (code/url) |
+| `-y, --yes` | bool | skip the confirmation prompt |
+
+#### `buttons import code`
+
+Wrap a script file as a button
+
+```
+buttons import code
+```
+
+#### `buttons import mcp`
+
+Create buttons from an MCP server's tools (planned)
+
+```
+buttons import mcp
+```
+
+#### `buttons import skill`
+
+Create buttons from an AgentSkills skill directory
+
+```
+buttons import skill
+```
+
+#### `buttons import url`
+
+Create a button from a spec fetched over HTTP
+
+```
+buttons import url
+```
+
 ### `buttons init`
 
 Initialize a project-local .buttons directory
@@ -267,6 +312,18 @@ buttons logs [flags]
 | `-f, --follow` | bool | stream the latest press's progress events live (agent-friendly, no TUI) |
 | `--limit` | int | max runs to return |
 
+### `buttons mcp`
+
+Run an MCP server over stdio (expose buttons to agents)
+
+```
+buttons mcp [flags]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--allow-create` | bool | expose the buttons_create tool (off by default) |
+
 ### `buttons press`
 
 Run a button
@@ -284,13 +341,47 @@ buttons press [flags]
 | `--idempotency-ttl` | duration | how long idempotency entries stay valid (e.g. 1h, 24h) |
 | `--timeout` | int | override timeout in seconds |
 
+### `buttons publish`
+
+Publish a local button to a source so others can install it
+
+```
+buttons publish [flags]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--source` | string | source directory to publish to (until the registry lands, #276) |
+
+### `buttons serve`
+
+Run a REST API server exposing buttons over HTTP
+
+```
+buttons serve [flags]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--allow-http-buttons` | bool | allow pressing http (outbound-request) buttons over the API (SSRF surface; off by default) |
+| `--api-key` | string | bearer key required on all endpoints (else the 'API_KEY' battery or $BUTTONS_API_KEY) |
+| `--host` | string | host/interface to bind (use 0.0.0.0 to expose; requires an API key) |
+| `--no-triggers` | bool | do not run the trigger engine (cron/watch/webhook) alongside the API |
+| `--port` | int | port to listen on |
+
 ### `buttons smash`
 
 Run multiple buttons in parallel
 
 ```
-buttons smash
+buttons smash [flags]
 ```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--concurrency` | int | max buttons running at once (0 = NumCPU; hard cap 50) |
+| `--on-failure` | string | stop | continue |
+| `--timeout` | int | per-button timeout override (seconds) |
 
 ### `buttons summary`
 
@@ -315,6 +406,49 @@ buttons tail [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `-f, --follow` | bool | keep tailing as new lines arrive |
+
+### `buttons trigger`
+
+Manage button triggers (cron, watch, webhook)
+
+```
+buttons trigger [command]
+```
+
+#### `buttons trigger add`
+
+Add a trigger to a button
+
+```
+buttons trigger add [flags]
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--arg` | stringArray | argument key=value passed when the trigger fires (repeatable) |
+| `--cron` | bool | cron-scheduled trigger |
+| `--path` | string | file path to watch |
+| `--schedule` | string | cron schedule, 5-field (e.g. "0 */6 * * *") |
+| `--token` | string | shared secret required on webhook POSTs (X-Buttons-Token or ?token=) |
+| `--watch` | bool | file-watch trigger |
+| `--webhook` | bool | webhook (HTTP POST) trigger |
+| `--webhook-path` | string | URL path for the webhook (e.g. /hooks/deploy) |
+
+#### `buttons trigger list`
+
+List triggers (all buttons, or one)
+
+```
+buttons trigger list
+```
+
+#### `buttons trigger rm`
+
+Remove a trigger from a button
+
+```
+buttons trigger rm
+```
 
 ### `buttons unignore`
 

--- a/docs/cli/buttons.md
+++ b/docs/cli/buttons.md
@@ -34,14 +34,19 @@ buttons [flags]
 * [buttons drawer](buttons_drawer.md)	 - Manage drawer workflows (chains of buttons)
 * [buttons history](buttons_history.md)	 - Show run history
 * [buttons ignore](buttons_ignore.md)	 - Keep a button or drawer out of git (writes .buttons/.gitignore)
+* [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
 * [buttons init](buttons_init.md)	 - Initialize a project-local .buttons directory
 * [buttons install](buttons_install.md)	 - Install a button (or every button with a tag) from a source
 * [buttons list](buttons_list.md)	 - List all buttons
 * [buttons logs](buttons_logs.md)	 - View past runs for a button or tail the live progress stream
+* [buttons mcp](buttons_mcp.md)	 - Run an MCP server over stdio (expose buttons to agents)
 * [buttons press](buttons_press.md)	 - Run a button
+* [buttons publish](buttons_publish.md)	 - Publish a local button to a source so others can install it
+* [buttons serve](buttons_serve.md)	 - Run a REST API server exposing buttons over HTTP
 * [buttons smash](buttons_smash.md)	 - Run multiple buttons in parallel
 * [buttons summary](buttons_summary.md)	 - Print a workspace snapshot (buttons, drawers, recent runs)
 * [buttons tail](buttons_tail.md)	 - Follow the progress JSONL of a press
+* [buttons trigger](buttons_trigger.md)	 - Manage button triggers (cron, watch, webhook)
 * [buttons unignore](buttons_unignore.md)	 - Re-include a previously-ignored button or drawer in git
 * [buttons update](buttons_update.md)	 - Update buttons to the latest version
 * [buttons version](buttons_version.md)	 - Print build version, commit, and date

--- a/docs/cli/buttons_import.md
+++ b/docs/cli/buttons_import.md
@@ -1,0 +1,45 @@
+---
+title: "buttons import"
+description: "CLI reference for buttons import"
+---
+
+## buttons import
+
+Create buttons from external sources (skill, code, url)
+
+### Synopsis
+
+Import buttons from external sources:
+
+  buttons import code <file>     wrap a script as a button (runtime inferred)
+  buttons import skill <dir>     a button per script in an AgentSkills skill
+  buttons import url <url>       create a button from a fetched HTTP spec
+  buttons import mcp <server>    (planned) one button per MCP tool
+
+Every import prints what it will create and asks to confirm. Pass --yes to
+skip the prompt (required when running non-interactively).
+
+### Options
+
+```
+  -h, --help          help for import
+      --name string   override the generated button name (code/url)
+  -y, --yes           skip the confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons](buttons.md)	 - Deterministic workflow engine for agents
+* [buttons import code](buttons_import_code.md)	 - Wrap a script file as a button
+* [buttons import mcp](buttons_import_mcp.md)	 - Create buttons from an MCP server's tools (planned)
+* [buttons import skill](buttons_import_skill.md)	 - Create buttons from an AgentSkills skill directory
+* [buttons import url](buttons_import_url.md)	 - Create a button from a spec fetched over HTTP
+

--- a/docs/cli/buttons_import_code.md
+++ b/docs/cli/buttons_import_code.md
@@ -1,0 +1,33 @@
+---
+title: "buttons import code"
+description: "CLI reference for buttons import code"
+---
+
+## buttons import code
+
+Wrap a script file as a button
+
+```
+buttons import code <file> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for code
+```
+
+### Options inherited from parent commands
+
+```
+      --json          output in JSON format
+      --name string   override the generated button name (code/url)
+      --no-input      disable all interactive prompts
+      --summary       show a read-only plan/snapshot instead of mutating
+  -y, --yes           skip the confirmation prompt
+```
+
+### SEE ALSO
+
+* [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
+

--- a/docs/cli/buttons_import_mcp.md
+++ b/docs/cli/buttons_import_mcp.md
@@ -1,0 +1,33 @@
+---
+title: "buttons import mcp"
+description: "CLI reference for buttons import mcp"
+---
+
+## buttons import mcp
+
+Create buttons from an MCP server's tools (planned)
+
+```
+buttons import mcp <server> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for mcp
+```
+
+### Options inherited from parent commands
+
+```
+      --json          output in JSON format
+      --name string   override the generated button name (code/url)
+      --no-input      disable all interactive prompts
+      --summary       show a read-only plan/snapshot instead of mutating
+  -y, --yes           skip the confirmation prompt
+```
+
+### SEE ALSO
+
+* [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
+

--- a/docs/cli/buttons_import_skill.md
+++ b/docs/cli/buttons_import_skill.md
@@ -1,0 +1,33 @@
+---
+title: "buttons import skill"
+description: "CLI reference for buttons import skill"
+---
+
+## buttons import skill
+
+Create buttons from an AgentSkills skill directory
+
+```
+buttons import skill <dir> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for skill
+```
+
+### Options inherited from parent commands
+
+```
+      --json          output in JSON format
+      --name string   override the generated button name (code/url)
+      --no-input      disable all interactive prompts
+      --summary       show a read-only plan/snapshot instead of mutating
+  -y, --yes           skip the confirmation prompt
+```
+
+### SEE ALSO
+
+* [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
+

--- a/docs/cli/buttons_import_url.md
+++ b/docs/cli/buttons_import_url.md
@@ -1,0 +1,33 @@
+---
+title: "buttons import url"
+description: "CLI reference for buttons import url"
+---
+
+## buttons import url
+
+Create a button from a spec fetched over HTTP
+
+```
+buttons import url <url> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for url
+```
+
+### Options inherited from parent commands
+
+```
+      --json          output in JSON format
+      --name string   override the generated button name (code/url)
+      --no-input      disable all interactive prompts
+      --summary       show a read-only plan/snapshot instead of mutating
+  -y, --yes           skip the confirmation prompt
+```
+
+### SEE ALSO
+
+* [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
+

--- a/docs/cli/buttons_mcp.md
+++ b/docs/cli/buttons_mcp.md
@@ -1,0 +1,52 @@
+---
+title: "buttons mcp"
+description: "CLI reference for buttons mcp"
+---
+
+## buttons mcp
+
+Run an MCP server over stdio (expose buttons to agents)
+
+### Synopsis
+
+Start a Model Context Protocol server on stdio so an agent (e.g. Claude
+Code) can discover and press buttons as tools.
+
+Uses a thin meta-tool surface — buttons_list, buttons_press, buttons_inspect
+(and buttons_create with --allow-create) — instead of one tool per button, so
+large button sets don't degrade the MCP client.
+
+Security:
+  - Only buttons with "mcp_enabled": true are listed, pressable, or inspectable.
+  - Args are validated against the button's spec and passed as BUTTONS_ARG_`<NAME>`
+    env vars — never substituted into shell text.
+  - Per button: max 10 calls/min, 1 concurrent press, hard 120s timeout cap.
+  - buttons_create is OFF unless --allow-create is passed.
+
+stdout carries only protocol messages; logs go to stderr. Register with an
+agent, e.g. Claude Code:
+  claude mcp add buttons -- buttons mcp
+
+```
+buttons mcp [flags]
+```
+
+### Options
+
+```
+      --allow-create   expose the buttons_create tool (off by default)
+  -h, --help           help for mcp
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons](buttons.md)	 - Deterministic workflow engine for agents
+

--- a/docs/cli/buttons_publish.md
+++ b/docs/cli/buttons_publish.md
@@ -1,0 +1,49 @@
+---
+title: "buttons publish"
+description: "CLI reference for buttons publish"
+---
+
+## buttons publish
+
+Publish a local button to a source so others can install it
+
+### Synopsis
+
+Publish a button — the inverse of 'buttons install'. The button folder
+(button.json + code + AGENT.md, never its run history) is content-hashed and
+written to a source, where 'buttons install <name> --source <dir>' can fetch it.
+
+The registry source (buttons.co, #275/#276) is not built yet; for now publish
+to a local source directory with --source (or $BUTTONS_SOURCE). That directory
+is a valid install source, so publish + install round-trip end-to-end today.
+
+**Examples:**
+
+```bash
+buttons publish deploy --source ./pack
+BUTTONS_SOURCE=./pack buttons publish deploy
+```
+
+```
+buttons publish <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for publish
+      --source string   source directory to publish to (until the registry lands, #276)
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons](buttons.md)	 - Deterministic workflow engine for agents
+

--- a/docs/cli/buttons_serve.md
+++ b/docs/cli/buttons_serve.md
@@ -1,0 +1,64 @@
+---
+title: "buttons serve"
+description: "CLI reference for buttons serve"
+---
+
+## buttons serve
+
+Run a REST API server exposing buttons over HTTP
+
+### Synopsis
+
+Start an HTTP server that exposes your buttons as a REST API, using the
+same structured-output contract and execution path as the CLI.
+
+Endpoints:
+  GET  /api/health               liveness (no auth)
+  GET  /api/buttons              list all buttons
+  GET  /api/buttons/{name}       a button's spec
+  POST /api/buttons/{name}/press execute a button (JSON body: {"args":{…},"timeout":N})
+  GET  /api/buttons/{name}/runs  recent run history
+
+Auth: every endpoint except /api/health requires 'Authorization: Bearer <key>'.
+The key comes from --api-key, else the 'API_KEY' battery, else $BUTTONS_API_KEY.
+With no key the server runs auth-free and therefore binds to loopback only —
+binding a non-loopback host without a key is refused.
+
+Buttons created via the CLI while the server runs are picked up immediately
+(state is read from disk per request).
+
+**Examples:**
+
+```bash
+buttons serve
+buttons serve --port 3000
+buttons serve --host 0.0.0.0 --api-key "$(openssl rand -hex 16)"
+```
+
+```
+buttons serve [flags]
+```
+
+### Options
+
+```
+      --allow-http-buttons   allow pressing http (outbound-request) buttons over the API (SSRF surface; off by default)
+      --api-key string       bearer key required on all endpoints (else the 'API_KEY' battery or $BUTTONS_API_KEY)
+  -h, --help                 help for serve
+      --host string          host/interface to bind (use 0.0.0.0 to expose; requires an API key) (default "127.0.0.1")
+      --no-triggers          do not run the trigger engine (cron/watch/webhook) alongside the API
+      --port int             port to listen on (default 8080)
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons](buttons.md)	 - Deterministic workflow engine for agents
+

--- a/docs/cli/buttons_smash.md
+++ b/docs/cli/buttons_smash.md
@@ -7,6 +7,21 @@ description: "CLI reference for buttons smash"
 
 Run multiple buttons in parallel
 
+### Synopsis
+
+Run several buttons concurrently. Names may be comma- or space-separated:
+
+  buttons smash a,b,c
+  buttons smash a b c
+
+  --on-failure continue   run them all, report failures at the end (default)
+  --on-failure stop       cancel the remaining buttons on the first failure
+  --concurrency N         max buttons running at once (0 = NumCPU; hard cap 50)
+  --timeout SECS          per-button timeout override
+
+JSON mode returns an array of per-button results; every run is recorded in
+history. Exits non-zero if any button failed.
+
 ```
 buttons smash [buttons...] [flags]
 ```
@@ -14,7 +29,10 @@ buttons smash [buttons...] [flags]
 ### Options
 
 ```
-  -h, --help   help for smash
+      --concurrency int     max buttons running at once (0 = NumCPU; hard cap 50)
+  -h, --help                help for smash
+      --on-failure string   stop | continue (default "continue")
+      --timeout int         per-button timeout override (seconds)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/buttons_trigger.md
+++ b/docs/cli/buttons_trigger.md
@@ -1,0 +1,49 @@
+---
+title: "buttons trigger"
+description: "CLI reference for buttons trigger"
+---
+
+## buttons trigger
+
+Manage button triggers (cron, watch, webhook)
+
+### Synopsis
+
+Attach event triggers to a button so it presses automatically.
+
+Triggers run under 'buttons serve':
+  - cron    fires on a schedule (5-field cron, in-process scheduler)
+  - watch   fires when a file changes (polled, 500ms debounce)
+  - webhook fires on an HTTP POST to a path on the serve listener
+
+**Examples:**
+
+```bash
+buttons trigger add health --cron --schedule "0 */6 * * *"
+buttons trigger add reindex --watch --path ./data.json
+buttons trigger add deploy --webhook --webhook-path /hooks/deploy --token s3cr3t
+buttons trigger list
+buttons trigger rm health <trigger-id>
+```
+
+### Options
+
+```
+  -h, --help   help for trigger
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons](buttons.md)	 - Deterministic workflow engine for agents
+* [buttons trigger add](buttons_trigger_add.md)	 - Add a trigger to a button
+* [buttons trigger list](buttons_trigger_list.md)	 - List triggers (all buttons, or one)
+* [buttons trigger rm](buttons_trigger_rm.md)	 - Remove a trigger from a button
+

--- a/docs/cli/buttons_trigger_add.md
+++ b/docs/cli/buttons_trigger_add.md
@@ -1,0 +1,39 @@
+---
+title: "buttons trigger add"
+description: "CLI reference for buttons trigger add"
+---
+
+## buttons trigger add
+
+Add a trigger to a button
+
+```
+buttons trigger add <button> [flags]
+```
+
+### Options
+
+```
+      --arg stringArray       argument key=value passed when the trigger fires (repeatable)
+      --cron                  cron-scheduled trigger
+  -h, --help                  help for add
+      --path string           file path to watch
+      --schedule string       cron schedule, 5-field (e.g. "0 */6 * * *")
+      --token string          shared secret required on webhook POSTs (X-Buttons-Token or ?token=)
+      --watch                 file-watch trigger
+      --webhook               webhook (HTTP POST) trigger
+      --webhook-path string   URL path for the webhook (e.g. /hooks/deploy)
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons trigger](buttons_trigger.md)	 - Manage button triggers (cron, watch, webhook)
+

--- a/docs/cli/buttons_trigger_list.md
+++ b/docs/cli/buttons_trigger_list.md
@@ -1,0 +1,31 @@
+---
+title: "buttons trigger list"
+description: "CLI reference for buttons trigger list"
+---
+
+## buttons trigger list
+
+List triggers (all buttons, or one)
+
+```
+buttons trigger list [button] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons trigger](buttons_trigger.md)	 - Manage button triggers (cron, watch, webhook)
+

--- a/docs/cli/buttons_trigger_rm.md
+++ b/docs/cli/buttons_trigger_rm.md
@@ -1,0 +1,31 @@
+---
+title: "buttons trigger rm"
+description: "CLI reference for buttons trigger rm"
+---
+
+## buttons trigger rm
+
+Remove a trigger from a button
+
+```
+buttons trigger rm <button> <trigger-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rm
+```
+
+### Options inherited from parent commands
+
+```
+      --json       output in JSON format
+      --no-input   disable all interactive prompts
+      --summary    show a read-only plan/snapshot instead of mutating
+```
+
+### SEE ALSO
+
+* [buttons trigger](buttons_trigger.md)	 - Manage button triggers (cron, watch, webhook)
+


### PR DESCRIPTION
Regenerated from current `main` HEAD via `docgen`/`skillgen`, capturing every Phase 4/5 command merged this cycle — serve (#193), mcp (#194), trigger (#195), smash (#191), import (#196), publish (#198).

**Consolidates and supersedes the six incremental auto-sync PRs (#202–#207)**, which were partial snapshots opened one-per-feature-merge by the docs-sync bot.

Generated via:
```
go run ./internal/tools/docgen -out ./docs/cli -format markdown -frontmatter
go run ./internal/tools/skillgen -out ./.agents/skills/buttons/SKILL.md
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the CLI reference with new pages for importing buttons from code, skills, URLs, and MCP sources.
  * Added docs for running an MCP server, publishing buttons, serving a REST API, and managing triggers.
  * Improved the `buttons smash` reference with clearer usage, options, and failure behavior.
  * Updated the main command index to include the new commands and related links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->