### PR TITLE
feat(registry): publish buttons to the hosted registry (#276 client)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -31,7 +31,7 @@ else $BUTTONS_REGISTRY_URL (the hosted registry, bearer-authed with the
 REGISTRY_KEY battery or $BUTTONS_BAT_REGISTRY_KEY).
 
 Examples:
-  BUTTONS_REGISTRY_URL=https://desk.buttons.sh buttons install @autono/hello
+  BUTTONS_REGISTRY_URL=https://registry.example buttons install @your-desk/hello
   buttons install deploy --source ../button-source
   buttons install deploy@1.2.0 --source ../button-source`,
 	Args: exactArgs(1),

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -3,63 +3,119 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/store"
 	"github.com/spf13/cobra"
 )
 
-var publishSource string
+var (
+	publishSource string
+	publishKind   string
+)
 
 var publishCmd = &cobra.Command{
-	Use:   "publish <name>",
-	Short: "Publish a local button to a source so others can install it",
+	Use:   "publish <name | @desk/name>",
+	Short: "Publish a local button to the registry (or a local source)",
 	Long: `Publish a button — the inverse of 'buttons install'. The button folder
 (button.json + code + AGENTS.md, never its run history) is content-hashed and
-written to a source, where 'buttons install <name> --source <dir>' can fetch it.
+uploaded so others can 'buttons install' it.
 
-The registry source (buttons.co, #275/#276) is not built yet; for now publish
-to a local source directory with --source (or $BUTTONS_SOURCE). That directory
-is a valid install source, so publish + install round-trip end-to-end today.
+Targets, in order:
+  --source <dir> / $BUTTONS_SOURCE   a local source directory (dev round-trip)
+  $BUTTONS_REGISTRY_URL              the hosted registry (publish @desk/name)
+
+A registry publish takes a scoped name (@desk/name): the on-disk button is found
+by its bare name, and @desk is its registry namespace. The registry pins
+immutable versions, so button.json must carry a "version". Auth uses the *write*
+key (REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct
+from the read key install uses.
 
 Examples:
-  buttons publish deploy --source ./pack
-  BUTTONS_SOURCE=./pack buttons publish deploy`,
+  BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
+  buttons publish deploy --source ./pack`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		// A local source (--source / $BUTTONS_SOURCE) wins, mirroring install.
 		srcDir := publishSource
 		if srcDir == "" {
 			srcDir = os.Getenv("BUTTONS_SOURCE")
 		}
-		if srcDir == "" {
-			msg := "no source: pass --source <dir> or set $BUTTONS_SOURCE (the registry publish target lands in #276)"
-			if jsonOutput {
-				_ = config.WriteJSONError("VALIDATION_ERROR", msg)
-				return errSilent
-			}
-			return fmt.Errorf("%s", msg)
+		if srcDir != "" {
+			return renderPublish(func() (*store.PublishResult, error) {
+				return store.Publish(&store.LocalSource{Root: srcDir}, name)
+			}, "to "+srcDir, " --source "+srcDir)
 		}
 
-		dst := &store.LocalSource{Root: srcDir}
-		res, err := store.Publish(dst, args[0])
-		if err != nil {
-			if jsonOutput {
-				_ = config.WriteJSONError("PUBLISH_ERROR", err.Error())
-				return errSilent
+		// Otherwise the hosted registry.
+		if reg := strings.TrimRight(os.Getenv("BUTTONS_REGISTRY_URL"), "/"); reg != "" {
+			key := registryWriteKey()
+			if key == "" {
+				return publishConfigError("registry write key not set: run `buttons batteries set REGISTRY_WRITE_KEY <key>` (or set $BUTTONS_BAT_REGISTRY_WRITE_KEY)")
 			}
-			return err
+			pub := &store.HTTPPublisher{BaseURL: reg, Key: key, Kind: publishKind}
+			return renderPublish(func() (*store.PublishResult, error) {
+				return store.PublishToRegistry(pub, name)
+			}, "to "+reg, "")
 		}
 
-		if jsonOutput {
-			return config.WriteJSON(res)
-		}
-		fmt.Fprintf(os.Stderr, "Published %s (%d files, sha256 %s) to %s\n", res.Name, res.Files, res.SHA256[:12], srcDir)
-		printNextHint("buttons install %s --source %s", res.Name, srcDir)
-		return nil
+		return publishConfigError("no publish target: set $BUTTONS_REGISTRY_URL (+ REGISTRY_WRITE_KEY) for the registry, or pass --source <dir> / $BUTTONS_SOURCE for a local source")
 	},
 }
 
+// renderPublish runs a publish closure and renders the shared success/error
+// output. dest describes where it went; installSuffix is appended to the
+// "buttons install <name>" next-step hint (e.g. " --source ./pack").
+func renderPublish(do func() (*store.PublishResult, error), dest, installSuffix string) error {
+	res, err := do()
+	if err != nil {
+		if jsonOutput {
+			_ = config.WriteJSONError("PUBLISH_ERROR", err.Error())
+			return errSilent
+		}
+		return err
+	}
+	if jsonOutput {
+		return config.WriteJSON(res)
+	}
+	v := res.Version
+	if v != "" {
+		v = "@" + v
+	}
+	fmt.Fprintf(os.Stderr, "Published %s%s (%d files, sha256 %s) %s\n", res.Name, v, res.Files, res.SHA256[:12], dest)
+	printNextHint("buttons install %s%s", res.Name, installSuffix)
+	return nil
+}
+
+// publishConfigError renders a pre-flight validation error in the active format.
+func publishConfigError(msg string) error {
+	if jsonOutput {
+		_ = config.WriteJSONError("VALIDATION_ERROR", msg)
+		return errSilent
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// registryWriteKey resolves the registry *write* bearer key — the
+// BUTTONS_BAT_REGISTRY_WRITE_KEY env (injected during a press) wins, else the
+// REGISTRY_WRITE_KEY battery.
+func registryWriteKey() string {
+	if k := os.Getenv("BUTTONS_BAT_REGISTRY_WRITE_KEY"); k != "" {
+		return k
+	}
+	if svc, err := newBatteryService(); err == nil {
+		if v, _, err := svc.Get("REGISTRY_WRITE_KEY"); err == nil {
+			return v
+		}
+	}
+	return ""
+}
+
 func init() {
-	publishCmd.Flags().StringVar(&publishSource, "source", "", "source directory to publish to (until the registry lands, #276)")
+	publishCmd.Flags().StringVar(&publishSource, "source", "", "local source directory to publish to (else $BUTTONS_REGISTRY_URL)")
+	publishCmd.Flags().StringVar(&publishKind, "kind", "button", "registry entry kind: button | drawer")
 	rootCmd.AddCommand(publishCmd)
 }

--- a/internal/store/http_publish.go
+++ b/internal/store/http_publish.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HTTPPublisher publishes a button to the hosted registry over POST /v1/buttons —
+// the write-side mirror of HTTPSource. It tars the bundle, hashes the tarball, and
+// uploads it bearer-authed with the *write* key (REGISTRY_WRITE_KEY). The registry
+// re-verifies the hash, stores the artifact content-addressed under the same key
+// scheme HTTPSource downloads from, and appends the index entry. It satisfies
+// Publisher, so cmd/publish selects it exactly like install selects HTTPSource.
+type HTTPPublisher struct {
+	BaseURL string       // the registry base URL ($BUTTONS_REGISTRY_URL), trailing / trimmed
+	Key     string       // write bearer key (REGISTRY_WRITE_KEY / BUTTONS_BAT_REGISTRY_WRITE_KEY)
+	Kind    string       // "button" | "drawer" (index metadata); "" → "button"
+	Client  *http.Client // nil → a 30s-timeout default
+}
+
+func (p *HTTPPublisher) httpClient() *http.Client {
+	if p.Client != nil {
+		return p.Client
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// Publish uploads a bundle to the registry. Bundle.Name carries the registry
+// identity (@desk/name); Version is required — the registry pins immutable
+// versions and rejects a re-publish of the same name@version.
+func (p *HTTPPublisher) Publish(b *Bundle) error {
+	if b.Name == "" || b.Version == "" {
+		return fmt.Errorf("registry publish requires name and version (got name=%q version=%q)", b.Name, b.Version)
+	}
+	tarball, err := tarGz(path.Base(b.Name), b.Files)
+	if err != nil {
+		return fmt.Errorf("pack %s: %w", b.Name, err)
+	}
+	if int64(len(tarball)) > maxArtifactBytes {
+		return fmt.Errorf("artifact for %s exceeds %d bytes", b.Name, int64(maxArtifactBytes))
+	}
+	sum := sha256hex(tarball)
+
+	kind := p.Kind
+	if kind == "" {
+		kind = "button"
+	}
+	endpoint := strings.TrimRight(p.BaseURL, "/") +
+		fmt.Sprintf("/v1/buttons/%s/%s", scopedPath(b.Name), url.PathEscape(b.Version))
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(tarball))
+	if err != nil {
+		return err
+	}
+	if p.Key != "" {
+		req.Header.Set("Authorization", "Bearer "+p.Key)
+	}
+	req.Header.Set("Content-Type", "application/gzip")
+	req.Header.Set("X-Content-Sha256", sum) // server verifies bytes against this
+	req.Header.Set("X-Button-Kind", kind)
+	req.ContentLength = int64(len(tarball))
+
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("registry %s: %w", p.BaseURL, err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return registryError("publish "+b.Name+"@"+b.Version, resp)
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// tarGz packs files into a gzip'd tar wrapped under a single top-level folder,
+// mirroring the layout HTTPSource.untarGz expects (it strips the wrapper). Keys
+// are sorted and timestamps zeroed so identical content yields an identical
+// archive — and so the tarball hash this computes round-trips through the
+// registry to install.
+func tarGz(wrapper string, files map[string][]byte) ([]byte, error) {
+	if wrapper == "" || strings.ContainsAny(wrapper, `/\`) {
+		wrapper = "button"
+	}
+	names := make([]string, 0, len(files))
+	for n := range files {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, n := range names {
+		data := files[n]
+		hdr := &tar.Header{
+			Name:     path.Join(wrapper, n),
+			Mode:     0o644,
+			Size:     int64(len(data)),
+			ModTime:  time.Unix(0, 0).UTC(),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/store/http_publish_test.go
+++ b/internal/store/http_publish_test.go
@@ -1,0 +1,221 @@
+package store
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockRegistry mimics the Worker's contract for both halves of the loop: a
+// write-key-gated POST that verifies the artifact hash + enforces version
+// immutability, and the read-key-gated GET index/download HTTPSource installs
+// from. Enough to round-trip publish → fetch entirely through the real clients.
+type mockRegistry struct {
+	readKey, writeKey string
+	mu                sync.Mutex
+	entries           []indexEntry
+	tarballs          map[string][]byte // "name@version" -> bytes
+}
+
+func newMockRegistry(readKey, writeKey string) *mockRegistry {
+	return &mockRegistry{readKey: readKey, writeKey: writeKey, tarballs: map[string][]byte{}}
+}
+
+func (m *mockRegistry) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/buttons/"):
+			if r.Header.Get("Authorization") != "Bearer "+m.writeKey {
+				http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"write key required"}}`, http.StatusUnauthorized)
+				return
+			}
+			// /v1/buttons/<name>/<version> — split version off the last slash
+			// (name itself contains a slash, e.g. @autono/hello).
+			mid := strings.TrimPrefix(r.URL.Path, "/v1/buttons/")
+			i := strings.LastIndex(mid, "/")
+			if i < 0 {
+				http.Error(w, `{"error":{"code":"BAD_PATH","message":"want /v1/buttons/<name>/<version>"}}`, http.StatusBadRequest)
+				return
+			}
+			name, version := mid[:i], mid[i+1:]
+			body, _ := io.ReadAll(r.Body)
+			if declared := r.Header.Get("X-Content-Sha256"); declared != sha(body) {
+				http.Error(w, `{"error":{"code":"HASH_MISMATCH","message":"declared hash != bytes"}}`, http.StatusBadRequest)
+				return
+			}
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			for _, e := range m.entries {
+				if e.Name == name && e.Version == version {
+					http.Error(w, `{"error":{"code":"VERSION_EXISTS","message":"versions are immutable"}}`, http.StatusConflict)
+					return
+				}
+			}
+			m.entries = append(m.entries, indexEntry{
+				Name: name, Kind: r.Header.Get("X-Button-Kind"), Version: version, SHA256: sha(body),
+			})
+			m.tarballs[name+"@"+version] = body
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/index":
+			if r.Header.Get("Authorization") != "Bearer "+m.readKey {
+				http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"read key required"}}`, http.StatusUnauthorized)
+				return
+			}
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(m.entries)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/buttons/") && strings.HasSuffix(r.URL.Path, "/download"):
+			if r.Header.Get("Authorization") != "Bearer "+m.readKey {
+				http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"read key required"}}`, http.StatusUnauthorized)
+				return
+			}
+			mid := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/buttons/"), "/download")
+			i := strings.LastIndex(mid, "/")
+			name, version := mid[:i], mid[i+1:]
+			m.mu.Lock()
+			tb, ok := m.tarballs[name+"@"+version]
+			m.mu.Unlock()
+			if !ok {
+				http.Error(w, `{"error":{"code":"NOT_FOUND","message":"no artifact"}}`, http.StatusNotFound)
+				return
+			}
+			w.Header().Set("X-Content-Sha256", sha(tb))
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(tb)
+
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+func sampleBundle() (map[string][]byte, *Bundle) {
+	files := map[string][]byte{
+		"button.json": []byte(`{"schema_version":1,"name":"hello","runtime":"shell","version":"1.0.0"}`),
+		"main.sh":     []byte("#!/bin/sh\necho hi\n"),
+		"AGENTS.md":   []byte("# hello\n"),
+	}
+	return files, &Bundle{Name: "@autono/hello", Version: "1.0.0", SHA256: hashFiles(files), Files: files}
+}
+
+// TestPublishThenFetchRoundTrip is the whole point: an artifact published by
+// HTTPPublisher is byte-for-byte installable by HTTPSource, and the content hash
+// install would pin equals the one the local bundle had.
+func TestPublishThenFetchRoundTrip(t *testing.T) {
+	reg := newMockRegistry("rk", "wk")
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	files, b := sampleBundle()
+	if err := (&HTTPPublisher{BaseURL: srv.URL, Key: "wk"}).Publish(b); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	got, err := (&HTTPSource{BaseURL: srv.URL, Key: "rk"}).Fetch("@autono/hello", "1.0.0")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got.SHA256 != hashFiles(files) {
+		t.Fatalf("round-trip content hash mismatch: fetched %s, published %s", got.SHA256, hashFiles(files))
+	}
+	if string(got.Files["main.sh"]) != "#!/bin/sh\necho hi\n" {
+		t.Errorf("main.sh round-trip wrong: %q", got.Files["main.sh"])
+	}
+	for k := range got.Files {
+		if strings.Contains(k, "/") {
+			t.Errorf("file key not flattened (wrapper not stripped): %q", k)
+		}
+	}
+	// version "" must also resolve to the just-published one via the index.
+	latest, err := (&HTTPSource{BaseURL: srv.URL, Key: "rk"}).Fetch("@autono/hello", "")
+	if err != nil || latest.Version != "1.0.0" {
+		t.Fatalf("latest resolve: ver=%q err=%v", latest.Version, err)
+	}
+}
+
+func TestHTTPPublisherRejectsDuplicateVersion(t *testing.T) {
+	reg := newMockRegistry("rk", "wk")
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	_, b := sampleBundle()
+	pub := &HTTPPublisher{BaseURL: srv.URL, Key: "wk"}
+	if err := pub.Publish(b); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	err := pub.Publish(b)
+	if err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("re-publishing a version should conflict, got %v", err)
+	}
+}
+
+func TestHTTPPublisherAuthFailure(t *testing.T) {
+	reg := newMockRegistry("rk", "wk")
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	_, b := sampleBundle()
+	if err := (&HTTPPublisher{BaseURL: srv.URL, Key: "wrong"}).Publish(b); err == nil {
+		t.Fatal("expected auth failure with the wrong write key")
+	}
+}
+
+func TestHTTPPublisherRequiresNameAndVersion(t *testing.T) {
+	pub := &HTTPPublisher{BaseURL: "http://unused.invalid", Key: "wk"}
+	if err := pub.Publish(&Bundle{Name: "@autono/hello", Files: map[string][]byte{"button.json": []byte("{}")}}); err == nil {
+		t.Error("missing version should error before any network call")
+	}
+	if err := pub.Publish(&Bundle{Version: "1.0.0", Files: map[string][]byte{"button.json": []byte("{}")}}); err == nil {
+		t.Error("missing name should error before any network call")
+	}
+}
+
+// TestTarGzUntarGzRoundTrip pins the artifact contract: tarGz wraps, untarGz
+// strips, content survives. This is what makes publish → install lossless.
+func TestTarGzUntarGzRoundTrip(t *testing.T) {
+	files := map[string][]byte{
+		"button.json": []byte(`{"name":"x"}`),
+		"main.sh":     []byte("echo hi\n"),
+		"AGENTS.md":   []byte("# x\n"),
+	}
+	tb, err := tarGz("x", files)
+	if err != nil {
+		t.Fatalf("tarGz: %v", err)
+	}
+	got, err := untarGz(tb)
+	if err != nil {
+		t.Fatalf("untarGz: %v", err)
+	}
+	if hashFiles(got) != hashFiles(files) {
+		t.Fatalf("round trip changed content: got %v want %v", got, files)
+	}
+}
+
+func TestSplitScoped(t *testing.T) {
+	ok := func(ref, wantDesk, wantName string) {
+		t.Helper()
+		d, n, err := splitScoped(ref)
+		if err != nil || d != wantDesk || n != wantName {
+			t.Errorf("splitScoped(%q) = (%q,%q,%v), want (%q,%q,nil)", ref, d, n, err, wantDesk, wantName)
+		}
+	}
+	bad := func(ref string) {
+		t.Helper()
+		if _, _, err := splitScoped(ref); err == nil {
+			t.Errorf("splitScoped(%q) should have errored", ref)
+		}
+	}
+	ok("@autono/hello", "@autono", "hello")
+	bad("hello")    // unscoped
+	bad("@autono")  // no name
+	bad("@autono/") // empty name
+	bad("@/hello")  // empty desk
+	bad("@a/b/c")   // name has a slash
+}

--- a/internal/store/http_source.go
+++ b/internal/store/http_source.go
@@ -17,11 +17,11 @@ import (
 )
 
 // HTTPSource installs from the hosted registry (#275) — a Cloudflare Worker that
-// serves the index + content-pinned tarballs over bearer auth (desk.buttons.sh).
-// It satisfies Source, so the install/update path is identical to a LocalSource;
-// the only difference is the bytes come over HTTPS and are hash-verified on the way in.
+// serves the index + content-pinned tarballs over bearer auth. It satisfies
+// Source, so the install/update path is identical to a LocalSource; the only
+// difference is the bytes come over HTTPS and are hash-verified on the way in.
 type HTTPSource struct {
-	BaseURL string       // e.g. https://desk.buttons.sh (trailing / trimmed)
+	BaseURL string       // the registry base URL ($BUTTONS_REGISTRY_URL), trailing / trimmed
 	Key     string       // bearer key (the REGISTRY_KEY battery / BUTTONS_BAT_REGISTRY_KEY)
 	Client  *http.Client // nil → a 30s-timeout default
 }
@@ -132,7 +132,7 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 		}
 	}
 
-	p := fmt.Sprintf("/v1/buttons/%s/%s/download", url.PathEscape(name), url.PathEscape(version))
+	p := fmt.Sprintf("/v1/buttons/%s/%s/download", scopedPath(name), url.PathEscape(version))
 	resp, err := s.get(p)
 	if err != nil {
 		return nil, err
@@ -175,6 +175,17 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 func sha256hex(b []byte) string {
 	h := sha256.Sum256(b)
 	return hex.EncodeToString(h[:])
+}
+
+// scopedPath renders a registry name (@desk/name) as path segments — each
+// component percent-escaped, the scope slash preserved — so the URL is
+// /v1/buttons/@desk/name (two real segments), not an opaque @desk%2Fname.
+func scopedPath(name string) string {
+	parts := strings.Split(name, "/")
+	for i := range parts {
+		parts[i] = url.PathEscape(parts[i])
+	}
+	return strings.Join(parts, "/")
 }
 
 // untarGz extracts a gzip'd tar into a flat map keyed by path relative to the

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
@@ -27,15 +28,53 @@ type PublishResult struct {
 
 // Publish reads an installed/local button and hands it to dst. It's the inverse
 // of InstallSpec: gather the button folder (button.json + main.* + AGENTS.md,
-// never pressed/ history), content-hash it, and publish.
+// never pressed/ history), content-hash it, and publish under the button's own
+// name (the LocalSource path).
 func Publish(dst Publisher, name string) (*PublishResult, error) {
-	dir, err := config.ButtonDir(button.Slugify(name))
+	bundle, err := loadLocalBundle(name, "")
+	if err != nil {
+		return nil, err
+	}
+	if err := dst.Publish(bundle); err != nil {
+		return nil, err
+	}
+	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+}
+
+// PublishToRegistry publishes a local button to the hosted registry under a
+// scoped identity (@desk/name). The on-disk button is found by its bare name;
+// the @desk scope is registry identity, assigned here (not stored on disk). A
+// version is required — the registry pins immutable versions.
+func PublishToRegistry(dst Publisher, ref string) (*PublishResult, error) {
+	_, localName, err := splitScoped(ref)
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := loadLocalBundle(localName, ref)
+	if err != nil {
+		return nil, err
+	}
+	if bundle.Version == "" {
+		return nil, fmt.Errorf("registry publish requires a version: set \"version\" in %q's button.json", localName)
+	}
+	if err := dst.Publish(bundle); err != nil {
+		return nil, err
+	}
+	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+}
+
+// loadLocalBundle reads a local button folder into a Bundle. localName locates
+// the on-disk folder (slugified); identity, when non-empty, overrides the
+// stamped Bundle.Name with the registry id (@desk/name) — for a LocalSource it
+// stays empty so the button keeps its own name.
+func loadLocalBundle(localName, identity string) (*Bundle, error) {
+	dir, err := config.ButtonDir(button.Slugify(localName))
 	if err != nil {
 		return nil, err
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("button %q not found: %w", name, err)
+		return nil, fmt.Errorf("button %q not found: %w", localName, err)
 	}
 
 	files := map[string][]byte{}
@@ -52,18 +91,36 @@ func Publish(dst Publisher, name string) (*PublishResult, error) {
 	}
 	specData, ok := files["button.json"]
 	if !ok {
-		return nil, fmt.Errorf("button %q has no button.json", name)
+		return nil, fmt.Errorf("button %q has no button.json", localName)
 	}
 	var spec button.Button
 	if err := json.Unmarshal(specData, &spec); err != nil {
-		return nil, fmt.Errorf("button %q: invalid button.json: %w", name, err)
+		return nil, fmt.Errorf("button %q: invalid button.json: %w", localName, err)
 	}
 
-	bundle := &Bundle{Name: spec.Name, Version: spec.Version, SHA256: hashFiles(files), Files: files}
-	if err := dst.Publish(bundle); err != nil {
-		return nil, err
+	name := spec.Name
+	if identity != "" {
+		name = identity
 	}
-	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(files)}, nil
+	return &Bundle{Name: name, Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
+}
+
+// splitScoped parses a registry identity @desk/name into its parts, rejecting
+// anything that isn't a single-segment name under an @scope.
+func splitScoped(ref string) (desk, name string, err error) {
+	bad := fmt.Errorf("registry name must be scoped like @desk/name, got %q", ref)
+	if !strings.HasPrefix(ref, "@") {
+		return "", "", bad
+	}
+	i := strings.IndexByte(ref, '/')
+	if i < 0 || i == len(ref)-1 || i == 1 { // need chars after @ and after /
+		return "", "", bad
+	}
+	desk, name = ref[:i], ref[i+1:]
+	if strings.ContainsRune(name, '/') {
+		return "", "", bad
+	}
+	return desk, name, nil
 }
 
 // Publish writes a bundle into the LocalSource directory as <Root>/<name>/…,


### PR DESCRIPTION
## What

The write-side twin of the install loop: `buttons publish @desk/name` pushes a
local button to the registry configured via `$BUTTONS_REGISTRY_URL` — the mirror
of `buttons install @desk/name`. Closes the client half of #276.

Until now `buttons publish` only wrote to a local `--source` directory.

## How

- **HTTPPublisher** (`internal/store/http_publish.go`) — inverse of HTTPSource:
  tarGz the bundle (wrap + sort + zero mtimes so untarGz round-trips losslessly),
  hash the tarball, POST it bearer-authed with the write key. Satisfies Publisher.
- **publish.go** — extracted `loadLocalBundle`; `PublishToRegistry` + `splitScoped`
  resolve `@desk/name` to the bare on-disk button under the scoped registry identity.
- **cmd/publish.go** — selects registry vs local exactly like install selects
  HTTPSource vs LocalSource (`$BUTTONS_REGISTRY_URL` + the write-key battery).
- **scoped-path routing** — names ride as two real path segments
  (`/v1/buttons/@desk/name/...`) via a shared `scopedPath`, no `%2F` encoding.
- **public-repo hygiene** — this repo carries the generic mechanism only; the
  concrete registry endpoint and publish/deploy ops live in the (private) registry
  repo. Help text + comment examples use placeholders.

## Test plan

`go test ./...` green. New store tests: publish→fetch round-trip through both real
clients (content hash matches install's pin), duplicate-version 409, auth failure,
requires-name+version, `tarGz`↔`untarGz`, `splitScoped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `buttons publish` now supports publishing from either a local folder or a configured registry.
  * Added support for scoped package names like `@desk/name` and a new `--kind` option for publishing different item types.
  * Publishing now shows clearer success output, including version info and a follow-up install command.

* **Bug Fixes**
  * Improved registry publishing and downloading for scoped names.
  * Added stronger validation and clearer error messages for missing or invalid publish settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->