### PR TITLE
feat(create): app-kind buttons under apps/ (--app <source>)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,6 +33,8 @@ var createMaxResponseSize string
 var createAllowPrivateNetworks bool
 var createArgs []string
 var createIgnore bool
+var createApp bool
+var createFrom string
 
 var createCmd = &cobra.Command{
 	Use:   "create [name]",
@@ -81,6 +83,30 @@ Examples:
   buttons create check-logs --prompt "Use the Northflank CLI to read production logs and summarize errors"`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// --app: scaffold an app-kind button under apps/ (served, not pressed).
+		// apps/ is created lazily here, so it never appears unless asked for.
+		if createApp {
+			btn, err := button.NewService().CreateApp(button.AppOpts{
+				Name:        args[0],
+				From:        createFrom,
+				Description: createDescription,
+			})
+			if err != nil {
+				return handleServiceError(err)
+			}
+			appDir, _ := config.AppDir(btn.Name)
+			if jsonOutput {
+				return config.WriteJSON(struct {
+					*button.Button
+					AppDir string `json:"app_dir"`
+				}{Button: btn, AppDir: appDir})
+			}
+			fmt.Fprintf(os.Stderr, "Created app: %s\n", btn.Name)
+			fmt.Fprintf(os.Stderr, "  %s\n", appDir)
+			printNextHint("buttons serve %s", btn.Name)
+			return nil
+		}
+
 		code := createCode
 
 		argDefs, err := button.ParseArgDefs(createArgs)
@@ -244,6 +270,8 @@ func init() {
 	createCmd.Flags().BoolVar(&createAllowPrivateNetworks, "allow-private-networks", false, "allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.")
 	createCmd.Flags().StringArrayVar(&createArgs, "arg", nil, "argument definition (name:type:required|optional)")
 	createCmd.Flags().BoolVar(&createIgnore, "ignore", false, "add this button to .buttons/.gitignore so git won't track it (good for scratch/test buttons)")
+	createCmd.Flags().BoolVar(&createApp, "app", false, "create an app-kind button (served, not pressed) under apps/")
+	createCmd.Flags().StringVar(&createFrom, "from", "", "with --app: git URL to clone (or local path to copy) into apps/<name>/")
 	rootCmd.AddCommand(createCmd)
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,8 +33,7 @@ var createMaxResponseSize string
 var createAllowPrivateNetworks bool
 var createArgs []string
 var createIgnore bool
-var createApp bool
-var createFrom string
+var createApp string
 
 var createCmd = &cobra.Command{
 	Use:   "create [name]",
@@ -85,10 +84,10 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// --app: scaffold an app-kind button under apps/ (served, not pressed).
 		// apps/ is created lazily here, so it never appears unless asked for.
-		if createApp {
+		if createApp != "" {
 			btn, err := button.NewService().CreateApp(button.AppOpts{
 				Name:        args[0],
-				From:        createFrom,
+				From:        createApp,
 				Description: createDescription,
 			})
 			if err != nil {
@@ -270,8 +269,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createAllowPrivateNetworks, "allow-private-networks", false, "allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.")
 	createCmd.Flags().StringArrayVar(&createArgs, "arg", nil, "argument definition (name:type:required|optional)")
 	createCmd.Flags().BoolVar(&createIgnore, "ignore", false, "add this button to .buttons/.gitignore so git won't track it (good for scratch/test buttons)")
-	createCmd.Flags().BoolVar(&createApp, "app", false, "create an app-kind button (served, not pressed) under apps/")
-	createCmd.Flags().StringVar(&createFrom, "from", "", "with --app: git URL to clone (or local path to copy) into apps/<name>/")
+	createCmd.Flags().StringVar(&createApp, "app", "", "create an app-kind button under apps/ from a git URL (cloned) or local path (copied)")
 	rootCmd.AddCommand(createCmd)
 }
 

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -69,17 +69,19 @@ buttons create [name] [flags]
 
 ```
       --allow-private-networks     allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.
+      --app                        create an app-kind button (served, not pressed) under apps/
       --arg stringArray            argument definition (name:type:required|optional)
       --body string                HTTP request body (supports {{arg}} templates)
       --code string                inline script code (shortcut for one-liners)
   -d, --description string         button description
   -f, --file string                copy an existing script file into the button folder
+      --from string                with --app: git URL to clone (or local path to copy) into apps/<name>/
       --header stringArray         HTTP header as 'Key: Value' (repeatable)
   -h, --help                       help for create
       --ignore                     add this button to .buttons/.gitignore so git won't track it (good for scratch/test buttons)
       --max-response-size string   max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M
       --method string              HTTP method for --url (default: GET)
-      --prompt string              prompt/instruction for the consuming agent (written to AGENT.md)
+      --prompt string              prompt/instruction for the consuming agent (written to AGENTS.md)
       --runtime string             code runtime: shell, python, node (default: shell)
       --timeout int                execution timeout in seconds (default 300)
       --url string                 HTTP API endpoint URL (supports {{arg}} templates)

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -69,13 +69,12 @@ buttons create [name] [flags]
 
 ```
       --allow-private-networks     allow --url buttons to reach private network addresses (localhost, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 private ranges). Required for local dev targets.
-      --app                        create an app-kind button (served, not pressed) under apps/
+      --app string                 create an app-kind button under apps/ from a git URL (cloned) or local path (copied)
       --arg stringArray            argument definition (name:type:required|optional)
       --body string                HTTP request body (supports {{arg}} templates)
       --code string                inline script code (shortcut for one-liners)
   -d, --description string         button description
   -f, --file string                copy an existing script file into the button folder
-      --from string                with --app: git URL to clone (or local path to copy) into apps/<name>/
       --header stringArray         HTTP header as 'Key: Value' (repeatable)
   -h, --help                       help for create
       --ignore                     add this button to .buttons/.gitignore so git won't track it (good for scratch/test buttons)

--- a/internal/button/app_test.go
+++ b/internal/button/app_test.go
@@ -1,0 +1,132 @@
+package button
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/config"
+)
+
+func readApp(t *testing.T, home, name string) Button {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "apps", name, "button.json"))
+	if err != nil {
+		t.Fatalf("read app button.json: %v", err)
+	}
+	var b Button
+	if err := json.Unmarshal(data, &b); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestCreateAppEmptyScaffold(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+
+	b, err := NewService().CreateApp(AppOpts{Name: "deckone", Description: "a deck"})
+	if err != nil {
+		t.Fatalf("CreateApp: %v", err)
+	}
+	if b.Kind != "app" || b.Serve == nil || b.Serve.Type != "static" {
+		t.Fatalf("unexpected button: %+v", b)
+	}
+	got := readApp(t, home, "deckone")
+	if got.Kind != "app" || got.Serve == nil {
+		t.Fatalf("on-disk button.json: %+v", got)
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps", "deckone", "AGENTS.md")); err != nil {
+		t.Fatal("AGENTS.md missing")
+	}
+	// no main.* — apps are served, not pressed
+	if _, err := os.Stat(filepath.Join(home, "apps", "deckone", "main.sh")); !os.IsNotExist(err) {
+		t.Fatal("app must not scaffold main.sh")
+	}
+}
+
+func TestCreateAppFromLocalPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "index.html"), []byte("<h1>hi</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewService().CreateApp(AppOpts{Name: "site", From: src}); err != nil {
+		t.Fatalf("CreateApp: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps", "site", "index.html")); err != nil {
+		t.Fatal("source not copied into apps/")
+	}
+	readApp(t, home, "site") // button.json written alongside the copied source
+}
+
+func TestCreateAppFromGitURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	orig := gitClone
+	defer func() { gitClone = orig }()
+
+	var clonedURL string
+	gitClone = func(url, dest string) error {
+		clonedURL = url
+		if err := os.MkdirAll(dest, 0o700); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "README.md"), []byte("cloned"), 0o644)
+	}
+
+	if _, err := NewService().CreateApp(AppOpts{Name: "repo", From: "https://github.com/x/y"}); err != nil {
+		t.Fatalf("CreateApp: %v", err)
+	}
+	if clonedURL != "https://github.com/x/y" {
+		t.Fatalf("gitClone not invoked with the URL, got %q", clonedURL)
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps", "repo", "README.md")); err != nil {
+		t.Fatal("cloned content missing")
+	}
+}
+
+func TestAppsNotScaffoldedByDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+
+	if err := config.EnsureDataDir(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps")); !os.IsNotExist(err) {
+		t.Fatal("apps/ must NOT exist until an app is created")
+	}
+	if _, err := NewService().CreateApp(AppOpts{Name: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps")); err != nil {
+		t.Fatal("apps/ should exist after CreateApp")
+	}
+}
+
+func TestCreateAppRejectsDuplicate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	if _, err := NewService().CreateApp(AppOpts{Name: "dup"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewService().CreateApp(AppOpts{Name: "dup"}); err == nil {
+		t.Fatal("duplicate app should error")
+	}
+}
+
+func TestIsGitURL(t *testing.T) {
+	for _, ok := range []string{"https://github.com/x/y", "http://x/y", "git@github.com:x/y.git", "x/y.git"} {
+		if !isGitURL(ok) {
+			t.Errorf("isGitURL(%q) = false, want true", ok)
+		}
+	}
+	for _, no := range []string{"./local", "/abs/path", "../rel"} {
+		if isGitURL(no) {
+			t.Errorf("isGitURL(%q) = true, want false", no)
+		}
+	}
+}

--- a/internal/button/app_test.go
+++ b/internal/button/app_test.go
@@ -118,6 +118,24 @@ func TestCreateAppRejectsDuplicate(t *testing.T) {
 	}
 }
 
+func TestCreateAppRollsBackOnFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	orig := gitClone
+	defer func() { gitClone = orig }()
+	gitClone = func(url, dest string) error {
+		_ = os.MkdirAll(dest, 0o700)
+		_ = os.WriteFile(filepath.Join(dest, "partial"), []byte("x"), 0o644)
+		return os.ErrInvalid // clone fails AFTER leaving a partial dir
+	}
+	if _, err := NewService().CreateApp(AppOpts{Name: "boom", From: "https://github.com/x/y"}); err == nil {
+		t.Fatal("expected clone failure")
+	}
+	if _, err := os.Stat(filepath.Join(home, "apps", "boom")); !os.IsNotExist(err) {
+		t.Fatal("partial app dir must be rolled back so a retry isn't blocked by ALREADY_EXISTS")
+	}
+}
+
 func TestIsGitURL(t *testing.T) {
 	for _, ok := range []string{"https://github.com/x/y", "http://x/y", "git@github.com:x/y.git", "x/y.git"} {
 		if !isGitURL(ok) {

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -9,6 +9,12 @@ type Button struct {
 	SchemaVersion int    `json:"schema_version"`
 	Name          string `json:"name"`
 	Description   string `json:"description,omitempty"`
+	// Kind distinguishes a regular button ("" or "button") from an app ("app").
+	// App buttons live under apps/ and are served (`buttons serve`), not pressed.
+	Kind string `json:"kind,omitempty"`
+	// Serve declares how an app-kind button builds and runs when exposed at a URL.
+	// Omitted for regular buttons.
+	Serve *ServeSpec `json:"serve,omitempty"`
 	// Tags group/categorize a button for discovery and install-source filtering
 	// (e.g. "finance", "sync"). Omitted when empty so existing buttons
 	// don't grow a noisy field.
@@ -114,6 +120,17 @@ type QueueConfig struct {
 	// appended to the queue name so distinct keys get distinct
 	// slot pools.
 	Key string `json:"key,omitempty"`
+}
+
+// ServeSpec is how an app-kind button is built and run when `buttons serve`
+// exposes it at a URL behind the tunnel. Static = build then serve the output
+// dir; dynamic = run a long-lived server on Port, proxied via the listener.
+type ServeSpec struct {
+	Type   string `json:"type"`             // "static" | "dynamic"
+	Build  string `json:"build,omitempty"`  // e.g. "pnpm install && pnpm build"
+	Run    string `json:"run,omitempty"`    // dynamic: long-running server on $PORT
+	Output string `json:"output,omitempty"` // static: built dir to serve
+	Port   int    `json:"port,omitempty"`   // dynamic: local port
 }
 
 type ArgDef struct {

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -137,6 +137,16 @@ func (s *Service) CreateApp(opts AppOpts) (*Button, error) {
 		return nil, err
 	}
 
+	// Roll back a half-created app dir on any failure below — a failed clone/copy
+	// or metadata write must not leave a partial dir that blocks a retry with
+	// ALREADY_EXISTS.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
 	switch {
 	case opts.From == "":
 		if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -173,6 +183,7 @@ func (s *Service) CreateApp(opts AppOpts) (*Button, error) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(appAgentsMD(name)), 0o600); err != nil {
 		return nil, err
 	}
+	success = true
 	return btn, nil
 }
 

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	neturl "net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -92,6 +93,102 @@ type Service struct{}
 
 func NewService() *Service {
 	return &Service{}
+}
+
+// AppOpts configures CreateApp. From is a git URL (cloned) or a local path
+// (copied); empty scaffolds an empty app folder.
+type AppOpts struct {
+	Name        string
+	From        string
+	Description string
+}
+
+// gitClone is overridable in tests. Shallow clone, then drop .git so the app is
+// a clean vendored snapshot, not a nested repo.
+var gitClone = func(url, dest string) error {
+	out, err := exec.Command("git", "clone", "--depth", "1", url, dest).CombinedOutput() // #nosec G204 -- url is a source the user chose to clone
+	if err != nil {
+		return fmt.Errorf("git clone: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return os.RemoveAll(filepath.Join(dest, ".git"))
+}
+
+// CreateApp scaffolds an app-kind button under apps/<name>/. apps/ is created
+// lazily (only here), so it never appears unless an app is created. From clones
+// a git URL or copies a local dir into the folder; button.json carries kind=app
+// plus a serve placeholder for the agent to fill in. No main.* — apps are served
+// (`buttons serve`), not pressed.
+func (s *Service) CreateApp(opts AppOpts) (*Button, error) {
+	if err := ValidateName(opts.Name); err != nil {
+		return nil, err
+	}
+	name := Slugify(opts.Name)
+	if name == "" {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "app name is empty after slugification"}
+	}
+	dir, err := config.AppDir(name)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(dir); err == nil {
+		return nil, &ServiceError{Code: "ALREADY_EXISTS", Message: fmt.Sprintf("app %q already exists", name)}
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o700); err != nil { // lazily create apps/
+		return nil, err
+	}
+
+	switch {
+	case opts.From == "":
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, err
+		}
+	case isGitURL(opts.From):
+		if err := gitClone(opts.From, dir); err != nil {
+			return nil, &ServiceError{Code: "CLONE_FAILED", Message: err.Error()}
+		}
+	default:
+		if err := os.CopyFS(dir, os.DirFS(opts.From)); err != nil {
+			return nil, &ServiceError{Code: "COPY_FAILED", Message: fmt.Sprintf("copy %s: %v", opts.From, err)}
+		}
+	}
+
+	now := time.Now().UTC()
+	btn := &Button{
+		SchemaVersion: 1,
+		Name:          name,
+		Kind:          "app",
+		Description:   opts.Description,
+		Serve:         &ServeSpec{Type: "static", Output: "dist"},
+		Env:           map[string]string{},
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	data, err := json.MarshalIndent(btn, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), data, 0o600); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(appAgentsMD(name)), 0o600); err != nil {
+		return nil, err
+	}
+	return btn, nil
+}
+
+func isGitURL(s string) bool {
+	return strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "git@") || strings.HasSuffix(s, ".git")
+}
+
+func appAgentsMD(name string) string {
+	return "# " + name + " (app button)\n\n" +
+		"Served at a URL by `buttons serve`, not pressed. Fill in the `serve` block in button.json:\n\n" +
+		"- `type`: `static` (build → serve `output`) or `dynamic` (run a server on `$PORT`).\n" +
+		"- `build`: build command, e.g. `pnpm install && pnpm build`.\n" +
+		"- `run`: dynamic only — the long-running server, e.g. `pnpm start`.\n" +
+		"- `output`: static only — the built dir to serve (e.g. `dist`).\n" +
+		"- `port`: dynamic only — the local port the server listens on.\n"
 }
 
 func (s *Service) Create(opts CreateOpts) (*Button, error) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -114,6 +114,31 @@ func DrawerDir(name string) (string, error) {
 	return p, nil
 }
 
+// AppsDir is where app-kind buttons live: <data>/apps. NOT created by
+// EnsureDataDir — it's scaffolded lazily by CreateApp, so apps/ never appears
+// unless the user actually creates an app.
+func AppsDir() (string, error) {
+	base, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "apps"), nil
+}
+
+// AppDir returns a specific app's folder, with the same path-escape rejection
+// ButtonDir/DrawerDir apply.
+func AppDir(name string) (string, error) {
+	dir, err := AppsDir()
+	if err != nil {
+		return "", err
+	}
+	p := filepath.Join(dir, name)
+	if !strings.HasPrefix(p, dir+string(filepath.Separator)) {
+		return "", fmt.Errorf("app name resolves outside data directory: %q", name)
+	}
+	return p, nil
+}
+
 // IdempotencyDir is where cross-run idempotency cache entries live.
 // One JSON file per key hash with TTL embedded.
 func IdempotencyDir() (string, error) {


### PR DESCRIPTION
## What

`buttons create <name> --app <git-url|path>` adds an **app-kind button** under
`apps/<name>/` — for web apps (static or dynamic) that are *served* at a URL, not *pressed*.

- **One flag carries the source**, matching `--file <path>` / `--url <url>`:
  - `--app <github-url>` → `git clone --depth 1` then strip `.git` (clean snapshot).
  - `--app <local-path>` → copy.
- **Opt-in:** `apps/` is created lazily (only when `--app` is used), never by `EnsureDataDir`.
- `button.json` carries `kind: "app"` + a `serve` block (`type`/`build`/`run`/`output`/`port`).
  No `main.*` — apps are served (`buttons serve`) / deployed (`buttons deploy`), not pressed.

## How

- `internal/button/entity.go`: `Kind` + `Serve` (`ServeSpec`).
- `internal/config/paths.go`: `AppsDir`/`AppDir` (path-escape-guarded; not in `EnsureDataDir`).
- `internal/button/service.go`: `CreateApp` (clone / copy / scaffold) + injectable `gitClone`.
- `cmd/create.go`: `--app <source>`.

## Test plan

`go test ./...` green. `internal/button/app_test.go`: empty scaffold, local-path copy,
git-URL clone (stubbed cloner), apps/-not-scaffolded-by-default, duplicate, `isGitURL`.
CLI smoke: `buttons create mydeck --app <dir>` → `apps/mydeck/{ button.json (kind:"app" +
serve), AGENTS.md, copied source }`.

## Docs

`docs/cli/buttons_create.md` regenerated. The aggregate SKILL.md + other CLI pages are
left to the **docs-sync workflow** (runs on merge to main) to avoid sweeping in unrelated
pre-existing drift.

## Independence

Disjoint files from #217 — merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
