### PR TITLE
standardize agent instruction file on AGENTS.md (+ scaffold for drawers)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -187,7 +187,7 @@ Examples:
 		if codePath != "" {
 			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", codePath)
 		} else if btn.Runtime == "prompt" {
-			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", filepath.Join(btnDir, "AGENT.md"))
+			fmt.Fprintf(os.Stderr, "  Edit:  %s\n", filepath.Join(btnDir, "AGENTS.md"))
 		}
 		// Build a press hint that's actually runnable — if the button
 		// has required args, stub them so the user can fill in values.
@@ -233,7 +233,7 @@ func init() {
 	createCmd.Flags().StringVar(&createMethod, "method", "", "HTTP method for --url (default: GET)")
 	createCmd.Flags().StringArrayVar(&createHeaders, "header", nil, "HTTP header as 'Key: Value' (repeatable)")
 	createCmd.Flags().StringVar(&createBody, "body", "", "HTTP request body (supports {{arg}} templates)")
-	createCmd.Flags().StringVar(&createPrompt, "prompt", "", "prompt/instruction for the consuming agent (written to AGENT.md)")
+	createCmd.Flags().StringVar(&createPrompt, "prompt", "", "prompt/instruction for the consuming agent (written to AGENTS.md)")
 	createCmd.Flags().StringVarP(&createDescription, "description", "d", "", "button description")
 	// 300s default: the old 60s cap bit real agent workloads — ETL jobs,
 	// long curls waiting on third-party APIs, DB migrations. Safety still

--- a/cmd/detail.go
+++ b/cmd/detail.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 
+	"github.com/autonoco/buttons/internal/agentdoc"
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/history"
@@ -16,9 +16,9 @@ import (
 //
 // Three paths:
 //
-//   --json          structured detail dict (agents, pipes)
-//   non-TTY         plain stderr printout (legacy / piped workflows)
-//   TTY + human     full-screen Bubble Tea detail page (internal/tui)
+//	--json          structured detail dict (agents, pipes)
+//	non-TTY         plain stderr printout (legacy / piped workflows)
+//	TTY + human     full-screen Bubble Tea detail page (internal/tui)
 func showButtonDetail(name string) error {
 	svc := button.NewService()
 	btn, err := svc.Get(name)
@@ -65,7 +65,7 @@ func renderDetailTUI(svc *button.Service, btn *button.Button) error {
 		}
 	} else if btn.Runtime == "prompt" {
 		if dir, err := config.ButtonDir(btn.Name); err == nil {
-			codePath = filepath.Join(dir, "AGENT.md")
+			codePath = agentdoc.Path(dir)
 		}
 	}
 
@@ -175,7 +175,7 @@ func readAgentMD(buttonName string) string {
 	}
 	// #nosec G304 -- btnDir comes from config.ButtonDir() which rejects any
 	// path escaping ButtonsDir; caller passes an already-slugified btn.Name.
-	data, err := os.ReadFile(filepath.Join(btnDir, "AGENT.md"))
+	data, err := os.ReadFile(agentdoc.Path(btnDir))
 	if err != nil {
 		return ""
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,7 +37,7 @@ A .gitignore is created inside .buttons/ to exclude run history
 (pressed/) from version control while keeping button specs, code
 files, and agent instructions committed.
 
-A reference guide is written to .buttons/AGENT.md so any coding
+A reference guide is written to .buttons/AGENTS.md so any coding
 agent that opens the folder can learn what Buttons is and how to
 use it.
 
@@ -69,7 +69,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// The AGENT.md reference is always (re)written — it's Buttons' own
+	// The AGENTS.md reference is always (re)written — it's Buttons' own
 	// docs, not something the user should hand-edit in-place.
 	agentMDPath, err := agentskill.WriteAgentMD(cwd)
 	if err != nil {

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/autonoco/buttons/internal/agentdoc"
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/engine"
@@ -107,7 +107,7 @@ Examples:
 				if err != nil {
 					return handleServiceError(err)
 				}
-				codePath = filepath.Join(btnDir, "AGENT.md")
+				codePath = agentdoc.Path(btnDir)
 			} else {
 				codePath, err = svc.CodePath(btn.Name)
 				if err != nil {
@@ -196,7 +196,7 @@ Examples:
 			<-sinkDone // drain the channel before emitting the final Result
 		}
 
-		// Attach prompt if AGENT.md has custom content (not the default template)
+		// Attach prompt if AGENTS.md has custom content (not the default template)
 		if promptMD := readPrompt(btn.Name); promptMD != "" {
 			result.Prompt = promptMD
 		}
@@ -305,7 +305,7 @@ func readPrompt(buttonName string) string {
 	}
 	// #nosec G304 -- btnDir comes from config.ButtonDir() which rejects any
 	// path escaping ButtonsDir; caller passes an already-slugified btn.Name.
-	data, err := os.ReadFile(filepath.Join(btnDir, "AGENT.md"))
+	data, err := os.ReadFile(agentdoc.Path(btnDir))
 	if err != nil {
 		return ""
 	}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -15,7 +15,7 @@ var publishCmd = &cobra.Command{
 	Use:   "publish <name>",
 	Short: "Publish a local button to a source so others can install it",
 	Long: `Publish a button — the inverse of 'buttons install'. The button folder
-(button.json + code + AGENT.md, never its run history) is content-hashed and
+(button.json + code + AGENTS.md, never its run history) is content-hashed and
 written to a source, where 'buttons install <name> --source <dir>' can fetch it.
 
 The registry source (buttons.co, #275/#276) is not built yet; for now publish

--- a/cmd/smash.go
+++ b/cmd/smash.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
+	"github.com/autonoco/buttons/internal/agentdoc"
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/engine"
@@ -187,7 +187,7 @@ func smashPress(ctx context.Context, name string, batteries map[string]string, t
 			if derr != nil {
 				return nil, derr
 			}
-			codePath = filepath.Join(dir, "AGENT.md")
+			codePath = agentdoc.Path(dir)
 		} else if codePath, err = svc.CodePath(btn.Name); err != nil {
 			return nil, err
 		}

--- a/internal/agentdoc/agentdoc.go
+++ b/internal/agentdoc/agentdoc.go
@@ -1,0 +1,39 @@
+// Package agentdoc centralizes the per-unit agent-instruction filename.
+//
+// Buttons standardizes on AGENTS.md — the agents.md convention used by
+// Codex, OpenClaw, Cursor, and others. AGENT.md (singular) is still
+// honored on read as a legacy fallback so buttons and drawers created
+// before the rename keep attaching their prompts; writes always use the
+// canonical name.
+package agentdoc
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Name is the canonical agent-instruction filename. All writes use this.
+const Name = "AGENTS.md"
+
+// Legacy is the pre-rename filename, honored on read only.
+const Legacy = "AGENT.md"
+
+// Path returns the agent-instruction path inside dir for READING: it
+// prefers the canonical AGENTS.md, falls back to a legacy AGENT.md when
+// only that exists, and otherwise returns the canonical path (so a
+// genuinely missing file still surfaces as a not-exist on the new name).
+func Path(dir string) string {
+	canonical := filepath.Join(dir, Name)
+	if _, err := os.Stat(canonical); err == nil {
+		return canonical
+	}
+	if legacy := filepath.Join(dir, Legacy); exists(legacy) {
+		return legacy
+	}
+	return canonical
+}
+
+func exists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/internal/agentdoc/agentdoc_test.go
+++ b/internal/agentdoc/agentdoc_test.go
@@ -1,0 +1,38 @@
+package agentdoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func write(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPath_PrefersCanonical(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, Name))
+	write(t, filepath.Join(dir, Legacy))
+	if got, want := Path(dir), filepath.Join(dir, Name); got != want {
+		t.Errorf("both present: want canonical %q, got %q", want, got)
+	}
+}
+
+func TestPath_FallsBackToLegacy(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, Legacy)) // only the pre-rename file exists
+	if got, want := Path(dir), filepath.Join(dir, Legacy); got != want {
+		t.Errorf("legacy only: want %q, got %q", want, got)
+	}
+}
+
+func TestPath_DefaultsToCanonicalWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	if got, want := Path(dir), filepath.Join(dir, Name); got != want {
+		t.Errorf("neither present: want canonical %q, got %q", want, got)
+	}
+}

--- a/internal/agentskill/agentskill.go
+++ b/internal/agentskill/agentskill.go
@@ -15,7 +15,7 @@
 //     BUTTONS:START / BUTTONS:END HTML comments so a subsequent
 //     `buttons init` can find + replace in-place.
 //
-// The `.buttons/AGENT.md` file is intentionally different: it's the
+// The `.buttons/AGENTS.md` file is intentionally different: it's the
 // folder's own onboarding doc, not an agent-discovery file. It's always
 // created and always overwritten on `init` — it belongs to Buttons, not
 // to the user's editor conventions.
@@ -136,7 +136,7 @@ const (
 
 // Body is the shared "what Buttons is" content appended to markdown
 // files. Kept short on purpose — pointers to `buttons --help` and the
-// `.buttons/AGENT.md` reference carry the detailed docs.
+// `.buttons/AGENTS.md` reference carry the detailed docs.
 const Body = `## Buttons
 
 This project uses [Buttons](https://buttons.sh) — a CLI workflow engine. Buttons are reusable, named actions with typed args and structured output.
@@ -171,9 +171,9 @@ In a triggered drawer, the POST is available as ` + "`${inputs.webhook.body}`" +
 
 Dry-run a webhook drawer without the listener: ` + "`buttons drawer <name> press --webhook-body '{...}'`" + ` or ` + "`--webhook-body @fixture.json`" + `.
 
-See ` + "`.buttons/AGENT.md`" + ` for more detail.`
+See ` + "`.buttons/AGENTS.md`" + ` for more detail.`
 
-// AgentMDBody is the always-installed `.buttons/AGENT.md` content.
+// AgentMDBody is the always-installed `.buttons/AGENTS.md` content.
 // Different audience than Body: this one teaches the concept to an
 // agent that happens to open the file, whereas Body is structured to
 // live alongside a user's existing agent instructions.
@@ -270,7 +270,7 @@ type InstallOpts struct {
 	ProjectRoot string
 
 	// TargetIDs is the set of target IDs to install. An empty slice
-	// means "install no agent skill files" — `.buttons/AGENT.md` is
+	// means "install no agent skill files" — `.buttons/AGENTS.md` is
 	// always written regardless.
 	TargetIDs []string
 }
@@ -283,11 +283,11 @@ type WriteResult struct {
 	Action   string `json:"action"` // "created" | "updated" | "appended"
 }
 
-// WriteAgentMD writes .buttons/AGENT.md. The `.buttons/` directory is
+// WriteAgentMD writes .buttons/AGENTS.md. The `.buttons/` directory is
 // assumed to exist already (buttons init creates it first). Always
 // overwrites — this file belongs to Buttons, not to the user.
 func WriteAgentMD(projectRoot string) (string, error) {
-	path := filepath.Join(projectRoot, ".buttons", "AGENT.md")
+	path := filepath.Join(projectRoot, ".buttons", "AGENTS.md")
 	if err := os.WriteFile(path, []byte(AgentMDBody), 0600); err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}

--- a/internal/agentskill/agentskill_test.go
+++ b/internal/agentskill/agentskill_test.go
@@ -17,7 +17,7 @@ func TestWriteAgentMD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if path != filepath.Join(dir, ".buttons", "AGENT.md") {
+	if path != filepath.Join(dir, ".buttons", "AGENTS.md") {
 		t.Errorf("unexpected path: %s", path)
 	}
 
@@ -26,7 +26,7 @@ func TestWriteAgentMD(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(data), "This folder is managed by") {
-		t.Error("AGENT.md missing expected heading content")
+		t.Error("AGENTS.md missing expected heading content")
 	}
 }
 

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -80,7 +80,7 @@ type CreateOpts struct {
 	Method               string
 	Headers              map[string]string
 	Body                 string
-	Prompt               string // Prompt/instruction written to AGENT.md
+	Prompt               string // Prompt/instruction written to AGENTS.md
 	Description          string
 	TimeoutSeconds       int
 	MaxResponseBytes     int64 // URL buttons only; zero → DefaultMaxResponseBytes
@@ -282,10 +282,10 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 		}
 	}
 
-	// Write AGENT.md
+	// Write AGENTS.md
 	var promptMD string
 	if hasPrompt {
-		// Prompt button: the instruction IS the AGENT.md
+		// Prompt button: the instruction IS the AGENTS.md
 		promptMD = opts.Prompt + "\n"
 	} else {
 		promptMD = fmt.Sprintf("# %s\n\n", name)
@@ -294,12 +294,12 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 		}
 		promptMD += "## Notes\n\n_Add context about this button here: why it exists, gotchas, expected output format._\n"
 	}
-	if err := os.WriteFile(filepath.Join(btnDir, "AGENT.md"), []byte(promptMD), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(btnDir, "AGENTS.md"), []byte(promptMD), 0600); err != nil {
 		// Best-effort cleanup of the partially created button directory.
 		// Error is intentionally ignored: we are already returning a failure
 		// and there is no useful recovery path if the cleanup itself fails.
 		_ = os.RemoveAll(btnDir)
-		return nil, fmt.Errorf("failed to write AGENT.md: %w", err)
+		return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 	}
 
 	return btn, nil

--- a/internal/button/service_test.go
+++ b/internal/button/service_test.go
@@ -80,10 +80,10 @@ func TestService_Create(t *testing.T) {
 		t.Fatalf("code file not found: %v", err)
 	}
 
-	// Verify AGENT.md was created
-	agentPath := filepath.Join(home, "buttons", "test", "AGENT.md")
+	// Verify AGENTS.md was created
+	agentPath := filepath.Join(home, "buttons", "test", "AGENTS.md")
 	if _, err := os.Stat(agentPath); err != nil {
-		t.Fatalf("AGENT.md not found: %v", err)
+		t.Fatalf("AGENTS.md not found: %v", err)
 	}
 
 	// Verify pressed/ directory was created

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -55,6 +55,21 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 		return nil, fmt.Errorf("failed to create drawer directory: %w", err)
 	}
 
+	// Scaffold AGENT.md — a drawer groups related buttons, so this is
+	// where an agent documents what the group is for and when to reach
+	// for each member. Mirrors the per-button AGENT.md scaffold.
+	agentMD := fmt.Sprintf("# %s\n\n", slug)
+	if description != "" {
+		agentMD += description + "\n\n"
+	}
+	agentMD += "## Notes\n\n_Add context about this drawer here: what these buttons are for, when to use which, and how they chain._\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENT.md"), []byte(agentMD), 0600); err != nil {
+		// Best-effort cleanup of the partially created drawer directory,
+		// mirroring the save-failure path below.
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("failed to write AGENT.md: %w", err)
+	}
+
 	now := time.Now().UTC()
 	d := &Drawer{
 		SchemaVersion: SchemaVersion,

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -55,19 +55,19 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 		return nil, fmt.Errorf("failed to create drawer directory: %w", err)
 	}
 
-	// Scaffold AGENT.md — a drawer groups related buttons, so this is
+	// Scaffold AGENTS.md — a drawer groups related buttons, so this is
 	// where an agent documents what the group is for and when to reach
-	// for each member. Mirrors the per-button AGENT.md scaffold.
+	// for each member. Mirrors the per-button AGENTS.md scaffold.
 	agentMD := fmt.Sprintf("# %s\n\n", slug)
 	if description != "" {
 		agentMD += description + "\n\n"
 	}
 	agentMD += "## Notes\n\n_Add context about this drawer here: what these buttons are for, when to use which, and how they chain._\n"
-	if err := os.WriteFile(filepath.Join(dir, "AGENT.md"), []byte(agentMD), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(agentMD), 0600); err != nil {
 		// Best-effort cleanup of the partially created drawer directory,
 		// mirroring the save-failure path below.
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("failed to write AGENT.md: %w", err)
+		return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 	}
 
 	now := time.Now().UTC()

--- a/internal/drawer/service_test.go
+++ b/internal/drawer/service_test.go
@@ -60,15 +60,15 @@ func TestService_Create_ScaffoldsAgentMD(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	path := filepath.Join(home, "drawers", "scaffold-doc", "AGENT.md")
+	path := filepath.Join(home, "drawers", "scaffold-doc", "AGENTS.md")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("expected AGENT.md scaffolded at %s: %v", path, err)
+		t.Fatalf("expected AGENTS.md scaffolded at %s: %v", path, err)
 	}
 	got := string(data)
 	for _, want := range []string{"# scaffold-doc", "groups the slides verbs", "## Notes"} {
 		if !strings.Contains(got, want) {
-			t.Errorf("AGENT.md missing %q; got:\n%s", want, got)
+			t.Errorf("AGENTS.md missing %q; got:\n%s", want, got)
 		}
 	}
 }

--- a/internal/drawer/service_test.go
+++ b/internal/drawer/service_test.go
@@ -3,6 +3,7 @@ package drawer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,27 @@ func TestService_CreateListGet(t *testing.T) {
 	}
 	if got.Description != "my flow" {
 		t.Errorf("description round-trip: got %q", got.Description)
+	}
+}
+
+func TestService_Create_ScaffoldsAgentMD(t *testing.T) {
+	home := newTestHome(t)
+	svc := NewService()
+
+	if _, err := svc.Create("scaffold-doc", "groups the slides verbs", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	path := filepath.Join(home, "drawers", "scaffold-doc", "AGENT.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected AGENT.md scaffolded at %s: %v", path, err)
+	}
+	got := string(data)
+	for _, want := range []string{"# scaffold-doc", "groups the slides verbs", "## Notes"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AGENT.md missing %q; got:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -42,7 +42,7 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 		return executeHTTP(ctx, btn, args, result)
 	}
 
-	// Prompt buttons return the instruction from AGENT.md
+	// Prompt buttons return the instruction from AGENTS.md
 	if btn.Runtime == "prompt" {
 		return executePrompt(ctx, codePath, result)
 	}
@@ -207,7 +207,7 @@ func interpreterForRuntime(runtime string) (string, error) {
 	}
 }
 
-// executePrompt reads the AGENT.md instruction and returns it as output.
+// executePrompt reads the AGENTS.md instruction and returns it as output.
 func executePrompt(ctx context.Context, promptPath string, result *Result) *Result {
 	start := result.StartedAt
 
@@ -222,13 +222,14 @@ func executePrompt(ctx context.Context, promptPath string, result *Result) *Resu
 	}
 
 	// #nosec G304 -- promptPath is constructed by callers from config.ButtonDir()
-	// (which rejects paths escaping ButtonsDir) + the literal "AGENT.md" suffix.
+	// (which rejects paths escaping ButtonsDir) + the agent-doc filename
+	// resolved by agentdoc.Path.
 	data, err := os.ReadFile(promptPath)
 	if err != nil {
 		result.Status = "error"
 		result.ExitCode = -1
 		result.ErrorType = "PROMPT_ERROR"
-		result.Stderr = fmt.Sprintf("failed to read AGENT.md: %v", err)
+		result.Stderr = fmt.Sprintf("failed to read AGENTS.md: %v", err)
 		result.DurationMs = time.Since(start).Milliseconds()
 		return result
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,10 +7,10 @@ package runner
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/autonoco/buttons/internal/agentdoc"
 	"github.com/autonoco/buttons/internal/battery"
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
@@ -79,7 +79,7 @@ func Press(ctx context.Context, name string, args map[string]string, opts Option
 			if derr != nil {
 				return nil, derr
 			}
-			codePath = filepath.Join(dir, "AGENT.md")
+			codePath = agentdoc.Path(dir)
 		} else {
 			codePath, err = svc.CodePath(btn.Name)
 			if err != nil {

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -26,7 +26,7 @@ type PublishResult struct {
 }
 
 // Publish reads an installed/local button and hands it to dst. It's the inverse
-// of InstallSpec: gather the button folder (button.json + main.* + AGENT.md,
+// of InstallSpec: gather the button folder (button.json + main.* + AGENTS.md,
 // never pressed/ history), content-hash it, and publish.
 func Publish(dst Publisher, name string) (*PublishResult, error) {
 	dir, err := config.ButtonDir(button.Slugify(name))

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -30,7 +30,7 @@ type Bundle struct {
 	Name    string
 	Version string
 	SHA256  string            // content hash of Files (provenance pin)
-	Files   map[string][]byte // relative filename -> bytes (button.json, main.*, AGENT.md)
+	Files   map[string][]byte // relative filename -> bytes (button.json, main.*, AGENTS.md)
 }
 
 // Source is where buttons are installed/updated from. HTTPSource (the registry,
@@ -85,7 +85,7 @@ func safeJoin(dir, rel string) (string, error) {
 }
 
 // LocalSource installs from a directory laid out like a buttons dir:
-// <Root>/<name>/{button.json, main.*, AGENT.md}. For dev/testing without a
+// <Root>/<name>/{button.json, main.*, AGENTS.md}. For dev/testing without a
 // registry server, and the reference for what an HTTPSource must reproduce.
 type LocalSource struct {
 	Root string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -170,7 +170,7 @@ func TestSafeJoin(t *testing.T) {
 			t.Errorf("safeJoin(%q) should be rejected", r)
 		}
 	}
-	for _, r := range []string{"button.json", "main.sh", "AGENT.md", "sub/file.txt"} {
+	for _, r := range []string{"button.json", "main.sh", "AGENTS.md", "sub/file.txt"} {
 		dst, err := safeJoin(dir, r)
 		if err != nil {
 			t.Errorf("safeJoin(%q) should be allowed: %v", r, err)

--- a/internal/tools/skillgen/main.go
+++ b/internal/tools/skillgen/main.go
@@ -180,7 +180,7 @@ func writeSkill(b *strings.Builder, root *cobra.Command) {
 	b.WriteString("~/.buttons/buttons/<name>/\n")
 	b.WriteString("  button.json     # spec (args, runtime, timeout)\n")
 	b.WriteString("  main.sh         # code file (.sh, .py, .js)\n")
-	b.WriteString("  AGENT.md        # prompt instruction\n")
+	b.WriteString("  AGENTS.md        # prompt instruction\n")
 	b.WriteString("  pressed/        # run history as JSON files\n")
 	b.WriteString("```\n")
 }

--- a/internal/tui/detail_model.go
+++ b/internal/tui/detail_model.go
@@ -17,7 +17,7 @@ type DetailModel struct {
 
 	btn      *button.Button
 	lastRun  *history.Run // nil if never pressed
-	agentMD  string       // AGENT.md contents if non-default
+	agentMD  string       // AGENTS.md contents if non-default
 	codePath string       // resolved on-disk code path for `e` edit
 
 	// Terminal size; tracked for the footer right-alignment.

--- a/test/integration/inline_code_test.go
+++ b/test/integration/inline_code_test.go
@@ -243,7 +243,7 @@ func TestCreate_ButtonFolderStructure(t *testing.T) {
 	btnDir := filepath.Join(env.home, "buttons", "mybutton")
 
 	// Check all expected files exist
-	for _, f := range []string{"button.json", "main.sh", "AGENT.md"} {
+	for _, f := range []string{"button.json", "main.sh", "AGENTS.md"} {
 		if _, err := os.Stat(filepath.Join(btnDir, f)); err != nil {
 			t.Errorf("expected %s to exist: %v", f, err)
 		}


### PR DESCRIPTION
## What

Buttons used **`AGENT.md`** (singular) for the per-button / `.buttons` instruction file. Codex, OpenClaw, Cursor, and the [agents.md](https://agents.md) convention all use **`AGENTS.md`** (plural). This standardizes Buttons on `AGENTS.md` everywhere — and, along the way, gives **drawers** the same scaffold buttons already had.

## Changes

1. **Rename `AGENT.md` → `AGENTS.md`** across the codebase (writes, reads, help text, skillgen, store/publish, comments, tests).
2. **New `internal/agentdoc`** — single source of truth for the filename:
   - `Name = "AGENTS.md"` (canonical, used by all writes)
   - `Legacy = "AGENT.md"` (honored on read only)
   - `Path(dir)` — prefers `AGENTS.md`, **falls back to a legacy `AGENT.md`** when only that exists.
3. **Reads** (press, smash, detail, runner→engine prompt execution) go through `agentdoc.Path` → existing buttons with a custom `AGENT.md` keep working. **Writes** (button create, drawer create, the `.buttons` reference guide) always emit `AGENTS.md`.
4. **`buttons drawer create` now scaffolds `AGENTS.md`** (the original ask) — heading + optional description + a Notes hint, mirroring the per-button scaffold.

## Backward compatibility

Non-breaking. New buttons/drawers write `AGENTS.md`; pre-rename buttons whose `AGENT.md` was customized are still read via the legacy fallback. Verified e2e: a prompt button with only an `AGENT.md` presses and returns its content.

## Tests

- New `internal/agentdoc` tests: prefers canonical, falls back to legacy, defaults to canonical when neither exists.
- New `TestService_Create_ScaffoldsAgentMD` for drawers.
- Full suite green (`go test ./...`), `go vet` clean, gofmt clean on all touched files.
- E2E on the built binary: button create → `AGENTS.md`; drawer create → `AGENTS.md`; legacy `AGENT.md` read OK.

## Note for review

Not changed: the repo-root `AGENTS.md` writer in `agentskill.go` already used the plural (it's the project-level agents.md file). A stale `.buttons/AGENT.md` left by an old `init` is harmless (the reference guide is regenerated as `.buttons/AGENTS.md`); say the word if you'd like `init` to delete the legacy one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)