### PR TITLE
[codex] docs: organize concepts and registry history

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ buttons history weather
 
 ## Creating Buttons
 
-Three button types. Use `--prompt` as a modifier on any of them to attach an instruction for the consuming agent.
+Buttons can wrap code, HTTP APIs, imported files, or prompt-only instructions. Use `--prompt` as a modifier on any runnable button to attach instructions for the consuming agent.
 
 ### Code
 
@@ -209,6 +209,78 @@ buttons create deploy --code '...' --arg env:enum:required:staging|prod|canary
 
 Code buttons get args as `BUTTONS_ARG_<NAME>` env vars. API buttons use `{{arg}}` template substitution.
 
+## Workflows
+
+Drawers chain buttons into repeatable workflows. Use them when one action needs multiple steps, data from an earlier step, loops, waits, or a triggerable wrapper.
+
+```bash
+buttons drawer create standup-digest
+buttons drawer standup-digest add github-activity granola-query slack-post
+buttons drawer standup-digest connect github-activity to slack-post
+buttons drawer standup-digest set slack-post.args.channel='#standup'
+buttons drawer standup-digest press
+```
+
+Step outputs are available to later steps through `${step_id.output.field}` refs when the upstream button prints JSON.
+
+```bash
+buttons drawer release-flow set publish.args.version='${build.output.version}'
+```
+
+Drawers also support sub-drawers, loops, switches, aggregates, waits, webhook triggers, validation summaries, error handlers, and their own run history.
+
+## Triggers
+
+Triggers are the planned unified surface for running buttons and drawers automatically:
+
+```bash
+buttons trigger webhook linkedin-sync /linkedin-sync
+buttons trigger cron slack-sync "0 */2 * * *"
+buttons trigger hook docs-sync --enable "file:docs/**/*.md"
+```
+
+Webhook, cron, and hook triggers all target a button or drawer. Button targets can compile down to hidden one-step drawer wrappers so the runtime keeps one workflow model internally.
+
+Current implementation: webhook-triggered drawers are live today with:
+
+```bash
+buttons drawer linkedin-sync trigger webhook /linkedin-sync
+buttons webhook listen
+```
+
+The unified `buttons trigger ...` command is the planned surface over the same drawer model.
+
+## Registry Install Contract
+
+The intended registry layout keeps runnable buttons in `.buttons/buttons/`, desired dependencies and registries in `.buttons/buttons.json`, exact resolved versions in `.buttons/buttons-lock.json`, and local audit events in `.buttons/history.json`. Commit `buttons.json` and `buttons-lock.json` as the team install contract; keep `history.json` local.
+
+Once registry-backed install lands, a teammate who pulls the repo should be able to materialize the project buttons from the manifest and lock file:
+
+```bash
+buttons install
+```
+
+Today, the install command still reads an explicit external source directory:
+
+```bash
+buttons install deploy --source ../button-source
+buttons install deploy@1.2.0 --source ../button-source
+buttons install tag:autono-cal --source ../button-source
+```
+
+Set `BUTTONS_SOURCE` to avoid repeating `--source`. Installed buttons record source, version, and content hash in `button.json`; required peer buttons from `requires` are installed too.
+
+## REST API Server
+
+Expose local buttons over HTTP with the same press contract as the CLI:
+
+```bash
+buttons serve
+buttons serve --host 0.0.0.0 --api-key "$(openssl rand -hex 16)"
+```
+
+Endpoints include `GET /api/buttons`, `GET /api/buttons/{name}`, `POST /api/buttons/{name}/press`, and `GET /api/buttons/{name}/runs`. HTTP buttons are gated behind `--allow-http-buttons`.
+
 ## Discovering Buttons
 
 ```bash
@@ -216,6 +288,7 @@ buttons                    # interactive card-grid board in a TTY, plain table w
 buttons <name>             # full-screen detail page (args, last run, script); press `e` to edit
 buttons logs <name>        # live log viewer — follow mode with `f`, jump with `g`/`G`, `Esc` to exit
 buttons list --json        # machine-readable list
+buttons summary --json     # workspace snapshot for agents
 ```
 
 On the board, pressing a button with required arguments opens an inline form instead of erroring out. Fill it in, hit Enter, the press fires.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,8 +43,8 @@ use it.
 
 Interactively (on a TTY), init also offers to install a Buttons
 skill file for your coding agent (Cursor, Claude Code, Cline,
-GitHub Copilot, or a generic AGENTS.md). None is installed without
-explicit selection.
+GitHub Copilot, AGENTS.md, OpenClaw, or Hermes). None is installed
+without explicit selection.
 
 Examples:
   cd my-project
@@ -140,15 +140,24 @@ func ensureButtonsDir(buttonsDir string) error {
 // and must never be committed.
 //
 // batteries.json — holds plaintext API keys. 0600 on disk, but that
-//                  doesn't stop an accidental `git add -A`.
+//
+//	doesn't stop an accidental `git add -A`.
+//
 // webhook.json   — Cloudflare tunnel config (hostname + tunnel id).
-//                  Not secret per se, but machine-specific.
+//
+//	Not secret per se, but machine-specific.
+//
 // buttons/*/pressed/ — run history including stdin args; can leak
-//                      sensitive values passed at press time.
+//
+//	sensitive values passed at press time.
+//
 // drawers/*/pressed/ — same, for drawer runs.
 // idempotency/   — cached successful results keyed on args. Can
-//                  contain secret-derived data.
+//
+//	contain secret-derived data.
+//
 // queues/        — file-lock semaphore state; machine-local.
+// history.json — local create/edit/install/update activity log.
 func defaultButtonsGitignore() string {
 	return `# Files that hold secrets — never commit.
 batteries.json
@@ -160,17 +169,20 @@ drawers/*/pressed/
 # Local execution state.
 idempotency/
 queues/
+# Local audit history. Commit buttons.json and buttons-lock.json instead.
+history.json
 `
 }
 
 // secretPatterns is the set of .gitignore lines we consider
-// load-bearing for secret hygiene. ensureSecretPatterns appends any
-// missing ones to an existing .buttons/.gitignore so an older project
-// upgrading past the init that introduced the pattern gets the
+// load-bearing for secret/runtime hygiene. ensureSecretPatterns appends
+// any missing ones to an existing .buttons/.gitignore so an older
+// project upgrading past the init that introduced the pattern gets the
 // coverage retroactively.
 var secretPatterns = []string{
 	"batteries.json",
 	"webhook.json",
+	"history.json",
 }
 
 func ensureSecretPatterns(path string) error {
@@ -334,6 +346,6 @@ func init() {
 		&initAgents,
 		"agent",
 		nil,
-		"agent integrations to install (cursor,claude,cline,copilot,agents-md); 'none' skips",
+		"agent integrations to install (cursor,claude,cline,copilot,agents-md,openclaw,hermes); 'none' skips",
 	)
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,9 +30,9 @@ The registry source (buttons.co, #275) is not built yet; for now pass a
 local source directory with --source (or $BUTTONS_SOURCE).
 
 Examples:
-  buttons install deploy --source ./pack
-  buttons install tag:autono-cal --source ./pack
-  buttons install deploy@1.2.0 --source ./pack`,
+  buttons install deploy --source ../button-source
+  buttons install tag:autono-cal --source ../button-source
+  buttons install deploy@1.2.0 --source ../button-source`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		srcDir := installSource

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -78,15 +78,15 @@ func runSummary() error {
 	for _, r := range allButtonRuns {
 		if r.Status != "ok" {
 			failures = append(failures, map[string]any{
-				"run_id":       r.StartedAt.Format("20060102-150405"),
-				"target":       "button/" + r.ButtonName,
-				"failed_step":  "",
+				"run_id":      r.StartedAt.Format("20060102-150405"),
+				"target":      "button/" + r.ButtonName,
+				"failed_step": "",
 				"error": map[string]any{
 					"code":    r.ErrorType,
 					"message": truncateStr(r.Stderr, 200),
 				},
-				"started_at":   r.StartedAt,
-				"started_ago":  prettyDuration(time.Since(r.StartedAt)),
+				"started_at":  r.StartedAt,
+				"started_ago": prettyDuration(time.Since(r.StartedAt)),
 			})
 			if len(failures) >= 5 {
 				break
@@ -118,16 +118,16 @@ func runSummary() error {
 		"data_dir": dataDir,
 		"profile":  profile,
 		"counts": map[string]int{
-			"buttons":        len(buttons),
-			"drawers":        len(drawers),
+			"buttons":         len(buttons),
+			"drawers":         len(drawers),
 			"failures_recent": len(failures),
 		},
-		"buttons":          btnEntries,
-		"drawers":          drawerEntries,
-		"active_runs":      []any{}, // v1 executor is sync; nothing is ever active between commands
-		"recent_failures":  failures,
-		"schedules":        []any{}, // stage 3
-		"webhook":          webhookBlock,
+		"buttons":         btnEntries,
+		"drawers":         drawerEntries,
+		"active_runs":     []any{}, // v1 executor is sync; nothing is ever active between commands
+		"recent_failures": failures,
+		"schedules":       []any{}, // stage 3
+		"webhook":         webhookBlock,
 	}
 
 	if jsonOutput {
@@ -154,7 +154,7 @@ func buttonSummary(b button.Button, recent []history.Run) map[string]any {
 	} else if len(b.OutputSchema) > 0 {
 		entry["output_schema_ref"] = b.Name + ".output"
 	}
-	// Surface pack/discovery metadata when present so an agent can filter
+	// Surface install/discovery metadata when present so an agent can filter
 	// (e.g. all "finance" buttons) and see installed versions.
 	if len(b.Tags) > 0 {
 		entry["tags"] = b.Tags
@@ -209,10 +209,10 @@ func buildWebhookSummaryBlock(drawers []drawer.Drawer) map[string]any {
 	}
 
 	block := map[string]any{
-		"mode":         mode,
-		"routes":       routes,
-		"route_count":  len(routes),
-		"listen_hint":  "buttons webhook listen",
+		"mode":        mode,
+		"routes":      routes,
+		"route_count": len(routes),
+		"listen_hint": "buttons webhook listen",
 	}
 	if hostname != "" {
 		block["hostname"] = hostname

--- a/docs/buttons/cron.mdx
+++ b/docs/buttons/cron.mdx
@@ -1,32 +1,40 @@
 ---
-title: "Cron buttons"
+title: "Cron triggers"
 sidebarTitle: "Cron"
-description: "Run a button on a recurring schedule."
-tag: "Coming soon"
+description: "Run a button or drawer on a recurring schedule."
+tag: "Design proposal"
 ---
 
-Cron buttons will press themselves automatically on a cron schedule. No separate scheduler to configure — you define the cadence when you create the button, and a background trigger daemon handles the rest.
+Cron triggers run a button or drawer on a recurring schedule.
 
 ```bash
-# Planned shape
-buttons create daily-snapshot \
-  --code './scripts/snapshot.sh' \
-  --cron '0 3 * * *'    # every day at 3am
+buttons trigger cron daily-snapshot "0 3 * * *"
+buttons trigger cron slack-sync "0 */2 * * *" --timezone America/New_York
 ```
 
-List scheduled buttons:
+If the target is a button, Buttons should create a hidden one-step drawer wrapper internally. If the target is a drawer, the trigger attaches directly to the drawer.
+
+## Flags
 
 ```bash
-buttons list --scheduled
+buttons trigger cron <target> "<cron>"
+  --timezone America/New_York
+  --overlap skip|queue|replace
+  --name <trigger-id>
 ```
 
-## Blocked on
+Default overlap policy: `skip`. If the previous run is still active when the next tick fires, Buttons should skip the new tick instead of creating accidental parallel work.
 
-The trigger system ([autonoco/autono#272](https://github.com/autonoco/autono/issues/272)). A cron schedule stored on a button is inert without a daemon watching the schedule and firing the button when the time arrives.
+## Management
 
-## What's changing when triggers land
+```bash
+buttons trigger list
+buttons trigger show <id>
+buttons trigger pause <id>
+buttons trigger resume <id>
+buttons trigger remove <id>
+```
 
-- `--cron '<schedule>'` flag accepts standard cron expressions (minute hour day month weekday)
-- Each scheduled press is recorded in the button's run history just like a manual press
-- Trigger daemon surface: `buttons serve --with-cron` or a standalone `buttons cron` process
-- Overlap protection: if a previous run is still executing when the next trigger fires, the new run is either skipped or queued (configurable per button)
+## Implementation note
+
+A cron schedule is inert without a daemon watching schedules and pressing the target. The daemon should record each scheduled press in normal button/drawer history, with trigger id and scheduled time attached to the run metadata.

--- a/docs/buttons/hook.mdx
+++ b/docs/buttons/hook.mdx
@@ -1,0 +1,111 @@
+---
+title: "Hook triggers"
+sidebarTitle: "Hook"
+description: "Run a button or drawer when a local event happens."
+tag: "Design proposal"
+---
+
+A hook trigger runs when a local event happens. It is not time-based and it is not an inbound HTTP request.
+
+- `cron` means time caused the run.
+- `webhook` means a remote service posted to Buttons.
+- `hook` means the local machine, repo, app, or Buttons runtime emitted an event.
+
+## Command shape
+
+```bash
+buttons trigger hook <target> --enable "<source>"
+```
+
+`--enable` names the event source that should cause the target to run.
+
+## File hooks
+
+```bash
+buttons trigger hook docs-sync --enable "file:docs/**/*.md"
+buttons trigger hook downloads-ingest --enable "file:~/Downloads/**/*.pdf" --event created
+```
+
+Useful file options:
+
+```bash
+--event created|modified|deleted|renamed|any
+--ignore "node_modules/**"
+--debounce 10s
+--batch 30s
+--include-existing false
+```
+
+## History hooks
+
+Buttons can use the same file-hook machinery internally to maintain `.buttons/history.json`.
+
+The internal watcher should track creates, edits, deletes, and renames for button and drawer files:
+
+```text
+.buttons/buttons.json
+.buttons/buttons-lock.json
+.buttons/buttons/*/button.json
+.buttons/buttons/*/main.*
+.buttons/buttons/*/AGENT.md
+.buttons/drawers/*/drawer.json
+```
+
+Explicit commands like `buttons create`, `buttons install`, and `buttons update` should write history events directly. File hooks catch manual edits and agent edits that happen outside a Buttons command.
+
+See [History](/concepts/history) for the event shape.
+
+## Git hooks
+
+```bash
+buttons trigger hook repo-index --enable "git:post-commit"
+buttons trigger hook preflight --enable "git:pre-push"
+```
+
+Planned Git events:
+
+```text
+git:pre-commit
+git:post-commit
+git:pre-push
+git:post-checkout
+git:post-merge
+```
+
+## Buttons runtime hooks
+
+```bash
+buttons trigger hook brain-audit --enable "button:*-sync.completed"
+buttons trigger hook notify-failure --enable "button:*.failed"
+buttons trigger hook qa-after-linkedin --enable "button:linkedin-sync.completed"
+```
+
+Planned runtime events:
+
+```text
+button:<name>.started
+button:<name>.completed
+button:<name>.failed
+drawer:<name>.started
+drawer:<name>.completed
+drawer:<name>.failed
+```
+
+## Common options
+
+```bash
+--name <trigger-id>
+--arg key=value
+--filter '<CEL expression>'
+--overlap skip|queue|replace
+```
+
+For lifecycle control, use trigger management commands instead of overloading `--enable`:
+
+```bash
+buttons trigger pause <id>
+buttons trigger resume <id>
+buttons trigger remove <id>
+```
+
+Recommended first implementation: ship `file:` and `button:` hooks, then add `git:` after the filesystem watcher and runtime event bus are stable.

--- a/docs/buttons/sql.mdx
+++ b/docs/buttons/sql.mdx
@@ -21,17 +21,22 @@ Press it:
 buttons press top-users --arg limit=50 --json
 ```
 
-## Blocked on
+## Current workaround
 
-Credential storage ([autonoco/autono#264](https://github.com/autonoco/autono/issues/264) — batteries). The SQL preset depends on being able to:
+SQL buttons are not implemented yet. Today, wrap a SQL CLI with a code button and store credentials in batteries:
 
-- Register a database connection once (`buttons store db analytics-prod --url 'postgres://...'`)
-- Reference it by name from any button (`--db analytics-prod`)
-- Share the same credential across multiple SQL buttons without re-specifying
+```bash
+buttons batteries set ANALYTICS_DATABASE_URL 'postgres://...' --global
 
-## What's changing when batteries lands
+buttons create top-users \
+  --code 'psql "$BUTTONS_BAT_ANALYTICS_DATABASE_URL" -f queries/top-users.sql' \
+  --runtime shell \
+  --arg limit:int:optional
+```
+
+## What's changing when SQL buttons land
 
 - `--sql <file>` flag reads the query from disk, copies it into the button folder
-- `--db <name>` resolves to a stored connection string
+- `--db <name>` resolves to a battery-backed connection reference
 - Arguments bind as parameters, not string substitution — no SQL injection surface
 - Supported drivers: Postgres first, then MySQL, then SQLite

--- a/docs/buttons/triggers.mdx
+++ b/docs/buttons/triggers.mdx
@@ -1,0 +1,62 @@
+---
+title: "Triggers"
+sidebarTitle: "Overview"
+description: "Run a button or drawer from a webhook, cron schedule, or local hook."
+tag: "Design proposal"
+---
+
+Triggers define when a button or drawer runs automatically.
+
+```bash
+buttons trigger webhook <target> [/path]
+buttons trigger cron <target> "<cron>"
+buttons trigger hook <target> --enable "<source>"
+```
+
+`<target>` can be a button or a drawer. If the target is a button, Buttons can create a hidden one-step drawer wrapper internally. If the target is already a drawer, the trigger attaches directly to that drawer.
+
+## Trigger kinds
+
+| Kind | Cause | Example |
+| --- | --- | --- |
+| `webhook` | A remote service sends an HTTP POST. | GitHub, Stripe, Apify, Linear |
+| `cron` | A schedule fires. | nightly sync, hourly digest |
+| `hook` | A local event fires. | file changed, Git commit, button completed |
+
+## Commands
+
+```bash
+buttons trigger webhook linkedin-sync /linkedin-sync
+buttons trigger cron slack-sync "0 */2 * * *"
+buttons trigger hook docs-sync --enable "file:docs/**/*.md"
+```
+
+Management commands should work across every trigger kind:
+
+```bash
+buttons trigger list
+buttons trigger show <id>
+buttons trigger remove <id>
+buttons trigger pause <id>
+buttons trigger resume <id>
+```
+
+## Target resolution
+
+If a button and drawer share a name, use an explicit target prefix:
+
+```bash
+buttons trigger webhook button/linkedin-sync /linkedin-sync
+buttons trigger webhook drawer/linkedin-sync-flow /linkedin-sync
+```
+
+## Current implementation
+
+The current CLI already supports webhook-triggered drawers:
+
+```bash
+buttons drawer <name> trigger webhook [/path]
+buttons webhook listen
+```
+
+The `buttons trigger ...` command is the intended unified surface. It should compile down to the drawer trigger model so existing drawer workflows keep working.

--- a/docs/buttons/webhook.mdx
+++ b/docs/buttons/webhook.mdx
@@ -1,39 +1,62 @@
 ---
-title: "Webhook buttons"
+title: "Webhook triggers"
 sidebarTitle: "Webhook"
-description: "Expose a button as a webhook endpoint that external services can POST to."
-tag: "Coming soon"
+description: "Run a button or drawer when an external service sends an HTTP POST."
+tag: "Partially available"
 ---
 
-Webhook buttons will turn a button into a **receiver**: an HTTP endpoint you can register with GitHub, Stripe, Linear, or any other service that fires webhooks. When the endpoint receives a POST, the button is pressed with the request body and headers available as arguments.
+A webhook trigger turns a button or drawer into a receiver: an HTTP endpoint you can register with GitHub, Stripe, Linear, Apify, or any other service that sends webhooks.
 
-This is the inverse of an [HTTP API button](/buttons/http-api). HTTP API buttons *send* requests; webhook buttons *receive* them.
-
-```bash
-# Planned shape
-buttons create github-pr-opened \
-  --webhook \
-  --secret $GITHUB_WEBHOOK_SECRET \
-  --code './scripts/on-pr-opened.sh'
-```
-
-Start the receiver:
+This is the inverse of an [HTTP API button](/buttons/http-api). HTTP API buttons send requests; webhook triggers receive them.
 
 ```bash
-buttons serve --port 8080
-# → POST http://localhost:8080/webhooks/github-pr-opened
+buttons drawer create github-pr-opened
+buttons drawer github-pr-opened add handle-github-pr
+buttons drawer github-pr-opened trigger webhook /github/pr-opened
+buttons webhook listen
 ```
 
-Point GitHub at that URL and every PR event fires the button.
+Webhook triggers currently attach to drawers. If you want to trigger one button, put it in a one-step drawer.
 
-## Blocked on
+## Flags
 
-`buttons serve` — a long-running server mode. Not just a flag: it needs an HTTP listener, a router, signature verification, retry/ack semantics, and a way to run in the background (launchd, systemd, Docker).
+```bash
+buttons drawer <name> trigger webhook [/path]
+  --auth none
+  --auth basic --auth-user <user> --auth-pass <password>
+  --auth header --auth-header-name <name> --auth-header-value <value>
+  --auth jwt --jwt-secret <secret> [--jwt-algorithm HS256|HS384|HS512]
+             [--jwt-issuer <issuer>] [--jwt-audience <audience>]
+```
 
-## What's changing when serve lands
+Default path: `/<drawer-name>`.
 
-- `--webhook` flag on `buttons create`
-- `--secret` flag for HMAC signature verification (required for production)
-- Request body injected as `BUTTONS_ARG_BODY`, headers as `BUTTONS_ARG_HEADER_<NAME>`
-- `buttons serve` sub-command that exposes all webhook buttons on one port
-- Per-button path routing: `/webhooks/<button-name>`
+Any secret-bearing value accepts `$ENV{VAR_NAME}` so committed `drawer.json` does not carry raw secrets.
+
+## Auth example
+
+```bash
+buttons drawer stripe-receipts trigger webhook /stripe \
+  --auth header \
+  --auth-header-name X-Stripe-Token \
+  --auth-header-value '$ENV{STRIPE_WEBHOOK_TOKEN}'
+```
+
+## Local testing
+
+Dry-run a webhook drawer without the listener:
+
+```bash
+buttons drawer github-pr-opened press --webhook-body '{"action":"opened"}'
+buttons drawer github-pr-opened press --webhook-body @fixture.json
+```
+
+## Planned unified surface
+
+The unified `buttons trigger webhook ...` surface should compile down to the same drawer trigger model.
+
+```bash
+buttons trigger webhook github-pr-opened /github/pr-opened
+```
+
+If the target is a button, Buttons should create a hidden one-step drawer wrapper internally. If the target is a drawer, the trigger attaches directly to the drawer.

--- a/docs/buttons/workflows.mdx
+++ b/docs/buttons/workflows.mdx
@@ -1,0 +1,295 @@
+---
+title: "Workflows"
+sidebarTitle: "Drawers"
+description: "Chain buttons into typed workflows with refs, loops, sub-drawers, waits, and history."
+---
+
+Workflows are called **drawers** in Buttons. A drawer chains one or more buttons into a repeatable run with typed inputs, step outputs, validation, and history.
+
+Use a button for one action. Use a drawer when the action has more than one step, needs data from an earlier step, or should be triggered as a unit.
+
+```bash
+buttons drawer create standup-digest
+buttons drawer standup-digest add github-activity granola-query slack-post
+buttons drawer standup-digest connect github-activity to slack-post
+buttons drawer standup-digest set slack-post.args.channel='#standup'
+buttons drawer standup-digest press
+```
+
+## Mental model
+
+| Concept | Meaning |
+| --- | --- |
+| Button | One reusable action. |
+| Drawer | A workflow made of steps. |
+| Step | A button, sub-drawer, loop, switch, aggregate, or wait position in the drawer. |
+| Input | A value supplied when the drawer is pressed. |
+| Output | A step's parsed JSON stdout, available to later steps. |
+| Ref | A `${...}` expression that reads from inputs, step outputs, env, or webhook URLs. |
+
+Each drawer lives on disk as `drawer.json` under the Buttons drawers directory and records its own run history under `pressed/`.
+
+## Create a drawer
+
+```bash
+buttons drawer create deploy-flow
+buttons drawer deploy-flow add build publish
+buttons drawer deploy-flow connect build to publish
+buttons drawer deploy-flow press env=prod
+```
+
+`add` accepts button names. It also accepts `drawer/<name>` for sub-drawers, `for_each:<button>` for loops, and `wait:<duration>` for time pauses.
+
+```bash
+buttons drawer nightly add gitcrawl-sync brain-audit
+buttons drawer parent-flow add drawer/child-flow
+buttons drawer notify-all add list-users for_each:send-message
+buttons drawer cooloff add wait:30s retry-fetch
+```
+
+## Wire data between steps
+
+When a button prints valid JSON to stdout, the drawer parses it and exposes it as the step output.
+
+```bash
+buttons create current-version \
+  --code 'echo "{\"version\":\"1.2.3\"}"'
+
+buttons create publish-version \
+  --arg version:string:required \
+  --code 'echo "{\"published\":\"$BUTTONS_ARG_VERSION\"}"'
+
+buttons drawer create release-flow
+buttons drawer release-flow add current-version publish-version
+buttons drawer release-flow set publish-version.args.version='${current-version.output.version}'
+buttons drawer release-flow press
+```
+
+If stdout is not JSON, the raw stdout string is still recorded in history, but structured refs like `${step.output.field}` only work against JSON output.
+
+## Auto-connect by schema
+
+If a button declares `output_schema`, `buttons drawer <name> connect A to B` can match compatible output fields to downstream args.
+
+```bash
+buttons drawer standup-digest connect github-activity to slack-post
+```
+
+Use explicit wiring when the field names do not line up:
+
+```bash
+buttons drawer standup-digest connect github-activity.output.summary to slack-post.args.text
+```
+
+## Drawer inputs
+
+Any unfilled required button arg can be supplied at drawer press time by name.
+
+```bash
+buttons drawer deploy-flow press env=prod
+```
+
+Explicit step args win. If a step arg is not set and a drawer input with the same name exists, Buttons fills it for that step.
+
+## Step kinds
+
+| Kind | Status | Purpose |
+| --- | --- | --- |
+| `button` | Live | Press a button. |
+| `drawer` | Live | Call another drawer. |
+| `for_each` | Live | Iterate nested steps over an array. |
+| `switch` | Live | Run the first matching branch. |
+| `aggregate` | Live | Collect values from an array. |
+| `wait` | Live | Pause by duration or until a timestamp. |
+| `split`, `merge`, `transform`, `batch` | Reserved | Present in schema for future executors. |
+
+## Sub-drawers
+
+A drawer can call another drawer with `drawer/<name>`.
+
+```bash
+buttons drawer create child-build
+buttons drawer child-build add build-artifact
+
+buttons drawer create parent-release
+buttons drawer parent-release add drawer/child-build publish
+```
+
+Sub-drawers are useful when a workflow has a reusable middle section. The child drawer can define a `return` block in `drawer.json` so the parent can reference selected values as `${child-build.output.<field>}`.
+
+```json
+{
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "version": { "type": "string" }
+    }
+  },
+  "return": {
+    "version": "${build-artifact.output.version}"
+  }
+}
+```
+
+## Loops
+
+Use `for_each:<button>` for per-item work.
+
+```bash
+buttons drawer create notify-users
+buttons drawer notify-users add list-users for_each:send-message
+buttons drawer notify-users set for_each-send-message.over='${list-users.output.users}'
+buttons drawer notify-users set for_each-send-message.as=user
+buttons drawer notify-users set for_each-send-message.steps.0.args.email='${user.email}'
+buttons drawer notify-users set for_each-send-message.parallelism=4
+buttons drawer notify-users press
+```
+
+Useful loop fields:
+
+| Field | Purpose |
+| --- | --- |
+| `over` | CEL expression that resolves to an array. |
+| `as` | Loop variable name, default `item`. |
+| `parallelism` | Max concurrent iterations. `0` or `1` means serial. |
+| `on_item_failure` | `stop` or `continue`. |
+
+The loop output includes `results` in input order, so downstream refs stay deterministic even when iterations run concurrently.
+
+## Switches
+
+Switch steps run the first case whose `when` expression is truthy. Author them in `drawer.json`.
+
+```json
+{
+  "id": "route",
+  "kind": "switch",
+  "cases": [
+    {
+      "id": "prod",
+      "when": "inputs.env == 'prod'",
+      "steps": [
+        { "id": "notify-prod", "kind": "button", "button": "notify-prod" }
+      ]
+    }
+  ],
+  "steps": [
+    { "id": "notify-dev", "kind": "button", "button": "notify-dev" }
+  ]
+}
+```
+
+The top-level `steps` on a switch act as the default branch.
+
+## Aggregates
+
+Aggregate steps collect values from an array, often after a `for_each`.
+
+```json
+{
+  "id": "summaries",
+  "kind": "aggregate",
+  "from": "${for_each-send-message.output.results}",
+  "pluck": "item.output.message_id"
+}
+```
+
+The output is `{ "values": [...], "count": N }`, with `values` in the same order as the input.
+
+## Waits
+
+Use waits to pause between steps.
+
+```bash
+buttons drawer retry-flow add fetch-api wait:30s fetch-api-2
+```
+
+You can also set wait fields directly:
+
+```bash
+buttons drawer retry-flow set wait.duration=2m
+buttons drawer deploy-window set wait.until=2026-06-28T21:00:00Z
+```
+
+Waits honor cancellation, so stopping the drawer does not leave a sleeping process behind.
+
+## Failure handling
+
+By default, a failing step fails the drawer. Step-level `on_failure` can be authored in `drawer.json` for retry or continue behavior:
+
+```json
+{
+  "id": "fetch-api",
+  "button": "fetch-api",
+  "on_failure": {
+    "action": "retry",
+    "max_attempts": 3,
+    "backoff": { "strategy": "exponential", "initial_ms": 500 }
+  }
+}
+```
+
+A drawer can also define `on_error` to call a separate error-handler drawer after failure. The handler receives `drawer`, `run_id`, `failed_step`, `error`, and redacted `inputs`. The failure still remains visible in the original drawer run history.
+
+```json
+{
+  "on_error": {
+    "drawer": "notify-workflow-failure",
+    "with": {
+      "severity": "warning"
+    }
+  }
+}
+```
+
+## Webhook-triggered drawers
+
+Webhook triggers currently attach to drawers:
+
+```bash
+buttons drawer create on-apify-done
+buttons drawer on-apify-done add apify-fetch-dataset
+buttons drawer on-apify-done trigger webhook /apify-done
+buttons webhook listen
+```
+
+The request appears as `${inputs.webhook}` inside the drawer:
+
+```text
+${inputs.webhook.body}
+${inputs.webhook.headers.Content-Type}
+${inputs.webhook.query.token}
+${inputs.webhook.method}
+${inputs.webhook.path}
+${inputs.webhook.received_at}
+```
+
+The planned `buttons trigger webhook <target>` surface should compile down to this same drawer model. If the target is a button, Buttons can create a hidden one-step drawer wrapper.
+
+## Inspect and debug
+
+```bash
+buttons drawer list
+buttons drawer standup-digest
+buttons drawer standup-digest logs
+buttons drawer standup-digest logs --failed
+buttons drawer standup-digest press --summary --json
+buttons drawer schema
+```
+
+`--summary` previews a drawer mutation or press without running it. Use `--json` when an agent or script needs structured output.
+
+`buttons drawer schema` prints the embedded JSON Schema for `drawer.json`. See [drawer.json](/concepts/drawer-json) for the full field reference.
+
+## Storage shape
+
+A drawer folder looks like this:
+
+```text
+~/.buttons/drawers/standup-digest/
+  drawer.json
+  pressed/
+    2026-06-28T09-00-00.json
+```
+
+The history file records drawer inputs, each step's resolved args, stdout, stderr, parsed output, duration, exit code, and structured errors. That is what lets agents recover from workflow failures without re-running blind.

--- a/docs/changelog/2026-04-12.mdx
+++ b/docs/changelog/2026-04-12.mdx
@@ -54,9 +54,9 @@ Buttons ships with four ways to create a button and two new command groups for o
 
 - **HTTP API buttons** — wrap any HTTP endpoint as a pressable button with `--url`, `--method`, `--header`, and `--body`. Placeholders like `{{arg}}` are automatically encoded based on context (path segment, query string, JSON body, or form body) so values are always safe. See [HTTP API buttons](/buttons/http-api).
 
-- **File buttons** — import an existing script file with `--file`. The script is copied into the button folder at create time so the button is self-contained. No size limit applies, unlike inline code buttons. See [file buttons](/buttons/file).
+- **File buttons** — import an existing script file with `--file`. The script is copied into the button folder at create time so the button is self-contained. No size limit applies, unlike inline code buttons. See [code buttons](/buttons/code).
 
-- **Agent buttons** — attach an LLM prompt to a button with `--agent`. Use it standalone to encode a task for an AI agent, or combine it with a code or HTTP button so the agent receives both the execution result and instructions in one response. See [agent buttons](/buttons/agent).
+- **Agent buttons** — attach an LLM prompt to a button with `--agent`. Use it standalone to encode a task for an AI agent, or combine it with a code or HTTP button so the agent receives both the execution result and instructions in one response. This was later renamed to prompt buttons; see [prompt buttons](/buttons/prompt).
 
 - **Drawers** — group related buttons into named collections with `buttons drawer create` and `buttons drawer add`. Use drawers to organize buttons by project, team, or workflow. See the [CLI reference](/cli/buttons_drawer).
 

--- a/docs/cli/buttons_batteries.md
+++ b/docs/cli/buttons_batteries.md
@@ -10,14 +10,17 @@ Manage environment variables and secrets
 ### Synopsis
 
 Batteries are key/value pairs injected into every button press
-as BUTTONS_BAT_`<KEY>`=<value>. Use them to store API tokens and other
+as BUTTONS_BAT_`<KEY>`=`<value>`. Use them to store API tokens and other
 secrets outside your button scripts.
 
 Scopes:
+
+```text
   global   ~/.buttons/batteries.json  — available from every project
   local    .buttons/batteries.json    — only when pressing inside the
                                         project; overrides global on
                                         key collision
+```
 
 List / get read from both scopes (local overrides on collision). Set /
 rm target local when inside a project, global otherwise; pass --global

--- a/docs/cli/buttons_config.md
+++ b/docs/cli/buttons_config.md
@@ -17,10 +17,13 @@ project repos via .buttons/. Project-level knobs live on each button
 specifically).
 
 Known keys:
+
+```text
   default-timeout   seconds used when 'buttons create' is run without
                     an explicit --timeout flag (fallback: 300)
   theme             board TUI theme: default | paper | phosphor | amber
                     (fallback: default — adapts to terminal background)
+```
 
 Running `buttons config` with no subcommand prints the current values.
 

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -11,7 +11,7 @@ Create a new button
 
 Create a new button.
 
-By default, 'buttons create <name>' scaffolds a shell button with a
+By default, 'buttons create `<name>`' scaffolds a shell button with a
 placeholder main.sh the agent can edit, then press. Use --runtime to
 scaffold a Python or Node button instead.
 
@@ -26,12 +26,17 @@ Enum args accept a 4th pipe-separated segment listing the allowed
 values — the TUI press form renders them as a horizontal choice row,
 and the CLI validates the supplied value is in the set:
 
+
+```text
   --arg env:enum:required:staging|prod|canary
+```
 
 Args are injected as env vars for scripts or substituted into URL
 templates for API buttons.
 
 Common flags:
+
+```text
   -f, --file PATH       copy an existing script file as this button's code
       --code STRING     inline script body (shortcut for one-liners)
       --url URL         turn this into an HTTP button
@@ -40,6 +45,7 @@ Common flags:
       --timeout SECS    execution timeout (default: 300)
   -d, --description S   human-readable description for 'buttons list'
       --runtime NAME    shell | python | node  (default: shell)
+```
 
 **Examples:**
 

--- a/docs/cli/buttons_drawer.md
+++ b/docs/cli/buttons_drawer.md
@@ -13,6 +13,8 @@ Manage drawers — typed workflows that chain buttons with
 ${ref} references between steps.
 
 Usage:
+
+```text
   buttons drawer create NAME
   buttons drawer list
   buttons drawer NAME add BUTTON [BUTTON ...]         append button step(s)
@@ -33,13 +35,17 @@ Usage:
   buttons drawer NAME remove                          delete the drawer
   buttons drawer NAME                                 summary (topology + validation + recent runs)
   buttons drawer schema                               print JSON Schema for drawer.json
+```
 
 Typical authoring flow:
+
+```text
   buttons drawer create deploy-flow
   buttons drawer deploy-flow add build publish
   buttons drawer deploy-flow connect build to publish
   buttons drawer deploy-flow set publish.args.env=prod
   buttons drawer deploy-flow press
+```
 
 ```
 buttons drawer [flags]

--- a/docs/cli/buttons_ignore.md
+++ b/docs/cli/buttons_ignore.md
@@ -13,11 +13,14 @@ Adds the named button/drawer to .buttons/.gitignore so git
 won't track it. Useful for scratch/test buttons an agent spins up
 while iterating.
 
+
+```text
   buttons ignore NAME                — ignore a button
   buttons ignore drawer/NAME         — ignore a drawer
   buttons ignore                     — list currently-ignored entries
   buttons unignore NAME              — re-include in git
   buttons create NAME --ignore       — create + ignore in one step
+```
 
 The .buttons/.gitignore file is a standard gitignore scoped to the
 .buttons/ subtree — git applies it natively, no extra config.

--- a/docs/cli/buttons_import.md
+++ b/docs/cli/buttons_import.md
@@ -11,10 +11,13 @@ Create buttons from external sources (skill, code, url)
 
 Import buttons from external sources:
 
+
+```text
   buttons import code <file>     wrap a script as a button (runtime inferred)
   buttons import skill <dir>     a button per script in an AgentSkills skill
   buttons import url <url>       create a button from a fetched HTTP spec
   buttons import mcp <server>    (planned) one button per MCP tool
+```
 
 Every import prints what it will create and asks to confirm. Pass --yes to
 skip the prompt (required when running non-interactively).

--- a/docs/cli/buttons_init.md
+++ b/docs/cli/buttons_init.md
@@ -30,8 +30,8 @@ use it.
 
 Interactively (on a TTY), init also offers to install a Buttons
 skill file for your coding agent (Cursor, Claude Code, Cline,
-GitHub Copilot, or a generic AGENTS.md). None is installed without
-explicit selection.
+GitHub Copilot, AGENTS.md, OpenClaw, or Hermes). None is installed
+without explicit selection.
 
 **Examples:**
 
@@ -50,7 +50,7 @@ buttons init [flags]
 ### Options
 
 ```
-      --agent strings   agent integrations to install (cursor,claude,cline,copilot,agents-md); 'none' skips
+      --agent strings   agent integrations to install (cursor,claude,cline,copilot,agents-md,openclaw,hermes); 'none' skips
   -h, --help            help for init
 ```
 

--- a/docs/cli/buttons_install.md
+++ b/docs/cli/buttons_install.md
@@ -12,9 +12,12 @@ Install a button (or every button with a tag) from a source
 Install buttons from a source into your buttons directory.
 
 The argument is one of:
+
+```text
   <name>            a single button (latest version)
   <name>@<version>  a pinned version
   tag:<tag>         every button in the source carrying <tag>
+```
 
 Each installed button's dependencies (its button.json "requires") are
 installed too. Source + version + content hash are recorded in each
@@ -26,9 +29,9 @@ local source directory with --source (or $BUTTONS_SOURCE).
 **Examples:**
 
 ```bash
-buttons install deploy --source ./pack
-buttons install tag:autono-cal --source ./pack
-buttons install deploy@1.2.0 --source ./pack
+buttons install deploy --source ../button-source
+buttons install tag:autono-cal --source ../button-source
+buttons install deploy@1.2.0 --source ../button-source
 ```
 
 ```

--- a/docs/cli/buttons_logs.md
+++ b/docs/cli/buttons_logs.md
@@ -12,12 +12,15 @@ View past runs for a button or tail the live progress stream
 Structured run history. CLI only — for the full-screen
 interactive viewer, use 'buttons board'.
 
+
+```text
   buttons BUTTONNAME logs            — past runs for this button
   buttons BUTTONNAME logs --follow   — tail live progress JSONL as it writes
   buttons BUTTONNAME logs --failed   — just failures
   buttons BUTTONNAME logs --limit 10 — how many (default 20)
   buttons drawer DRAWERNAME logs     — past runs for this drawer
   buttons logs                       — recent failures across the workspace
+```
 
 --follow streams the latest press's progress events to stdout as
 plain text (JSONL: one event per line). No TUI. Pipe it, parse it,

--- a/docs/cli/buttons_mcp.md
+++ b/docs/cli/buttons_mcp.md
@@ -17,15 +17,21 @@ Uses a thin meta-tool surface — buttons_list, buttons_press, buttons_inspect
 large button sets don't degrade the MCP client.
 
 Security:
+
+```text
   - Only buttons with "mcp_enabled": true are listed, pressable, or inspectable.
-  - Args are validated against the button's spec and passed as BUTTONS_ARG_`<NAME>`
+  - Args are validated against the button's spec and passed as BUTTONS_ARG_<NAME>
     env vars — never substituted into shell text.
   - Per button: max 10 calls/min, 1 concurrent press, hard 120s timeout cap.
   - buttons_create is OFF unless --allow-create is passed.
+```
 
 stdout carries only protocol messages; logs go to stderr. Register with an
 agent, e.g. Claude Code:
+
+```text
   claude mcp add buttons -- buttons mcp
+```
 
 ```
 buttons mcp [flags]

--- a/docs/cli/buttons_press.md
+++ b/docs/cli/buttons_press.md
@@ -16,10 +16,13 @@ variables (BUTTONS_ARG_`<NAME>`) for code buttons, or as template substitutions
 for API buttons. Returns structured output in --json mode.
 
 Common flags:
+
+```text
       --arg KEY=VALUE   pass an argument (repeatable; validated against the spec)
       --timeout SECS    override the button's configured timeout for this press
       --dry-run         print what would run without executing
       --json            emit machine-readable output (default when stdout is piped)
+```
 
 **Examples:**
 

--- a/docs/cli/buttons_publish.md
+++ b/docs/cli/buttons_publish.md
@@ -11,7 +11,7 @@ Publish a local button to a source so others can install it
 
 Publish a button — the inverse of 'buttons install'. The button folder
 (button.json + code + AGENT.md, never its run history) is content-hashed and
-written to a source, where 'buttons install <name> --source <dir>' can fetch it.
+written to a source, where 'buttons install `<name>` --source `<dir>`' can fetch it.
 
 The registry source (buttons.co, #275/#276) is not built yet; for now publish
 to a local source directory with --source (or $BUTTONS_SOURCE). That directory

--- a/docs/cli/buttons_serve.md
+++ b/docs/cli/buttons_serve.md
@@ -13,13 +13,16 @@ Start an HTTP server that exposes your buttons as a REST API, using the
 same structured-output contract and execution path as the CLI.
 
 Endpoints:
+
+```text
   GET  /api/health               liveness (no auth)
   GET  /api/buttons              list all buttons
   GET  /api/buttons/{name}       a button's spec
   POST /api/buttons/{name}/press execute a button (JSON body: {"args":{…},"timeout":N})
   GET  /api/buttons/{name}/runs  recent run history
+```
 
-Auth: every endpoint except /api/health requires 'Authorization: Bearer <key>'.
+Auth: every endpoint except /api/health requires 'Authorization: Bearer `<key>`'.
 The key comes from --api-key, else the 'API_KEY' battery, else $BUTTONS_API_KEY.
 With no key the server runs auth-free and therefore binds to loopback only —
 binding a non-loopback host without a key is refused.

--- a/docs/cli/buttons_smash.md
+++ b/docs/cli/buttons_smash.md
@@ -11,13 +11,19 @@ Run multiple buttons in parallel
 
 Run several buttons concurrently. Names may be comma- or space-separated:
 
+
+```text
   buttons smash a,b,c
   buttons smash a b c
+```
 
+
+```text
   --on-failure continue   run them all, report failures at the end (default)
   --on-failure stop       cancel the remaining buttons on the first failure
   --concurrency N         max buttons running at once (0 = NumCPU; hard cap 50)
   --timeout SECS          per-button timeout override
+```
 
 JSON mode returns an array of per-button results; every run is recorded in
 history. Exits non-zero if any button failed.

--- a/docs/cli/buttons_tail.md
+++ b/docs/cli/buttons_tail.md
@@ -12,14 +12,20 @@ Follow the progress JSONL of a press
 Tail a press's structured progress stream.
 
 Argument can be either:
+
+```text
   • a button name — tails the LATEST press's progress file
   • an absolute path to a .progress.jsonl file
+```
 
 Scripts write to $BUTTONS_PROGRESS_PATH (set automatically by the
 engine). Typical event shape:
 
+
+```text
     {"ts":"...","event":"progress","pct":0.25,"msg":"downloaded 5/20"}
     {"ts":"...","event":"log","level":"info","msg":"..."}
+```
 
 **Examples:**
 

--- a/docs/cli/buttons_trigger.md
+++ b/docs/cli/buttons_trigger.md
@@ -12,9 +12,12 @@ Manage button triggers (cron, watch, webhook)
 Attach event triggers to a button so it presses automatically.
 
 Triggers run under 'buttons serve':
+
+```text
   - cron    fires on a schedule (5-field cron, in-process scheduler)
   - watch   fires when a file changes (polled, 500ms debounce)
   - webhook fires on an HTTP POST to a path on the serve listener
+```
 
 **Examples:**
 

--- a/docs/cli/buttons_webhook.md
+++ b/docs/cli/buttons_webhook.md
@@ -16,22 +16,31 @@ that URL works without hosting anything yourself.
 
 Two modes:
 
+
+```text
   quick   zero setup. Each webhook step spawns a fresh Quick Tunnel
           (ephemeral *.trycloudflare.com URL). Good when the service
           accepts a per-run webhook URL.
+```
 
+
+```text
   named   stable hostname on your own Cloudflare account. Set up once
           via 'buttons webhook setup'. Required when a service wants a
           fixed URL registered up front (e.g. GitHub webhooks).
+```
 
 Prereq: 'cloudflared' binary on PATH. Install via 'brew install cloudflared'.
 
 Verbs:
+
+```text
   buttons webhook setup    — one-time: Cloudflare login + pick a hostname
   buttons webhook status   — show current mode + hostname
   buttons webhook test     — end-to-end round-trip verify
   buttons webhook listen   — run the dispatcher that presses triggered drawers
   buttons webhook logout   — forget the named-tunnel config (quick mode again)
+```
 
 ```
 buttons webhook [flags]

--- a/docs/cli/buttons_webhook_listen.md
+++ b/docs/cli/buttons_webhook_listen.md
@@ -14,19 +14,27 @@ drawers with webhook triggers get invoked when third-party services
 POST to their paths.
 
 Prereq:
+
+```text
   1. 'cloudflared' on PATH (brew install cloudflared)
   2. 'buttons webhook setup' run once for a stable named tunnel
      (quick-tunnel mode works too, but the URL changes each run — fine
      for dev, not for services that register a fixed URL up front)
+```
 
 Workflow:
+
+```text
   1. Create a drawer:               buttons drawer create on-apify-done
   2. Add steps that consume the webhook body via \${inputs.webhook.body.*}
   3. Attach a webhook trigger:      buttons drawer on-apify-done trigger webhook /apify
   4. Start the listener:            buttons webhook listen
   5. Configure the third-party service to POST to the printed URL.
+```
 
 When a POST arrives at a registered path:
+
+```text
   - The request body, headers, query, and method are materialized as
     \${inputs.webhook.body}, \${inputs.webhook.headers.*}, etc.
   - The drawer is pressed asynchronously — the HTTP response returns
@@ -34,6 +42,7 @@ When a POST arrives at a registered path:
     full workflow.
   - If the drawer has a shared-token secret set, X-Buttons-Token (or
     ?token= query param) must match or the request is rejected 401.
+```
 
 The listener stays up until Ctrl-C. Run it in tmux, a separate pane,
 or under launchd/systemd for always-on setups.

--- a/docs/concepts/arguments.mdx
+++ b/docs/concepts/arguments.mdx
@@ -70,7 +70,7 @@ buttons press send-alert --arg channel=ops
 
 ## How arguments reach code buttons
 
-For [code buttons](/buttons/code) and [file buttons](/buttons/file), each argument is injected as an environment variable named `BUTTONS_ARG_<NAME>` where `<NAME>` is the argument name uppercased:
+For [code buttons](/buttons/code), including buttons created from imported files with `--file`, each argument is injected as an environment variable named `BUTTONS_ARG_<NAME>` where `<NAME>` is the argument name uppercased:
 
 ```bash
 # Declared as:  --arg region:string:required

--- a/docs/concepts/button-json.mdx
+++ b/docs/concepts/button-json.mdx
@@ -1,0 +1,155 @@
+---
+title: "button.json"
+description: "The on-disk spec for a button."
+---
+
+Every button has a `button.json` spec in its button folder. It is the source of truth for runtime, arguments, HTTP settings, metadata, concurrency, and packaging fields.
+
+```text
+~/.buttons/buttons/<name>/
+  button.json
+  main.sh | main.py | main.js
+  AGENT.md
+  pressed/
+```
+
+Project-local buttons use the same shape under `.buttons/buttons/<name>/`.
+
+## Example
+
+```json
+{
+  "schema_version": 2,
+  "name": "deploy",
+  "description": "Deploy a tagged release",
+  "runtime": "shell",
+  "args": [
+    { "name": "env", "type": "enum", "required": true, "values": ["staging", "prod"] },
+    { "name": "version", "type": "string", "required": true }
+  ],
+  "timeout_seconds": 300,
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "url": { "type": "string" }
+    }
+  },
+  "queue": {
+    "name": "deploys",
+    "concurrency": 1
+  }
+}
+```
+
+## Core fields
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Button spec version. Newly created buttons use version `2`. |
+| `name` | Kebab-case button name. |
+| `description` | One-line description surfaced by `buttons list`, `summary`, and the board. |
+| `runtime` | `shell`, `python`, `node`, `http`, or `prompt`. |
+| `args` | Typed press-time arguments. |
+| `timeout_seconds` | Default timeout for this button. |
+| `created_at`, `updated_at` | UTC timestamps. |
+
+## Code buttons
+
+Code buttons use `runtime: shell`, `python`, or `node`. The script lives next to `button.json` as `main.sh`, `main.py`, or `main.js`.
+
+Arguments arrive as environment variables:
+
+```text
+BUTTONS_ARG_<NAME>
+```
+
+## HTTP buttons
+
+HTTP buttons use `runtime: http`.
+
+| Field | Meaning |
+| --- | --- |
+| `url` | URL template created with `--url`. |
+| `method` | HTTP method. Defaults to `GET`. |
+| `headers` | Header templates. |
+| `body` | Request body template. |
+| `max_response_bytes` | Response body cap. Defaults to 10 MB for HTTP buttons. |
+| `allow_private_networks` | Allows loopback/RFC1918/link-local targets when true. |
+| `allowed_host` | Scheme/host lock derived at create time. Template args cannot redirect to a new host. |
+
+## Prompt buttons
+
+Prompt-only buttons use `runtime: prompt` and do not have a `main.*` file. Their instruction lives in `AGENT.md` and is returned in the `prompt` field when pressed.
+
+Code and HTTP buttons can also carry `AGENT.md` instructions; in that case the command runs first and the prompt is attached to the result.
+
+## Arguments
+
+Args are declared at create time:
+
+```bash
+buttons create deploy \
+  --arg env:enum:required:staging|prod \
+  --arg version:string:required
+```
+
+Supported arg types are `string`, `int`, `bool`, and `enum`.
+
+## Output schema
+
+`output_schema` is optional JSON Schema for the button's JSON stdout. Drawers use it to type-check refs and auto-connect compatible fields.
+
+```json
+{
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "summary": { "type": "string" }
+    }
+  }
+}
+```
+
+When a button prints valid JSON to stdout, a drawer exposes it as `${step_id.output.<field>}`.
+
+## Queues
+
+`queue` limits concurrent presses.
+
+```json
+{
+  "queue": {
+    "name": "openai",
+    "concurrency": 3,
+    "key": "${inputs.user_id}"
+  }
+}
+```
+
+Buttons sharing a queue name share the same slot pool. A `key` scopes that pool per press, so one queue can enforce a per-user or per-account limit.
+
+## Packaging fields
+
+Installed buttons can include package metadata:
+
+| Field | Meaning |
+| --- | --- |
+| `tags` | Groups used by `buttons install tag:<tag>`. |
+| `version` | Button content version. |
+| `requires` | Other buttons to install with this one. |
+| `requires_batteries` | Battery keys the button needs. Values are never shipped. |
+| `source` | Install source reference. |
+| `content_hash` | Hash recorded at install time for drift/update checks. |
+
+## Board metadata
+
+`pinned: true` surfaces a button as a large card at the top of `buttons board`.
+
+## Related
+
+- [Code buttons](/buttons/code)
+- [API buttons](/buttons/http-api)
+- [Arguments](/concepts/arguments)
+- [Registry](/concepts/registry)
+- [History](/concepts/history)
+- [Workflows](/buttons/workflows)

--- a/docs/concepts/buttons.mdx
+++ b/docs/concepts/buttons.mdx
@@ -1,0 +1,44 @@
+---
+title: "Buttons"
+description: "The core unit of reusable work in Buttons."
+---
+
+A button is one reusable action with typed inputs, a runtime, structured output, and run history.
+
+Use a button when an agent or human should be able to repeat the same action without rebuilding the command from scratch.
+
+```bash
+buttons create deploy --arg env:string:required --code './deploy "$BUTTONS_ARG_ENV"'
+buttons press deploy --arg env=staging
+```
+
+## Mental model
+
+Each button owns:
+
+| Part | Purpose |
+| --- | --- |
+| `button.json` | Name, args, runtime, timeout, metadata, and install fields. |
+| `main.*` | Optional executable code for shell, Python, or Node buttons. |
+| `AGENT.md` | Agent instructions and context for when to use the button. |
+| `pressed/` | Per-machine run history. |
+
+Buttons live under `.buttons/buttons/<name>/` for a project or `~/.buttons/buttons/<name>/` globally.
+
+## When to create a button
+
+Create a button when the action is:
+
+- repeated more than once
+- risky to type by hand
+- useful to an agent
+- part of a larger workflow
+- worth giving typed arguments and JSON output
+
+## Related
+
+- [Code buttons](/buttons/code)
+- [HTTP API buttons](/buttons/http-api)
+- [Prompt buttons](/buttons/prompt)
+- [button.json](/concepts/button-json)
+- [Drawers](/concepts/drawers)

--- a/docs/concepts/drawer-json.mdx
+++ b/docs/concepts/drawer-json.mdx
@@ -1,0 +1,159 @@
+---
+title: "drawer.json"
+description: "The workflow spec for drawers."
+---
+
+A drawer is a workflow made of steps. Its source of truth is `drawer.json`.
+
+```text
+~/.buttons/drawers/<name>/
+  drawer.json
+  pressed/
+```
+
+Project-local drawers use the same shape under `.buttons/drawers/<name>/`.
+
+## Example
+
+```json
+{
+  "schema_version": 1,
+  "name": "release-flow",
+  "inputs": [
+    { "name": "env", "type": "enum", "required": true, "values": ["staging", "prod"] }
+  ],
+  "steps": [
+    { "id": "build", "kind": "button", "button": "build-artifact" },
+    {
+      "id": "publish",
+      "kind": "button",
+      "button": "publish-artifact",
+      "args": {
+        "env": "${inputs.env}",
+        "version": "${build.output.version}"
+      }
+    }
+  ],
+  "return": {
+    "version": "${build.output.version}",
+    "url": "${publish.output.url}"
+  }
+}
+```
+
+## Top-level fields
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Drawer spec version. Current version is `1`. |
+| `name` | Drawer name. |
+| `description` | Human-readable one-liner. |
+| `inputs` | Values supplied at drawer press time. |
+| `steps` | Ordered workflow steps. |
+| `output_schema` | Optional JSON Schema for values exposed when called as a sub-drawer. |
+| `return` | Map of output fields to `${...}` expressions. |
+| `triggers` | Automatic invocation sources. Webhook triggers are live today. |
+| `on_error` | Optional drawer to call after failure. |
+
+## Step kinds
+
+| Kind | Status | Purpose |
+| --- | --- | --- |
+| `button` | Live | Press a button. |
+| `drawer` | Live | Call another drawer as a sub-workflow. |
+| `for_each` | Live | Iterate nested steps over an array. |
+| `switch` | Live | Run the first matching branch. |
+| `aggregate` | Live | Pluck values out of an array, often after `for_each`. |
+| `wait` | Live | Pause for a duration or until an RFC3339 time. |
+| `split`, `merge`, `transform`, `batch` | Reserved | Schema-reserved for future runtimes. |
+
+## References
+
+Step args and drawer fields can use `${...}` expressions. The expression body is CEL.
+
+```text
+${inputs.env}
+${build.output.version}
+${env.GITHUB_TOKEN}
+${webhooks.on-scrape-done}
+${inputs.count * 2}
+${has(build.output.url) ? build.output.url : "missing"}
+```
+
+Hyphenated step IDs are supported in refs; Buttons rewrites them internally so CEL can parse them.
+
+## Inputs
+
+Drawer inputs mirror button args and add `secret` redaction:
+
+```json
+{
+  "inputs": [
+    { "name": "api_key", "type": "string", "required": true, "secret": true }
+  ]
+}
+```
+
+Secret inputs can still flow into a step's resolved args, but they are redacted from drawer history.
+
+## Failure handling
+
+Step-level `on_failure` controls one step:
+
+```json
+{
+  "on_failure": {
+    "action": "retry",
+    "max_attempts": 3,
+    "backoff": {
+      "strategy": "exponential",
+      "initial_ms": 500,
+      "factor": 2,
+      "max_ms": 10000,
+      "jitter": true
+    }
+  }
+}
+```
+
+Supported actions are `stop`, `continue`, and `retry`.
+
+Drawer-level `on_error` calls another drawer after a failed run. The handler receives `drawer`, `run_id`, `failed_step`, `error`, and redacted `inputs`.
+
+## Webhook triggers
+
+Webhook triggers are stored in `triggers`.
+
+```json
+{
+  "triggers": [
+    {
+      "kind": "webhook",
+      "path": "/apify-done",
+      "auth": {
+        "type": "header",
+        "header_name": "X-Buttons-Token",
+        "header_value": "$ENV{APIFY_WEBHOOK_TOKEN}"
+      }
+    }
+  ]
+}
+```
+
+Inside the drawer, the request appears as `${inputs.webhook.body}`, plus headers, query, method, path, and `received_at`.
+
+## Schema
+
+Print the embedded JSON Schema:
+
+```bash
+buttons drawer schema
+```
+
+The published copy lives at `docs/schemas/drawer.schema.json`.
+
+## Related
+
+- [Workflows](/buttons/workflows)
+- [Webhook triggers](/buttons/webhook)
+- [JSON output](/concepts/json-output)

--- a/docs/concepts/drawers.mdx
+++ b/docs/concepts/drawers.mdx
@@ -1,0 +1,41 @@
+---
+title: "Drawers"
+description: "Typed workflows that chain buttons together."
+---
+
+A drawer is a workflow made of buttons and workflow steps. Use a drawer when an action has multiple steps, needs output from an earlier step, or should be triggered as a unit.
+
+```bash
+buttons drawer create release-flow
+buttons drawer release-flow add build publish notify
+buttons drawer release-flow connect build to publish
+buttons drawer release-flow press env=prod
+```
+
+## Mental model
+
+| Concept | Meaning |
+| --- | --- |
+| Drawer | A reusable workflow. |
+| Step | A button, sub-drawer, loop, switch, aggregate, or wait. |
+| Input | A value supplied when the drawer is pressed. |
+| Output | JSON produced by a step and made available to later steps. |
+| Ref | A `${...}` expression that reads inputs, step outputs, env, or webhook URLs. |
+
+Drawers live under `.buttons/drawers/<name>/` and record their own run history under `pressed/`.
+
+## How drawers relate to buttons
+
+Buttons are the units of work. Drawers compose them.
+
+```text
+button -> one action
+drawer -> many actions wired together
+```
+
+## Related
+
+- [Workflow guide](/buttons/workflows)
+- [drawer.json](/concepts/drawer-json)
+- [Buttons](/concepts/buttons)
+- [Triggers](/concepts/triggers)

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -1,14 +1,19 @@
 ---
-title: "Button folder structure"
-description: "How buttons are stored on disk under ~/.buttons/."
+title: "Folder structure"
+description: "How Buttons stores buttons, drawers, history, secrets, and runtime state."
 ---
 
-Buttons stores all its data under `~/.buttons/`. Each button gets its own subdirectory with a spec file, an optional code file, optional agent context, and a run history folder.
+Buttons stores data under `~/.buttons/` by default. In a project initialized with `buttons init`, the active data directory is the closest `.buttons/` folder in the current directory tree.
+
+Each button gets its own subdirectory with a spec file, optional code file, agent context, and run history. Drawers get the same pattern for workflow specs and workflow history.
 
 ## Directory layout
 
 ```
-~/.buttons/
+~/.buttons/ or .buttons/
+├── buttons.json              # project manifest; desired buttons and version policy
+├── buttons-lock.json         # resolved exact versions, hashes, and sources
+├── history.json              # local create/edit/install/update history; gitignored
 ├── buttons/
 │   ├── deploy/
 │   │   ├── button.json       # button spec
@@ -26,17 +31,21 @@ Buttons stores all its data under `~/.buttons/`. Each button gets its own subdir
 │       └── pressed/
 ├── drawers/
 │   └── release-flow/
-│       └── drawer.json
-└── state.db                  # SQLite run history (WAL mode)
+│       ├── drawer.json
+│       └── pressed/
+├── batteries.json            # secret/env values; gitignored for project-local dirs
+├── webhook.json              # Cloudflare tunnel config; gitignored for project-local dirs
+├── idempotency/              # cached successful press results
+└── queues/                   # file-lock semaphore state
 ```
 
 ## button.json
 
-The spec file for a button. It describes the button type, arguments, runtime, and all other configuration. Every spec includes `"schema_version": 1`.
+The spec file for a button. It describes the button type, arguments, runtime, and all other configuration. Newly created specs use `"schema_version": 2`.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "deploy",
   "description": "Deploy a tagged release to an environment",
   "runtime": "shell",
@@ -47,6 +56,39 @@ The spec file for a button. It describes the button type, arguments, runtime, an
   "created_at": "2026-04-10T11:00:00Z"
 }
 ```
+
+See [button.json](/concepts/button-json) for every field, including HTTP host locks, queues, output schemas, package metadata, and required batteries.
+
+## drawer.json
+
+The workflow spec for a drawer. It stores inputs, steps, refs, triggers, return values, and error handling.
+
+```json
+{
+  "schema_version": 1,
+  "name": "release-flow",
+  "steps": [
+    { "id": "build", "kind": "button", "button": "build" },
+    { "id": "publish", "kind": "button", "button": "publish" }
+  ]
+}
+```
+
+See [drawer.json](/concepts/drawer-json) for the full workflow schema.
+
+## buttons.json and buttons-lock.json
+
+`buttons.json` at the root of `.buttons/` declares the desired project buttons and version policy.
+
+`buttons-lock.json` records the exact resolved versions, sources, and content hashes. Commit it with `buttons.json` so teammates can recreate the same installed buttons.
+
+## history.json
+
+`history.json` records local create, edit, install, update, delete, rollback, and failed resolution events. Commands write explicit events; file hooks can record manual edits to tracked button and drawer files.
+
+In a team repo, commit `buttons.json`, `buttons-lock.json`, and authored button/drawer files. Do not commit `history.json`; it is a local runtime artifact.
+
+When installed buttons are generated entirely from a registry, the repo can recreate them from the manifest and lock file. When a button is authored directly in the project, commit its folder under `buttons/`.
 
 ## main.\*
 
@@ -72,9 +114,23 @@ One JSON file per run, named by timestamp. Each file records the input arguments
 }
 ```
 
-## state.db
+## batteries.json
 
-A SQLite database (WAL mode, `busy_timeout=5000`) that mirrors the run history for indexed queries. `buttons history` reads from this file. The JSON files in `pressed/` are the authoritative record; `state.db` is the query index.
+Batteries are key/value pairs injected into button presses as `BUTTONS_BAT_<KEY>`.
+
+Project-local batteries live at `.buttons/batteries.json`. Global batteries live at `~/.buttons/batteries.json`. Local values override global values on key collision.
+
+## webhook.json
+
+Named webhook setup stores Cloudflare tunnel configuration in `webhook.json`. It is machine-specific and should not be committed.
+
+## idempotency/
+
+Successful presses with `--idempotency-key` are cached here until their TTL expires.
+
+## queues/
+
+Buttons with a `queue` declaration use file locks here to enforce concurrency limits.
 
 ## Overriding the home directory
 
@@ -92,6 +148,8 @@ The `~/.buttons/` directory and all files inside it are created with mode `0700`
 
 ## Related
 
-- [Button folder structure](/concepts/folder-structure) — this page
+- [button.json](/concepts/button-json) — button spec fields
+- [drawer.json](/concepts/drawer-json) — workflow spec fields
+- [History](/concepts/history) — local audit history
 - [JSON output](/concepts/json-output) — the shape of history records
-- [File buttons](/buttons/file) — how `main.*` is populated from an imported script
+- [Code buttons](/buttons/code) — how `main.*` is populated from scaffolded or imported scripts

--- a/docs/concepts/history.mdx
+++ b/docs/concepts/history.mdx
@@ -1,0 +1,106 @@
+---
+title: "History"
+description: "Local audit history for button creates, edits, installs, updates, and rollbacks."
+---
+
+`history.json` is the local audit log for a Buttons workspace.
+
+It records two kinds of changes:
+
+- command-driven changes, like `buttons create`, `buttons install`, `buttons update`, `buttons delete`, and rollback
+- file-hook changes, like editing `button.json`, `main.sh`, `AGENT.md`, `drawer.json`, `buttons.json`, or `buttons-lock.json` directly
+
+```text
+.buttons/
+  buttons.json
+  buttons-lock.json
+  history.json
+  buttons/
+  drawers/
+```
+
+## Event shape
+
+```json
+{
+  "schema_version": 1,
+  "events": [
+    {
+      "at": "2026-06-28T18:42:10Z",
+      "action": "install",
+      "target": "button:slack-sync",
+      "source": "git+https://github.com/autonoco/autono-buttons@main",
+      "from_version": null,
+      "to_version": "1.2.4",
+      "from_hash": null,
+      "to_hash": "sha256:4f8c...",
+      "status": "ok"
+    }
+  ]
+}
+```
+
+## Actions
+
+History should record:
+
+| Action | Cause |
+| --- | --- |
+| `create` | A button or drawer is created. |
+| `edit` | A tracked button, drawer, manifest, or lock file changes. |
+| `delete` | A button or drawer is removed. |
+| `install` | A registry or source installs a button. |
+| `update` | An installed button resolves to a newer version/hash. |
+| `rollback` | A button is restored to an earlier locked version. |
+| `resolve_failed` | Registry/source resolution fails. |
+
+## File-hook tracking
+
+Commands should write explicit history events when they mutate state. File hooks should catch manual edits and agent edits that happen outside a Buttons command.
+
+The watcher should track:
+
+```text
+.buttons/buttons.json
+.buttons/buttons-lock.json
+.buttons/buttons/*/button.json
+.buttons/buttons/*/main.*
+.buttons/buttons/*/AGENT.md
+.buttons/drawers/*/drawer.json
+```
+
+The watcher should ignore runtime and secret-bearing files:
+
+```text
+.buttons/history.json
+.buttons/buttons/*/pressed/**
+.buttons/drawers/*/pressed/**
+.buttons/batteries.json
+.buttons/webhook.json
+.buttons/idempotency/**
+.buttons/queues/**
+```
+
+For each file-hook event, Buttons can compute a before/after content hash and append one debounced `edit` event.
+
+## Commit policy
+
+Commit:
+
+- `.buttons/buttons.json`
+- `.buttons/buttons-lock.json`
+- authored button and drawer files
+
+Do not commit:
+
+- `.buttons/history.json`
+- pressed run history
+- batteries or webhook config
+
+The lock file gives the team shared reproducibility. `history.json` gives each machine local auditability.
+
+## Related
+
+- [Registry](/concepts/registry)
+- [Hook triggers](/buttons/hook)
+- [Folder structure](/concepts/folder-structure)

--- a/docs/concepts/registry.mdx
+++ b/docs/concepts/registry.mdx
@@ -1,0 +1,141 @@
+---
+title: "Registry"
+description: "How Buttons resolves, installs, locks, and updates shared buttons."
+---
+
+A registry is a catalog of installable buttons. It answers: "What buttons are available, what versions exist, what tags do they belong to, and what content hash should I install?"
+
+The registry does not contain runnable local buttons. Runnable buttons live in `.buttons/buttons/`. Desired dependencies live in `.buttons/buttons.json`; exact resolved versions live in `.buttons/buttons-lock.json`.
+
+```text
+.buttons/
+  buttons.json
+  buttons-lock.json
+  history.json
+  buttons/
+    slack-sync/
+      button.json
+      main.sh
+      AGENT.md
+```
+
+## buttons.json
+
+`buttons.json` is the project manifest. It lives at the root of `.buttons/` and is committed with the repo.
+
+It declares trusted registries and desired buttons:
+
+```json
+{
+  "schema_version": 1,
+  "default_registry": "autono",
+  "registries": {
+    "autono": {
+      "type": "git",
+      "url": "https://github.com/autonoco/autono-buttons",
+      "ref": "main"
+    }
+  },
+  "dependencies": {
+    "imessage-sync": "latest",
+    "slack-sync": {
+      "version": "^1.2.0",
+      "auto_update": true
+    },
+    "plaid-sync": {
+      "version": "1.4.2",
+      "auto_update": false
+    }
+  }
+}
+```
+
+The simple string form is enough for most buttons. The object form keeps room for per-button options like `auto_update`, channels, constraints, or rollout policy.
+
+## buttons-lock.json
+
+`buttons-lock.json` is the resolved lock file. It lives next to `buttons.json` and should be committed with the repo.
+
+```json
+{
+  "schema_version": 1,
+  "buttons": {
+    "slack-sync": {
+      "registry": "autono",
+      "source": "git+https://github.com/autonoco/autono-buttons@main",
+      "requested": "^1.2.0",
+      "version": "1.2.4",
+      "content_hash": "sha256:4f8c...",
+      "resolved_at": "2026-06-28T18:42:10Z"
+    }
+  }
+}
+```
+
+`buttons.json` is the desired state. `buttons-lock.json` is the exact resolved state.
+
+```text
+buttons.json          semver ranges, latest, registry config, auto_update policy
+buttons-lock.json     exact versions, hashes, resolved sources
+```
+
+This follows the same shape as package manifests and lock files: ranges are human-authored, exact versions are machine-resolved and committed for repeatability.
+
+## history.json
+
+`history.json` is local and should not be committed. It records what happened on one machine over time: creates, edits, installs, updates, rollbacks, deletes, and failed registry fetches.
+
+See [History](/concepts/history) for the event model.
+
+## Install Flow
+
+When registry-backed install runs, Buttons should:
+
+1. Read `.buttons/buttons.json` for registries, desired buttons, and version policy.
+2. Resolve the requested button, version, or tag from the configured registry.
+3. Fetch the button bundle, including `button.json`, `main.*`, `AGENT.md`, and support files.
+4. Install the runnable copy into `.buttons/buttons/<name>/`.
+5. Install required peer buttons from `requires`.
+6. Stamp `source`, `version`, and `content_hash` into the installed `button.json`.
+7. Update `.buttons/buttons-lock.json` with exact resolved versions and hashes.
+8. Append an event to `.buttons/history.json`.
+
+## Resolution
+
+Install requests can target a button, a pinned version, or a tag:
+
+```bash
+buttons install slack-sync
+buttons install slack-sync@1.2.0
+buttons install tag:autono-cal
+```
+
+The intended source resolution order is:
+
+1. `--source`, for explicit one-off local installs.
+2. `BUTTONS_SOURCE`, for a local default source.
+3. `.buttons/buttons.json`, for the project team contract.
+
+## Source Layout
+
+A local registry source is a directory of button folders:
+
+```text
+button-source/
+  slack-sync/
+    button.json
+    main.sh
+    AGENT.md
+  calendar-sync/
+    button.json
+    main.sh
+    AGENT.md
+```
+
+Each button folder must include `button.json`. Support files are copied into the installed button.
+
+## Related
+
+- [History](/concepts/history)
+- [button.json](/concepts/button-json)
+- [buttons install](/cli/buttons_install)

--- a/docs/concepts/triggers.mdx
+++ b/docs/concepts/triggers.mdx
@@ -1,0 +1,42 @@
+---
+title: "Triggers"
+description: "Automatic ways to run buttons and drawers."
+---
+
+A trigger runs a button or drawer when something happens.
+
+Triggers let Buttons move from manual commands to durable automation: webhooks for remote events, cron for schedules, and hooks for local events.
+
+```bash
+buttons trigger webhook linkedin-sync /linkedin-sync
+buttons trigger cron slack-sync "0 */2 * * *"
+buttons trigger hook docs-sync --enable "file:docs/**/*.md"
+```
+
+## Trigger kinds
+
+| Kind | Cause | Example |
+| --- | --- | --- |
+| Webhook | A remote service sends an HTTP request. | GitHub, Stripe, Linear |
+| Cron | A schedule fires. | nightly sync, hourly digest |
+| Hook | A local event fires. | file changed, Git commit, button completed |
+
+## Target model
+
+A trigger targets a button or drawer. If it targets a button, Buttons can wrap it as a one-step drawer internally so the workflow runtime stays consistent.
+
+```text
+event -> trigger -> drawer -> button steps
+```
+
+## Current status
+
+Webhook-triggered drawers are implemented today. The unified `buttons trigger ...` command is the intended surface for webhook, cron, and hook triggers.
+
+## Related
+
+- [Trigger guide](/buttons/triggers)
+- [Webhook](/buttons/webhook)
+- [Cron](/buttons/cron)
+- [Hook](/buttons/hook)
+- [Drawers](/concepts/drawers)

--- a/docs/deployment/rest-api.mdx
+++ b/docs/deployment/rest-api.mdx
@@ -1,0 +1,91 @@
+---
+title: "REST API server"
+description: "Expose local buttons over HTTP with buttons serve."
+---
+
+`buttons serve` runs a local HTTP API that exposes the same press path as the CLI.
+
+```bash
+buttons serve
+```
+
+By default it binds to `127.0.0.1:8080`.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/api/health` | No | Liveness check. |
+| `GET` | `/api/buttons` | Yes | List buttons. |
+| `GET` | `/api/buttons/{name}` | Yes | Read a button spec. |
+| `POST` | `/api/buttons/{name}/press` | Yes | Press a button. |
+| `GET` | `/api/buttons/{name}/runs` | Yes | Recent run history. |
+
+## Press a button
+
+```bash
+curl -sS http://127.0.0.1:8080/api/buttons/weather/press \
+  -H "Content-Type: application/json" \
+  -d '{"args":{"city":"Miami"},"timeout":30}'
+```
+
+The response uses the same envelope as CLI JSON output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "button": "weather",
+    "status": "ok"
+  }
+}
+```
+
+## Auth
+
+Every endpoint except `/api/health` requires a bearer token when an API key is configured.
+
+The key comes from the first available source:
+
+1. `--api-key`
+2. `API_KEY` battery
+3. `BUTTONS_API_KEY` environment variable
+
+```bash
+export BUTTONS_API_KEY="$(openssl rand -hex 16)"
+buttons batteries set API_KEY "$BUTTONS_API_KEY" --global
+buttons serve
+```
+
+Call with:
+
+```bash
+curl -H "Authorization: Bearer $BUTTONS_API_KEY" \
+  http://127.0.0.1:8080/api/buttons
+```
+
+## Binding rules
+
+Without an API key, `buttons serve` only allows loopback binding. Binding `0.0.0.0` without auth is refused.
+
+```bash
+buttons serve --host 0.0.0.0 --api-key "$(openssl rand -hex 16)"
+```
+
+## HTTP buttons are gated
+
+Pressing HTTP buttons through the REST API is disabled by default because an exposed API can otherwise trigger outbound requests.
+
+Enable it explicitly:
+
+```bash
+buttons serve --allow-http-buttons
+```
+
+Code and prompt buttons are pressable without this flag.
+
+## Related
+
+- [buttons serve](/cli/buttons_serve)
+- [JSON output](/concepts/json-output)
+- [Batteries](/cli/buttons_batteries)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -23,7 +23,18 @@
             ]
           },
           {
-            "group": "Button types",
+            "group": "Core Concepts",
+            "public": true,
+            "pages": [
+              "concepts/buttons",
+              "concepts/drawers",
+              "concepts/registry",
+              "concepts/triggers",
+              "concepts/history"
+            ]
+          },
+          {
+            "group": "Button Guides",
             "public": true,
             "pages": [
               "buttons/code",
@@ -31,19 +42,36 @@
               "buttons/prompt",
               "buttons/cli",
               "buttons/sql",
-              "buttons/webhook",
-              "buttons/cron",
               "buttons/mcp"
             ]
           },
           {
-            "group": "Concepts",
+            "group": "Workflow Guides",
+            "public": true,
+            "pages": [
+              "buttons/workflows"
+            ]
+          },
+          {
+            "group": "Trigger Guides",
+            "public": true,
+            "pages": [
+              "buttons/triggers",
+              "buttons/webhook",
+              "buttons/cron",
+              "buttons/hook"
+            ]
+          },
+          {
+            "group": "Reference",
             "public": true,
             "pages": [
               "concepts/arguments",
               "concepts/json-output",
               "concepts/templates",
-              "concepts/folder-structure"
+              "concepts/folder-structure",
+              "concepts/button-json",
+              "concepts/drawer-json"
             ]
           },
           {
@@ -51,7 +79,8 @@
             "public": true,
             "pages": [
               "deployment/docker",
-              "deployment/install-script"
+              "deployment/install-script",
+              "deployment/rest-api"
             ]
           },
           {
@@ -103,13 +132,24 @@
               "cli/buttons_create",
               "cli/buttons_press",
               "cli/buttons_list",
+              "cli/buttons_logs",
               "cli/buttons_history",
-              "cli/buttons_delete",
-              "cli/buttons_update",
-              "cli/buttons_version",
               "cli/buttons_summary",
               "cli/buttons_tail",
-              "cli/buttons_ignore"
+              "cli/buttons_delete",
+              "cli/buttons_update",
+              "cli/buttons_version"
+            ]
+          },
+          {
+            "group": "Project commands",
+            "public": true,
+            "expanded": false,
+            "pages": [
+              "cli/buttons_init",
+              "cli/buttons_install",
+              "cli/buttons_ignore",
+              "cli/buttons_unignore"
             ]
           },
           {
@@ -169,8 +209,12 @@
             "public": true,
             "expanded": false,
             "pages": [
+              "cli/buttons_config",
+              "cli/buttons_config_set",
+              "cli/buttons_config_unset",
               "cli/buttons_batteries",
               "cli/buttons_batteries_set",
+              "cli/buttons_batteries_get",
               "cli/buttons_batteries_list",
               "cli/buttons_batteries_rm"
             ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -18,7 +18,24 @@ Each button wraps a single action: a shell script, an HTTP API call, a Python/No
   </Card>
 </Columns>
 
-## Button types
+## Core Concepts
+
+<Columns cols={2}>
+  <Card title="Buttons" icon="square" href="/concepts/buttons">
+    The core unit of reusable work.
+  </Card>
+  <Card title="Drawers" icon="workflow" href="/concepts/drawers">
+    Typed workflows that compose buttons.
+  </Card>
+  <Card title="Registry" icon="boxes" href="/concepts/registry">
+    Resolve, install, lock, and update shared buttons.
+  </Card>
+  <Card title="History" icon="history" href="/concepts/history">
+    Local audit history for creates, edits, installs, and updates.
+  </Card>
+</Columns>
+
+## Button guides
 
 <Columns cols={2}>
   <Card title="Code" icon="code" href="/buttons/code">
@@ -27,11 +44,43 @@ Each button wraps a single action: a shell script, an HTTP API call, a Python/No
   <Card title="HTTP API" icon="globe" href="/buttons/http-api">
     GET/POST with URL templates and typed args.
   </Card>
-  <Card title="File" icon="file" href="/buttons/file">
+  <Card title="File import" icon="file" href="/buttons/code">
     Import an existing script file.
   </Card>
-  <Card title="Agent" icon="robot" href="/buttons/agent">
+  <Card title="Prompt" icon="robot" href="/buttons/prompt">
     Attach an instruction for the consuming agent.
+  </Card>
+</Columns>
+
+## Workflows
+
+Drawers chain buttons into typed workflows with refs, loops, sub-drawers, waits, and run history.
+
+<Card title="Workflows" icon="workflow" href="/buttons/workflows" horizontal>
+  Build multi-step automations from reusable buttons.
+</Card>
+
+## Triggers
+
+Triggers are the planned unified surface for running buttons and drawers from external or local events.
+
+<Columns cols={2}>
+  <Card title="Trigger concept" icon="zap" href="/concepts/triggers">
+    Automatic ways to run buttons and drawers.
+  </Card>
+  <Card title="Trigger guide" icon="list-checks" href="/buttons/triggers">
+    Commands and management model.
+  </Card>
+  <Card title="Hook" icon="git-branch" href="/buttons/hook">
+    Local file, Git, and Buttons-runtime events.
+  </Card>
+</Columns>
+
+## Operations
+
+<Columns cols={2}>
+  <Card title="REST API server" icon="server" href="/deployment/rest-api">
+    Expose local buttons over HTTP with the same press contract.
   </Card>
 </Columns>
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install Buttons via curl, Docker, Go, or Homebrew."
+description: "Install Buttons via curl, Docker, Go, Homebrew, or npm."
 icon: "download"
 ---
 
@@ -75,6 +75,19 @@ brew install autonoco/tap/buttons
 
 The tap auto-publishes on every release, so `brew upgrade buttons` always gets you the newest version. Supports macOS and Linux on both Intel and Apple Silicon.
 
+## npm / pnpm / bun
+
+```bash
+npm install -g @autono/buttons
+```
+
+The npm package is a thin JavaScript shim that resolves the right prebuilt binary for your platform through optional dependencies.
+
+```bash
+pnpm add -g @autono/buttons
+bun add -g @autono/buttons
+```
+
 ## Verify
 
 ```bash
@@ -102,6 +115,7 @@ You can also update through your original install channel:
 | Docker | `docker pull ghcr.io/autonoco/buttons:latest` |
 | Go | `go install github.com/autonoco/buttons@latest` |
 | Homebrew | `brew upgrade buttons` |
+| npm | `npm update -g @autono/buttons` |
 
 <Note>
 If you installed via Homebrew, `buttons update` detects this and asks you to use `brew upgrade` instead.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quick start"
-description: "Create and press your first button in 30 seconds."
+description: "Initialize a project, create a button, and press it."
 icon: "rocket"
 ---
 
@@ -13,6 +13,20 @@ curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh | 
 ```
 
 Or see [installation](/installation) for Docker, Go, and other options.
+
+</Step>
+
+<Step title="Initialize a project">
+
+Create a project-local `.buttons/` directory so the button belongs to this workspace instead of your global `~/.buttons/` folder:
+
+```bash
+mkdir buttons-demo
+cd buttons-demo
+buttons init --agent agents-md
+```
+
+`buttons init` also writes `.buttons/AGENT.md` and adds a Buttons section to `AGENTS.md` so coding agents know to discover and press existing buttons before writing one-off commands.
 
 </Step>
 
@@ -80,6 +94,9 @@ Every press is recorded as a JSON file in the button's `pressed/` folder.
   </Card>
   <Card title="Prompt buttons" icon="robot" href="/buttons/prompt">
     Attach instructions for the consuming agent.
+  </Card>
+  <Card title="Workflows" icon="workflow" href="/buttons/workflows">
+    Chain buttons into drawers.
   </Card>
   <Card title="Arguments" icon="list-check" href="/concepts/arguments">
     Typed args with validation.

--- a/docs/security/overview.mdx
+++ b/docs/security/overview.mdx
@@ -18,7 +18,7 @@ The security controls in Buttons are aimed at preventing unintended execution or
 | Path traversal via argument values | `PathEscape` applied to URL path segments — see [template encoding](/security/template-encoding) |
 | Command injection via argument values | Args injected as env vars (`BUTTONS_ARG_<NAME>`), never interpolated into the shell body |
 | SSRF via HTTP buttons targeting internal services | Private network blocking by default — see [SSRF protection](/security/ssrf-protection) |
-| Credential leakage via run history | `pressed/*.json` and `state.db` created with mode `0600` |
+| Credential leakage via run history | `pressed/*.json` created with mode `0600`; project-local secret-bearing files are gitignored |
 | Unauthorized reads of button specs | `~/.buttons/` created with mode `0700` |
 | Query/JSON injection via argument values | Context-aware encoding in URL and body templates |
 

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -9,12 +9,12 @@ type Button struct {
 	SchemaVersion int    `json:"schema_version"`
 	Name          string `json:"name"`
 	Description   string `json:"description,omitempty"`
-	// Tags group/categorize a button for discovery and pack filtering
+	// Tags group/categorize a button for discovery and install-source filtering
 	// (e.g. "finance", "sync"). Omitted when empty so existing buttons
 	// don't grow a noisy field.
 	Tags []string `json:"tags,omitempty"`
 	// Version is the button's content release (semver), distinct from
-	// SchemaVersion (the on-disk format counter). Set by pack/store
+	// SchemaVersion (the on-disk format counter). Set by install tooling
 	// tooling so an installed copy can be pinned and diffed for updates.
 	// Empty for hand-authored local buttons (treated as "unversioned").
 	Version              string            `json:"version,omitempty"`
@@ -67,11 +67,11 @@ type Button struct {
 	// than by cwd. Omitted when empty.
 	Requires []string `json:"requires,omitempty"`
 	// RequiresBatteries names the secret keys this button needs (e.g.
-	// "PIPEDREAM_CLIENT_ID"). A pack ships requirement NAMES, never
+	// "PIPEDREAM_CLIENT_ID"). An install source ships requirement NAMES, never
 	// values; `store install` prompts for them via `buttons batteries`.
 	RequiresBatteries []string `json:"requires_batteries,omitempty"`
 	// Source records where an installed button came from (the store
-	// source ref, e.g. "git+https://github.com/autonoco/autono-packs@v1").
+	// source ref, e.g. "git+https://github.com/autonoco/autono-desk@v1").
 	// Empty for locally-created buttons.
 	Source string `json:"source,omitempty"`
 	// ContentHash is the SHA256 of the button's content at install time —

--- a/internal/tools/docgen/main.go
+++ b/internal/tools/docgen/main.go
@@ -88,9 +88,10 @@ func main() {
 	}
 
 	// Post-process markdown files for MDX compatibility. Cobra's doc
-	// generator outputs Examples as indented text (not fenced code blocks)
-	// and uses <WORD> patterns in prose. MDX parses {{ as JSX expressions
-	// and <WORD> as HTML tags, both of which break the build.
+	// generator outputs Examples and literal synopsis blocks as indented
+	// text (not fenced code blocks) and uses <placeholder> patterns in
+	// prose. MDX parses {{ as JSX expressions and <placeholder> as HTML
+	// tags, both of which break the build.
 	if *format == "markdown" {
 		if err := postProcessMDX(*out); err != nil {
 			log.Fatalf("post-process failed: %v", err)
@@ -100,9 +101,9 @@ func main() {
 	fmt.Printf("docs generated in %s (%s format)\n", *out, *format)
 }
 
-// angleBracketPattern matches <ALLCAPS> patterns in prose that MDX would
-// interpret as unclosed HTML tags (e.g. BUTTONS_ARG_<NAME>).
-var angleBracketPattern = regexp.MustCompile(`<([A-Z][A-Z0-9_]*)>`)
+// angleBracketPattern matches <placeholder> patterns in prose that MDX would
+// interpret as unclosed HTML tags (e.g. <name>, <value>, BUTTONS_ARG_<NAME>).
+var angleBracketPattern = regexp.MustCompile(`<([A-Za-z][A-Za-z0-9_-]*)>`)
 
 // postProcessMDX walks every .md file in dir and fixes two MDX-incompatible
 // patterns that Cobra's doc generator produces:
@@ -110,7 +111,9 @@ var angleBracketPattern = regexp.MustCompile(`<([A-Z][A-Z0-9_]*)>`)
 //  1. Examples blocks: indented text containing {{arg}} templates and JSON
 //     with curly braces. These get wrapped in fenced code blocks so MDX
 //     treats them as literal text.
-//  2. <ALLCAPS> patterns in prose (e.g. BUTTONS_ARG_<NAME>): these get
+//  2. Other indented synopsis/literal blocks: these get fenced too so
+//     route templates, JSON examples, and ${...} refs stay literal.
+//  3. <placeholder> patterns in prose (e.g. BUTTONS_ARG_<NAME>): these get
 //     wrapped in backtick inline code so MDX doesn't parse them as tags.
 func postProcessMDX(dir string) error {
 	entries, err := os.ReadDir(dir)
@@ -131,6 +134,7 @@ func postProcessMDX(dir string) error {
 
 		content := string(data)
 		content = fenceExamples(content)
+		content = fenceIndentedBlocks(content)
 		content = escapeAngleBrackets(content)
 
 		// #nosec G306 -- generated docs must be world-readable.
@@ -177,7 +181,53 @@ func fenceExamples(content string) string {
 	return strings.Join(result, "\n")
 }
 
-// escapeAngleBrackets finds <ALLCAPS> patterns in lines that are NOT inside
+// fenceIndentedBlocks wraps non-example literal blocks emitted by Cobra as
+// 2-space-indented text. MDX otherwise tries to parse route placeholders
+// (/api/buttons/{name}), JSON snippets, and ${...} examples as JSX.
+func fenceIndentedBlocks(content string) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	inFence := false
+	inIndentedBlock := false
+
+	closeBlock := func() {
+		if inIndentedBlock {
+			result = append(result, "```")
+			inIndentedBlock = false
+		}
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "```") {
+			closeBlock()
+			inFence = !inFence
+			result = append(result, line)
+			continue
+		}
+		if inFence {
+			result = append(result, line)
+			continue
+		}
+
+		indented := strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t")
+		if indented {
+			if !inIndentedBlock {
+				result = append(result, "")
+				result = append(result, "```text")
+				inIndentedBlock = true
+			}
+			result = append(result, line)
+			continue
+		}
+
+		closeBlock()
+		result = append(result, line)
+	}
+	closeBlock()
+	return strings.Join(result, "\n")
+}
+
+// escapeAngleBrackets finds <placeholder> patterns in lines that are NOT inside
 // fenced code blocks and wraps the surrounding token in backtick inline code.
 // For example: BUTTONS_ARG_<NAME> → `BUTTONS_ARG_<NAME>`
 func escapeAngleBrackets(content string) string {
@@ -195,15 +245,49 @@ func escapeAngleBrackets(content string) string {
 			result = append(result, line)
 			continue
 		}
-		// Outside a code fence: escape <ALLCAPS> by wrapping the
-		// surrounding word in backticks. Only match if NOT already
-		// inside backticks.
-		if angleBracketPattern.MatchString(line) && !strings.Contains(line, "`") {
-			line = angleBracketPattern.ReplaceAllStringFunc(line, func(match string) string {
-				return "`" + match + "`"
-			})
+		// Outside a code fence: escape <placeholder> by wrapping it in
+		// backticks, but leave placeholders already inside inline code
+		// alone.
+		if angleBracketPattern.MatchString(line) {
+			line = replaceAnglePlaceholdersOutsideInlineCode(line)
 		}
 		result = append(result, line)
 	}
 	return strings.Join(result, "\n")
+}
+
+func replaceAnglePlaceholdersOutsideInlineCode(line string) string {
+	matches := angleBracketPattern.FindAllStringIndex(line, -1)
+	if len(matches) == 0 {
+		return line
+	}
+
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if insideInlineCode(line, start) {
+			continue
+		}
+		b.WriteString(line[last:start])
+		b.WriteByte('`')
+		b.WriteString(line[start:end])
+		b.WriteByte('`')
+		last = end
+	}
+	if last == 0 {
+		return line
+	}
+	b.WriteString(line[last:])
+	return b.String()
+}
+
+func insideInlineCode(line string, idx int) bool {
+	count := 0
+	for i := 0; i < idx && i < len(line); i++ {
+		if line[i] == '`' {
+			count++
+		}
+	}
+	return count%2 == 1
 }


### PR DESCRIPTION
## Summary

- Reorganizes the docs sidebar around Core Concepts, guides, reference, deployment, and security.
- Adds concept docs for Buttons, Drawers, Registry, Triggers, and History.
- Documents the registry install model with `.buttons/buttons.json`, `.buttons/buttons-lock.json`, and local `.buttons/history.json`.
- Adds workflow, trigger, hook, REST API, button.json, and drawer.json docs, plus regenerated CLI reference docs.
- Updates `buttons init` gitignore behavior so `history.json` stays local.

## Validation

- `git diff --cached --check`
- `python3 -m json.tool docs/docs.json >/dev/null`
- `go test ./...`
- Local docs smoke checks returned `200` for `/concepts/buttons`, `/concepts/drawers`, `/concepts/registry`, `/concepts/triggers`, `/concepts/history`, `/buttons/workflows`, `/buttons/hook`, and `/deployment/rest-api`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for workflows, triggers, registry installs, history, and the REST API server.
  * Expanded the quickstart and installation guides with project initialization and npm-based install options.
  * Clarified support for more agent integrations during setup.

* **Documentation**
  * Updated command references and examples across the docs for buttons, drawers, webhook triggers, cron triggers, and install/serve commands.
  * Improved navigation and structure in the documentation home and sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->