### PR TITLE
feat(store): HTTPSource — install from the hosted registry (#275 client)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -26,30 +26,26 @@ Each installed button's dependencies (its button.json "requires") are
 installed too. Source + version + content hash are recorded in each
 installed button.json for pinning and updates.
 
-The registry source (buttons.co, #275) is not built yet; for now pass a
-local source directory with --source (or $BUTTONS_SOURCE).
+Source resolution, in order: --source <dir> / $BUTTONS_SOURCE (a local source),
+else $BUTTONS_REGISTRY_URL (the hosted registry, bearer-authed with the
+REGISTRY_KEY battery or $BUTTONS_BAT_REGISTRY_KEY).
 
 Examples:
+  BUTTONS_REGISTRY_URL=https://desk.buttons.sh buttons install @autono/hello
   buttons install deploy --source ../button-source
-  buttons install tag:autono-cal --source ../button-source
   buttons install deploy@1.2.0 --source ../button-source`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		srcDir := installSource
-		if srcDir == "" {
-			srcDir = os.Getenv("BUTTONS_SOURCE")
-		}
-		if srcDir == "" {
-			msg := "no source: pass --source <dir> or set $BUTTONS_SOURCE (the registry source lands in #275)"
+		src, sourceRef, err := resolveInstallSource()
+		if err != nil {
 			if jsonOutput {
-				_ = config.WriteJSONError("VALIDATION_ERROR", msg)
+				_ = config.WriteJSONError("VALIDATION_ERROR", err.Error())
 				return errSilent
 			}
-			return fmt.Errorf("%s", msg)
+			return err
 		}
 
-		src := &store.LocalSource{Root: srcDir}
-		res, err := store.InstallSpec(src, args[0], "local:"+srcDir)
+		res, err := store.InstallSpec(src, args[0], sourceRef)
 		if err != nil {
 			if jsonOutput {
 				_ = config.WriteJSONError("INSTALL_ERROR", err.Error())
@@ -67,7 +63,41 @@ Examples:
 	},
 }
 
+// resolveInstallSource picks the install source: an explicit --source / $BUTTONS_SOURCE
+// local directory wins; otherwise the hosted registry at $BUTTONS_REGISTRY_URL.
+func resolveInstallSource() (store.Source, string, error) {
+	dir := installSource
+	if dir == "" {
+		dir = os.Getenv("BUTTONS_SOURCE")
+	}
+	if dir != "" {
+		return &store.LocalSource{Root: dir}, "local:" + dir, nil
+	}
+	if reg := strings.TrimRight(os.Getenv("BUTTONS_REGISTRY_URL"), "/"); reg != "" {
+		key := registryKey()
+		if key == "" {
+			return nil, "", fmt.Errorf("registry key not set: run `buttons batteries set REGISTRY_KEY <key>` (or set $BUTTONS_BAT_REGISTRY_KEY)")
+		}
+		return &store.HTTPSource{BaseURL: reg, Key: key}, reg, nil
+	}
+	return nil, "", fmt.Errorf("no source: set $BUTTONS_REGISTRY_URL (+ REGISTRY_KEY battery) for the registry, or pass --source <dir> / $BUTTONS_SOURCE for a local source")
+}
+
+// registryKey resolves the registry bearer key — the BUTTONS_BAT_REGISTRY_KEY env
+// (injected during a press) wins, else the REGISTRY_KEY battery.
+func registryKey() string {
+	if k := os.Getenv("BUTTONS_BAT_REGISTRY_KEY"); k != "" {
+		return k
+	}
+	if svc, err := newBatteryService(); err == nil {
+		if v, _, err := svc.Get("REGISTRY_KEY"); err == nil {
+			return v
+		}
+	}
+	return ""
+}
+
 func init() {
-	installCmd.Flags().StringVar(&installSource, "source", "", "source directory to install from (until the registry lands, #275)")
+	installCmd.Flags().StringVar(&installSource, "source", "", "local source directory to install from (else $BUTTONS_REGISTRY_URL)")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/store/http_source.go
+++ b/internal/store/http_source.go
@@ -1,0 +1,233 @@
+package store
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// HTTPSource installs from the hosted registry (#275) — a Cloudflare Worker that
+// serves the index + content-pinned tarballs over bearer auth (desk.buttons.sh).
+// It satisfies Source, so the install/update path is identical to a LocalSource;
+// the only difference is the bytes come over HTTPS and are hash-verified on the way in.
+type HTTPSource struct {
+	BaseURL string       // e.g. https://desk.buttons.sh (trailing / trimmed)
+	Key     string       // bearer key (the REGISTRY_KEY battery / BUTTONS_BAT_REGISTRY_KEY)
+	Client  *http.Client // nil → a 30s-timeout default
+}
+
+// Caps on a fetched artifact — defend against a hostile or oversized registry.
+const (
+	maxArtifactBytes = 64 << 20  // 64 MiB compressed
+	maxBundleBytes   = 256 << 20 // 256 MiB uncompressed
+	maxBundleFiles   = 4096
+)
+
+func (s *HTTPSource) httpClient() *http.Client {
+	if s.Client != nil {
+		return s.Client
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func (s *HTTPSource) get(p string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(s.BaseURL, "/")+p, nil)
+	if err != nil {
+		return nil, err
+	}
+	if s.Key != "" {
+		req.Header.Set("Authorization", "Bearer "+s.Key)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := s.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("registry %s: %w", s.BaseURL, err)
+	}
+	return resp, nil
+}
+
+// registryError turns a non-200 into a useful message, parsing the
+// {"error":{"code","message"}} envelope the Worker returns.
+func registryError(what string, resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
+		return fmt.Errorf("registry %s: %d %s (%s)", what, resp.StatusCode, env.Error.Message, env.Error.Code)
+	}
+	return fmt.Errorf("registry %s: %d %s", what, resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+// indexEntry is one row of the Worker's /v1/index (a superset of ButtonRef).
+type indexEntry struct {
+	Name    string   `json:"name"`
+	Kind    string   `json:"kind"`
+	Version string   `json:"version"`
+	Tags    []string `json:"tags"`
+	SHA256  string   `json:"sha256"`
+}
+
+func (s *HTTPSource) index() ([]indexEntry, error) {
+	resp, err := s.get("/v1/index")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, registryError("index", resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var entries []indexEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("registry index: decode: %w", err)
+	}
+	return entries, nil
+}
+
+// Index returns the catalog (for search / dependency resolution).
+func (s *HTTPSource) Index() ([]ButtonRef, error) {
+	entries, err := s.index()
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]ButtonRef, 0, len(entries))
+	for _, e := range entries {
+		refs = append(refs, ButtonRef{Name: e.Name, Version: e.Version, Tags: e.Tags, SHA256: e.SHA256})
+	}
+	return refs, nil
+}
+
+// Fetch downloads a button tarball, verifies it against the registry's advertised
+// content hash, and extracts it into a Bundle. version "" resolves to latest.
+func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
+	// Resolve "" → latest. The Worker treats the last index entry for a name as
+	// latest; mirror that so install/update agree with the server.
+	wantHash := ""
+	if version == "" {
+		entries, err := s.index()
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.Name == name {
+				version, wantHash = e.Version, e.SHA256
+			}
+		}
+		if version == "" {
+			return nil, fmt.Errorf("button %q not found in registry", name)
+		}
+	}
+
+	p := fmt.Sprintf("/v1/buttons/%s/%s/download", url.PathEscape(name), url.PathEscape(version))
+	resp, err := s.get(p)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, registryError("download "+name+"@"+version, resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	tarball, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("button %q: download: %w", name, err)
+	}
+	if int64(len(tarball)) > maxArtifactBytes {
+		return nil, fmt.Errorf("button %q: artifact exceeds %d bytes", name, int64(maxArtifactBytes))
+	}
+
+	// Integrity: the bytes must match the registry's advertised tarball hash —
+	// from the x-content-sha256 header and/or the resolved index entry.
+	got := sha256hex(tarball)
+	want := resp.Header.Get("X-Content-Sha256")
+	if want == "" {
+		want = wantHash
+	}
+	if want != "" && got != want {
+		return nil, fmt.Errorf("button %q@%s: content hash mismatch (registry %s, got %s)", name, version, want, got)
+	}
+
+	files, err := untarGz(tarball)
+	if err != nil {
+		return nil, fmt.Errorf("button %q: %w", name, err)
+	}
+	if _, ok := files["button.json"]; !ok {
+		return nil, fmt.Errorf("button %q: bundle has no button.json", name)
+	}
+	// Bundle.SHA256 is the file-content hash (what install stamps as content_hash),
+	// consistent with LocalSource — distinct from the tarball hash verified above.
+	return &Bundle{Name: name, Version: version, SHA256: hashFiles(files), Files: files}, nil
+}
+
+func sha256hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// untarGz extracts a gzip'd tar into a flat map keyed by path relative to the
+// single top-level folder (publish.mjs wraps each button as <name>/...). Directory
+// and non-regular entries are skipped; absolute / traversal paths are rejected;
+// safeJoin at write time is the final backstop.
+func untarGz(data []byte) (map[string][]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gunzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	files := map[string][]byte{}
+	var total int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("untar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue // dirs, symlinks, etc.
+		}
+		clean := path.Clean(hdr.Name)
+		if clean == "." || clean == ".." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") {
+			return nil, fmt.Errorf("unsafe path in artifact: %q", hdr.Name)
+		}
+		i := strings.IndexByte(clean, '/')
+		if i < 0 {
+			continue // a bare top-level file (no wrapping button dir) — skip
+		}
+		rel := clean[i+1:]
+		if rel == "" || strings.HasPrefix(rel, "pressed/") {
+			continue // skip the wrapper itself and local run history
+		}
+		if base := path.Base(rel); strings.HasPrefix(base, "._") || base == ".DS_Store" {
+			continue // macOS AppleDouble / Finder junk — never part of a button
+		}
+		if len(files) >= maxBundleFiles {
+			return nil, fmt.Errorf("artifact has too many files (> %d)", maxBundleFiles)
+		}
+		buf, err := io.ReadAll(io.LimitReader(tr, maxBundleBytes-total+1))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", hdr.Name, err)
+		}
+		total += int64(len(buf))
+		if total > maxBundleBytes {
+			return nil, fmt.Errorf("artifact too large uncompressed (> %d bytes)", int64(maxBundleBytes))
+		}
+		files[rel] = buf
+	}
+	return files, nil
+}

--- a/internal/store/http_source_test.go
+++ b/internal/store/http_source_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// makeTarball builds a gz tarball wrapping files under <folder>/ — the layout
+// tools/publish.mjs produces (the on-disk button folder name is the wrapper).
+func makeTarball(t *testing.T, folder string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	// a directory entry, like tar -C src folder produces
+	if err := tw.WriteHeader(&tar.Header{Name: folder + "/", Mode: 0755, Typeflag: tar.TypeDir}); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if err := tw.WriteHeader(&tar.Header{Name: folder + "/" + name, Mode: 0644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func sha(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+// registryServer mocks the Worker: /v1/index + the bearer-gated download route,
+// setting x-content-sha256 to the tarball hash like the real Worker does.
+func registryServer(t *testing.T, key string, entries []indexEntry, tarballs map[string][]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+key {
+			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"valid Bearer key required"}}`, http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.URL.Path == "/v1/index":
+			_ = json.NewEncoder(w).Encode(entries)
+		case strings.HasPrefix(r.URL.Path, "/v1/buttons/") && strings.HasSuffix(r.URL.Path, "/download"):
+			mid := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/buttons/"), "/download")
+			i := strings.LastIndex(mid, "/") // split name / version on the last slash
+			name := mid[:i]
+			tb, ok := tarballs[name]
+			if !ok {
+				http.Error(w, `{"error":{"code":"NOT_FOUND","message":"no button"}}`, http.StatusNotFound)
+				return
+			}
+			w.Header().Set("X-Content-Sha256", sha(tb))
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(tb)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestHTTPSourceIndexAndFetch(t *testing.T) {
+	const key = "test-key"
+	files := map[string]string{
+		"button.json": `{"schema_version":2,"name":"hello","runtime":"shell","requires":["@autono/dep"]}`,
+		"main.sh":     "echo hi\n",
+		"AGENTS.md":   "# hello\n",
+	}
+	tb := makeTarball(t, "hello", files)
+	entries := []indexEntry{{Name: "@autono/hello", Kind: "button", Version: "0.1.0", SHA256: sha(tb)}}
+	srv := registryServer(t, key, entries, map[string][]byte{"@autono/hello": tb})
+	defer srv.Close()
+
+	src := &HTTPSource{BaseURL: srv.URL, Key: key}
+
+	refs, err := src.Index()
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if len(refs) != 1 || refs[0].Name != "@autono/hello" || refs[0].Version != "0.1.0" {
+		t.Fatalf("unexpected refs: %+v", refs)
+	}
+
+	// version "" → resolves latest from the index
+	b, err := src.Fetch("@autono/hello", "")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if b.Version != "0.1.0" {
+		t.Errorf("version = %q, want 0.1.0", b.Version)
+	}
+	if got := string(b.Files["main.sh"]); got != "echo hi\n" {
+		t.Errorf("main.sh = %q", got)
+	}
+	if _, ok := b.Files["button.json"]; !ok {
+		t.Error("bundle missing button.json")
+	}
+	// keys are flattened (the wrapping "hello/" stripped), so install writes them
+	// directly into the button dir.
+	for k := range b.Files {
+		if strings.Contains(k, "/") {
+			t.Errorf("file key not flattened: %q", k)
+		}
+	}
+	// Bundle.SHA256 is the file-content hash (stamped as content_hash), not the tarball hash.
+	if b.SHA256 != hashFiles(b.Files) {
+		t.Error("Bundle.SHA256 should equal hashFiles(Files)")
+	}
+	if b.SHA256 == sha(tb) {
+		t.Error("Bundle.SHA256 must differ from the tarball hash")
+	}
+}
+
+func TestHTTPSourceRejectsHashMismatch(t *testing.T) {
+	const key = "k"
+	tb := makeTarball(t, "x", map[string]string{"button.json": `{"name":"x"}`})
+	// Server streams the real tarball but advertises a WRONG x-content-sha256.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+key {
+			http.Error(w, "no", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("X-Content-Sha256", "00deadbeef")
+		_, _ = w.Write(tb)
+	}))
+	defer srv.Close()
+
+	src := &HTTPSource{BaseURL: srv.URL, Key: key}
+	_, err := src.Fetch("x", "1.0.0") // pinned version → goes straight to download
+	if err == nil || !strings.Contains(err.Error(), "content hash mismatch") {
+		t.Fatalf("expected content hash mismatch, got %v", err)
+	}
+}
+
+func TestHTTPSourceAuthFailure(t *testing.T) {
+	srv := registryServer(t, "right-key", nil, nil)
+	defer srv.Close()
+	src := &HTTPSource{BaseURL: srv.URL, Key: "wrong-key"}
+	if _, err := src.Index(); err == nil {
+		t.Fatal("expected auth failure with wrong key")
+	}
+}
+
+func TestHTTPSourceSkipsMacJunk(t *testing.T) {
+	const key = "k"
+	files := map[string]string{
+		"button.json":   `{"name":"hello"}`,
+		"main.sh":       "echo hi\n",
+		"._button.json": "appledouble-junk", // macOS `tar` xattr sidecar
+		".DS_Store":     "finder-junk",
+	}
+	tb := makeTarball(t, "hello", files)
+	entries := []indexEntry{{Name: "@autono/hello", Version: "0.1.0", SHA256: sha(tb)}}
+	srv := registryServer(t, key, entries, map[string][]byte{"@autono/hello": tb})
+	defer srv.Close()
+
+	b, err := (&HTTPSource{BaseURL: srv.URL, Key: key}).Fetch("@autono/hello", "0.1.0")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if _, ok := b.Files["._button.json"]; ok {
+		t.Error("._button.json (AppleDouble) should be skipped")
+	}
+	if _, ok := b.Files[".DS_Store"]; ok {
+		t.Error(".DS_Store should be skipped")
+	}
+	if _, ok := b.Files["button.json"]; !ok {
+		t.Error("button.json should be kept")
+	}
+	if len(b.Files) != 2 {
+		t.Errorf("expected 2 real files, got %d", len(b.Files))
+	}
+}


### PR DESCRIPTION
The missing registry client. `HTTPSource` satisfies the existing `Source` interface, so `buttons install` now works against the hosted Worker (desk.buttons.sh) — not just a local `--source`.

- `Index()` → `GET /v1/index`; `Fetch()` → `GET /v1/buttons/<@desk/name>/<ver>/download`, **verifies the tarball against `x-content-sha256`**, extracts into a `Bundle` (file-content hash stamped as `content_hash`, consistent with `LocalSource`).
- Hardened untar: size/file-count caps, traversal rejected, wrapping-folder flattened, macOS `._*`/`.DS_Store` junk skipped.
- `cmd/install.go`: `LocalSource` (`--source`/`$BUTTONS_SOURCE`) else `HTTPSource` (`$BUTTONS_REGISTRY_URL` + `REGISTRY_KEY` battery).

**Validated live:** `buttons install @autono/hello` against desk.buttons.sh → fetch → hash-verify → install → stamp. 4 new tests; full suite green (19 pkgs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Install now supports selecting button sources from either a local path or a hosted registry, with clearer resolution rules.
  * Hosted downloads now work over secure authenticated requests and can automatically use the latest available version.

* **Bug Fixes**
  * Improved error messages for invalid source setup and registry access issues.
  * Added integrity checks and safer extraction for downloaded bundles, reducing the risk of corrupted or unsafe files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->