### PR TITLE
docs: refresh Mintlify docs to match shipped reality

### DIFF
--- a/docs/ai/mcp-server.mdx
+++ b/docs/ai/mcp-server.mdx
@@ -12,6 +12,10 @@ The MCP server exposes two tools:
 
 Your AI tool decides when to use these tools based on the conversation context. If you ask about creating an HTTP button, it searches the docs and pulls the relevant page automatically.
 
+<Note>
+This is the **docs-search** MCP server — it lets an agent read these documentation pages. It is **not** the same as running Buttons *as* an MCP server. To expose your own buttons to an agent as deterministic, pressable tools, run [`buttons mcp`](/buttons/mcp) (only buttons marked `"mcp_enabled": true` are listed/pressable).
+</Note>
+
 ## Connect to your AI tool
 
 <Tabs>
@@ -94,18 +98,18 @@ Select any text on this docs site and use the contextual menu to:
 - **Connect to Cursor** — one-click install into Cursor
 - **Connect to VS Code** — one-click install into VS Code
 
-## MCP + SKILL.md
+## MCP + skill.md
 
-MCP and the [SKILL.md](https://github.com/autonoco/buttons/blob/main/SKILL.md) file in the Buttons repo serve complementary roles:
+MCP and the [skill.md](/ai/skill-md) capability file serve complementary roles:
 
-| | MCP server | SKILL.md |
+| | MCP server | skill.md |
 |---|---|---|
 | **What it provides** | Real-time search across all docs pages | Full CLI reference in one file |
 | **How the agent uses it** | Searches on demand during conversation | Loaded into context at session start |
-| **Stays current** | Auto-indexed on every docs deployment | Regenerated via `go run ./internal/tools/skillgen` |
+| **Stays current** | Auto-indexed on every docs deployment | Auto-generated from the Cobra command tree (`go run ./internal/tools/skillgen`) |
 | **Best for** | Deep questions, discovering pages, getting full page content | Quick reference, offline use, CI agents without network |
 
-Use both: load `SKILL.md` for baseline context, connect the MCP server for deep dives.
+Use both: load `skill.md` for baseline context, connect the MCP server for deep dives.
 
 <Note>
 The MCP server URL above uses `buttons.mintlify.app`. If you're self-hosting or using a custom domain, replace with your actual docs URL followed by `/mcp`.

--- a/docs/ai/skill-md.mdx
+++ b/docs/ai/skill-md.mdx
@@ -60,8 +60,8 @@ The Buttons skill is auto-generated from the Cobra command tree via `go run ./in
 - **Full command reference** — every command and subcommand with flags table
 - **JSON output contract** — success/error shapes and all error codes
 - **Argument types** — string, int, bool with env var and template injection rules
-- **Button sources** — code, HTTP, file, agent with runtime details
-- **Common patterns** — lifecycle, agent context, local dev server examples
+- **Button sources** — code, HTTP, file, and prompt buttons with runtime details
+- **Common patterns** — lifecycle, prompt context, local dev server examples
 - **Storage layout** — `~/.buttons/` directory structure
 
 ## Keeping the skill current

--- a/docs/buttons/cli.mdx
+++ b/docs/buttons/cli.mdx
@@ -1,34 +1,50 @@
 ---
 title: "CLI buttons"
 sidebarTitle: "CLI"
-description: "Wrap a shell command as a button without writing a script."
-tag: "Coming soon"
+description: "Wrap a shell command as a button — one line, no separate script file."
 ---
 
-CLI buttons will be sugar for the common case: wrap a command-line invocation as a button in one line, no `--runtime`, no script body.
+A "CLI button" is just a shell-runtime button whose body is the command you want to run. There's no special flag for it: `buttons create` scaffolds a shell button by default, and `--code` lets you pass the command inline so you never open an editor.
 
 ```bash
-# Planned shape
-buttons create tail-logs --cli 'openclaw tail --service api --env production'
-buttons create git-status --cli 'git status --short'
+buttons create tail-logs --code 'openclaw tail --service api --env production'
+buttons create git-status --code 'git status --short'
 ```
 
-Under the hood, a CLI button is a shell code button whose `main.sh` is the command you passed. The preset exists so agents can recognize the pattern — "I just want to run this command" — without thinking about runtimes.
+`--code` writes the command straight into the button's `main.sh` and skips the placeholder scaffold. `--runtime` defaults to `shell`, so you don't pass it for a CLI command (it's there for `python` / `node` bodies). Press it like any other button:
 
-## Today
+```bash
+buttons press git-status
+```
 
-You can already wrap any CLI command with `--code`:
+## Without `--code`
+
+Run `buttons create <name>` with no shortcut flags and it scaffolds a shell button with a placeholder `main.sh` you then edit:
+
+```bash
+buttons create deploy-check
+# edit .buttons/buttons/deploy-check/main.sh
+```
+
+To start from an existing script file instead of inline code, use `-f, --file`:
+
+```bash
+buttons create deploy-check --file ./scripts/deploy-check.sh
+```
+
+## Adding args
+
+Declare typed args with `--arg name:type:required|optional` (repeatable). Each is injected into the press as `$BUTTONS_ARG_<NAME>`:
 
 ```bash
 buttons create tail-logs \
-  --code 'openclaw tail --service api --env production' \
-  --runtime shell
+  --code 'openclaw tail --service "$BUTTONS_ARG_SERVICE" --env "$BUTTONS_ARG_ENV"' \
+  --arg service:string:required \
+  --arg env:enum:required:staging|production
+
+buttons press tail-logs --arg service=api --arg env=production
 ```
 
-See [Code buttons](/buttons/code) for the full flag set.
+Add `-d, --description` for what shows in `buttons list`, and `--timeout <secs>` to override the default press timeout.
 
-## What's changing
-
-- `--cli '<command>'` flag on `buttons create`
-- Runtime value `cli` in `button.json` (still executes via `/bin/sh`)
-- Detail view and `list` surface CLI buttons with a dedicated label
+See [Code buttons](/buttons/code) for the full `buttons create` flag set (runtimes, HTTP buttons, batteries, and more).

--- a/docs/buttons/code.mdx
+++ b/docs/buttons/code.mdx
@@ -119,7 +119,7 @@ After `buttons create`, the button folder contains:
 ~/.buttons/buttons/<name>/
   button.json     # spec: args, runtime, timeout
   main.sh         # your code (or main.py / main.js)
-  AGENT.md        # notes for agents pressing this button
+  AGENTS.md       # notes for agents pressing this button
   pressed/        # run history, one JSON file per press
 ```
 

--- a/docs/buttons/cron.mdx
+++ b/docs/buttons/cron.mdx
@@ -1,40 +1,55 @@
 ---
 title: "Cron triggers"
 sidebarTitle: "Cron"
-description: "Run a button or drawer on a recurring schedule."
-tag: "Design proposal"
+description: "Run a button on a recurring schedule."
 ---
 
-Cron triggers run a button or drawer on a recurring schedule.
+A cron trigger fires a **button** press on a recurring schedule. It lives on the
+button's spec and runs under the `buttons serve` trigger engine.
 
 ```bash
-buttons trigger cron daily-snapshot "0 3 * * *"
-buttons trigger cron slack-sync "0 */2 * * *" --timezone America/New_York
+buttons trigger add daily-snapshot --cron --schedule "0 3 * * *"
+buttons trigger add slack-sync --cron --schedule "0 */2 * * *"
 ```
 
-If the target is a button, Buttons should create a hidden one-step drawer wrapper internally. If the target is a drawer, the trigger attaches directly to the drawer.
+Schedules are standard **5-field** cron expressions (parsed with `cron.ParseStandard`).
+Cron attaches to a button only — drawers support webhook triggers, not cron (the
+`cron` drawer kind is reserved but not implemented).
 
-## Flags
+## Passing args
+
+Pass `--arg KEY=VALUE` (repeatable) to set the args the press runs with each tick:
 
 ```bash
-buttons trigger cron <target> "<cron>"
-  --timezone America/New_York
-  --overlap skip|queue|replace
-  --name <trigger-id>
+buttons trigger add report --cron --schedule "0 9 * * 1" --arg window=weekly
 ```
 
-Default overlap policy: `skip`. If the previous run is still active when the next tick fires, Buttons should skip the new tick instead of creating accidental parallel work.
+`buttons trigger add` requires exactly one kind flag: `--cron`, `--watch`, or
+`--webhook`. The trigger id is generated automatically (a short hex id) — there is
+no `--name`, `--timezone`, or `--overlap` flag.
 
 ## Management
 
 ```bash
-buttons trigger list
-buttons trigger show <id>
-buttons trigger pause <id>
-buttons trigger resume <id>
-buttons trigger remove <id>
+buttons trigger list             # every trigger, across all buttons
+buttons trigger list <button>    # just this button's triggers
+buttons trigger rm <button> <trigger-id>
 ```
 
-## Implementation note
+There is no `show`, `pause`, or `resume` — to stop a schedule, remove the trigger
+with `buttons trigger rm` (the id comes from `buttons trigger list`).
 
-A cron schedule is inert without a daemon watching schedules and pressing the target. The daemon should record each scheduled press in normal button/drawer history, with trigger id and scheduled time attached to the run metadata.
+## How it fires
+
+A cron schedule is inert without a process watching it. The engine that fires
+triggers runs **in-process inside `buttons serve`** (the local REST API server),
+not a separate daemon:
+
+- On startup, `buttons serve` collects every button's triggers. The cron scheduler
+  starts only if at least one cron trigger exists.
+- Each scheduled fire presses the target button with the trigger's configured args
+  and **records a normal run in the button's history**.
+- Run `buttons serve --no-triggers` to start the API without the trigger engine.
+
+Cron triggers fire only while `buttons serve` is running — keep it up (or under a
+process supervisor) for schedules to tick.

--- a/docs/buttons/hook.mdx
+++ b/docs/buttons/hook.mdx
@@ -2,110 +2,58 @@
 title: "Hook triggers"
 sidebarTitle: "Hook"
 description: "Run a button or drawer when a local event happens."
-tag: "Design proposal"
 ---
 
-A hook trigger runs when a local event happens. It is not time-based and it is not an inbound HTTP request.
+A hook trigger fires a button when something changes on the local machine. It is one of the three button trigger kinds, and the counterpart to the time-based and inbound-HTTP kinds:
 
-- `cron` means time caused the run.
-- `webhook` means a remote service posted to Buttons.
-- `hook` means the local machine, repo, app, or Buttons runtime emitted an event.
+- `cron` — time fires the run (a schedule).
+- `webhook` — a remote service POSTs to fire the run.
+- `watch` — a local file changes and fires the run. This is the shipped "hook."
 
-## Command shape
+All three live on a button's spec and run inside `buttons serve`, which hosts the trigger engine alongside the local REST API.
 
-```bash
-buttons trigger hook <target> --enable "<source>"
-```
-
-`--enable` names the event source that should cause the target to run.
-
-## File hooks
+## Watch a file
 
 ```bash
-buttons trigger hook docs-sync --enable "file:docs/**/*.md"
-buttons trigger hook downloads-ingest --enable "file:~/Downloads/**/*.pdf" --event created
+buttons trigger add docs-index --watch --path ./docs/CHANGELOG.md
 ```
 
-Useful file options:
+`--watch` selects the file-watch kind; `--path` is the single file to watch (required). When that file's size or modification time changes, the button presses.
+
+Pass args that the press should receive each time it fires:
 
 ```bash
---event created|modified|deleted|renamed|any
---ignore "node_modules/**"
---debounce 10s
---batch 30s
---include-existing false
+buttons trigger add reindex --watch --path ./data/index.json --arg mode=incremental
 ```
 
-## History hooks
+`--arg KEY=VALUE` is repeatable.
 
-Buttons can use the same file-hook machinery internally to maintain `.buttons/history.json`.
+## How watching works
 
-The internal watcher should track creates, edits, deletes, and renames for button and drawer files:
+The engine polls the file with `os.Stat` every 500 ms and compares modification time and size. It deliberately does not use fsnotify — polling survives editor rename-on-save and needs no native dependency. The first poll records a baseline and does **not** fire; only a later change triggers the press. Each firing is recorded in run history like a normal press.
 
-```text
-.buttons/buttons.json
-.buttons/buttons-lock.json
-.buttons/buttons/*/button.json
-.buttons/buttons/*/main.*
-.buttons/buttons/*/AGENT.md
-.buttons/drawers/*/drawer.json
-```
-
-Explicit commands like `buttons create`, `buttons install`, and `buttons update` should write history events directly. File hooks catch manual edits and agent edits that happen outside a Buttons command.
-
-See [History](/concepts/history) for the event shape.
-
-## Git hooks
+Watching is active only while `buttons serve` is running — the same process that serves the REST API also runs the cron/watch trigger engine in-process. Pass `--no-triggers` to serve the API without firing triggers.
 
 ```bash
-buttons trigger hook repo-index --enable "git:post-commit"
-buttons trigger hook preflight --enable "git:pre-push"
+buttons serve
 ```
 
-Planned Git events:
-
-```text
-git:pre-commit
-git:post-commit
-git:pre-push
-git:post-checkout
-git:post-merge
-```
-
-## Buttons runtime hooks
+## Manage triggers
 
 ```bash
-buttons trigger hook brain-audit --enable "button:*-sync.completed"
-buttons trigger hook notify-failure --enable "button:*.failed"
-buttons trigger hook qa-after-linkedin --enable "button:linkedin-sync.completed"
+buttons trigger list             # every trigger across all buttons
+buttons trigger list <button>    # one button's triggers
+buttons trigger rm <button> <trigger-id>
 ```
 
-Planned runtime events:
+`trigger list` shows each trigger's id; `rm` takes the button name and that id. There is no pause/resume — remove and re-add to change a trigger.
 
-```text
-button:<name>.started
-button:<name>.completed
-button:<name>.failed
-drawer:<name>.started
-drawer:<name>.completed
-drawer:<name>.failed
-```
+## Not yet shipped
 
-## Common options
+Only three trigger kinds exist today: `cron`, `watch`, and `webhook`. There is no `buttons trigger hook ... --enable "<source>"` command, no git-event hooks (`pre-commit`, `post-push`), and no button/drawer lifecycle events (`button:<name>.completed`, `*.failed`). The `--watch` trigger is the way to react to a local file change.
 
-```bash
---name <trigger-id>
---arg key=value
---filter '<CEL expression>'
---overlap skip|queue|replace
-```
+For the other shipped paths:
 
-For lifecycle control, use trigger management commands instead of overloading `--enable`:
-
-```bash
-buttons trigger pause <id>
-buttons trigger resume <id>
-buttons trigger remove <id>
-```
-
-Recommended first implementation: ship `file:` and `button:` hooks, then add `git:` after the filesystem watcher and runtime event bus are stable.
+- Time-based: `buttons trigger add <button> --cron --schedule "0 */6 * * *"`.
+- Remote callback into a button: `buttons trigger add <button> --webhook --webhook-path /hooks/x [--token …]`.
+- Remote callback into a drawer (n8n-style auth, Cloudflare tunnel): `buttons drawer <name> trigger webhook`, served by `buttons webhook listen`.

--- a/docs/buttons/http-api.mdx
+++ b/docs/buttons/http-api.mdx
@@ -69,12 +69,12 @@ buttons create list-repos \
 
 ## Response size limit
 
-Responses are capped at **10 MB** by default. Override with `--max-response-size` (value in bytes):
+Responses are capped at **10 MB** by default. Override with `--max-response-size`, which accepts a size with an optional unit suffix (`B`, `K`/`KB`, `M`/`MB`, `G`/`GB`; a bare number means bytes). The hard ceiling is 2 GB.
 
 ```bash
 buttons create large-export \
   --url 'https://api.example.com/export' \
-  --max-response-size 52428800 \
+  --max-response-size 50M \
   -d "Download up to 50 MB"
 ```
 

--- a/docs/buttons/mcp.mdx
+++ b/docs/buttons/mcp.mdx
@@ -5,36 +5,54 @@ description: "Freeze an MCP tool invocation as a deterministic, reusable button.
 tag: "Coming soon"
 ---
 
-MCP buttons capture the result of an agent's exploration of an MCP server. The agent lists tools, figures out the right tool and the right parameter shape, confirms the call works — and then saves that frozen invocation as a button. Future presses skip the exploration entirely and go straight to the known-good call.
+MCP and Buttons meet in two directions. One ships today; the other is planned.
 
-```bash
-# Planned shape
-buttons create notify-deploy \
-  --mcp 'slack://post_message' \
-  --mcp-arg channel='#deploys' \
-  --mcp-arg text='{{message}}' \
-  --arg message:string:required
+- **Buttons → MCP (shipped):** `buttons mcp` runs Buttons *as* an MCP server, so any agent can list and press your buttons as deterministic tools.
+- **MCP → Buttons (planned):** capture an agent's exploration of an MCP server — list tools, find the right tool and parameter shape, confirm the call works — and freeze that known-good invocation as a button. This is the page's namesake feature and is **not built yet**.
+
+## What ships today: expose buttons as MCP tools
+
+`buttons mcp` runs an MCP server over stdio that exposes a small meta-tool surface to any MCP client (Claude Desktop, Cursor, etc.):
+
+- `buttons_list` — list buttons available as tools
+- `buttons_press` — press a button by name with args
+- `buttons_inspect` — read a button's spec
+- `buttons_create` — **only** when started with `--allow-create` (off by default)
+
+Point an MCP client at it:
+
+```json
+{
+  "mcpServers": {
+    "buttons": { "command": "buttons", "args": ["mcp"] }
+  }
+}
 ```
 
-Press it:
+Add `"--allow-create"` to `args` to also expose `buttons_create`.
+
+Only buttons that opt in are visible or pressable: set `"mcp_enabled": true` in the button's `button.json`. The server is rate-limited (10 calls/min, 1 concurrent, 120s cap per call) so an agent can't hammer it.
+
+This is the inverse of the planned "freeze an MCP tool" flow: instead of wrapping someone else's MCP tool as a button, you take any button you already have — shell, HTTP, anything — mark it `mcp_enabled`, and it becomes a scoped, deterministic tool an agent can call without re-discovering anything.
+
+## What's planned: MCP → Buttons
+
+<Note>
+The MCP-tool-to-button import is **not implemented yet**. The intended entry point is `buttons import mcp <server>`, which today returns an `IMPORT_ERROR` ("not implemented yet"). Only `import code`, `import skill`, and `import url` create buttons right now. There is no `buttons create --mcp` flag.
+</Note>
+
+When it lands, the idea is to save a frozen MCP invocation as a button so future presses skip the exploration entirely and go straight to the known-good call:
 
 ```bash
-buttons press notify-deploy --arg message="v1.4.2 shipped"
+# Planned — not yet implemented
+buttons import mcp slack
 ```
 
-The same button works in two contexts:
+The same button would then work in two contexts:
 
-- An agent reviewing the button sees it's a safe, scoped Slack post — no re-discovery of the MCP server required
+- An agent reviewing the button sees it's a safe, scoped call — no re-discovery of the MCP server required
 - A deterministic workflow (drawer, cron, webhook) can press it without involving an LLM at all — the MCP call is already parameterized and approved
 
-## Why this matters
+### Why this matters
 
-Without MCP buttons, every agent session has to rediscover the same tools: list servers, list tools, read schemas, guess parameters, verify the call. MCP buttons turn that one-time exploration into a reusable asset.
-
-## What's changing when MCP buttons land
-
-- `--mcp '<server>://<tool>'` flag naming the MCP server and tool
-- `--mcp-arg key=value` for static parameters; `--arg` for dynamic ones bound at press time
-- Runtime value `mcp` in `button.json`
-- Connection details resolved via the same credential system as SQL buttons (register an MCP server once, reference by name)
-- Press returns the tool's structured response, same JSON envelope as every other button
+Without this, every agent session has to rediscover the same tools: list servers, list tools, read schemas, guess parameters, verify the call. Freezing that one-time exploration into a button turns it into a reusable asset — and, pressed as JSON, returns the tool's structured response in the same envelope as every other button.

--- a/docs/buttons/prompt.mdx
+++ b/docs/buttons/prompt.mdx
@@ -14,12 +14,12 @@ A standalone prompt button has no code to execute. It just carries an instructio
 
 ```bash
 buttons create summarize-pr \
-  --prompt 'You are a code reviewer. Read the diff provided in BUTTONS_ARG_DIFF and write a summary of what changed, why it matters, and any risks. Return JSON with keys: summary, risks, verdict.' \
+  --prompt 'You are a code reviewer. Read the diff passed in the `diff` argument and write a summary of what changed, why it matters, and any risks. Return JSON with keys: summary, risks, verdict.' \
   --arg diff:string:required \
   -d "Summarize a pull request diff"
 ```
 
-Pressing it returns the prompt with the argument values substituted, so the caller can pass it straight to an LLM:
+A standalone prompt button runs no code. Pressing it validates the declared args, then returns the instruction **verbatim** — the prompt is **not** templated, so `${arg}`/`BUTTONS_ARG_*` substitution does not happen here. The instruction text lands in both the `prompt` and `stdout` fields, and the args you passed are echoed back under `args`, so the caller can hand the whole thing straight to an LLM:
 
 ```bash
 buttons press summarize-pr --arg diff="$(git diff main)" --json
@@ -30,7 +30,11 @@ buttons press summarize-pr --arg diff="$(git diff main)" --json
   "ok": true,
   "data": {
     "button": "summarize-pr",
-    "prompt": "You are a code reviewer. Read the diff provided in BUTTONS_ARG_DIFF and write a summary..."
+    "status": "ok",
+    "exit_code": 0,
+    "stdout": "You are a code reviewer. Read the diff passed in the `diff` argument...",
+    "prompt": "You are a code reviewer. Read the diff passed in the `diff` argument...",
+    "args": { "diff": "diff --git a/... b/..." }
   }
 }
 ```
@@ -71,7 +75,7 @@ The agent receives both the raw output and the instruction in a single structure
 
 ## Updating prompt instructions
 
-The prompt lives at `~/.buttons/buttons/<name>/AGENT.md` — agents look for that filename by convention. Edit it directly, or recreate the button:
+The prompt lives at `~/.buttons/buttons/<name>/AGENTS.md` — the `AGENTS.md` convention agents look for (a legacy singular `AGENT.md` is still read if present, but every write goes to `AGENTS.md`). Edit it directly, or recreate the button:
 
 ```bash
 buttons delete summarize-pr
@@ -92,5 +96,5 @@ buttons create analyze-logs \
 ## Related
 
 - [Code buttons](/buttons/code) — add code execution alongside a prompt
-- [Arguments](/concepts/arguments) — typed args available in the prompt
+- [Arguments](/concepts/arguments) — typed args validated at press time and echoed in the result (and, on code/HTTP buttons, available as `BUTTONS_ARG_*`)
 - [JSON output](/concepts/json-output) — reading `prompt` programmatically

--- a/docs/buttons/triggers.mdx
+++ b/docs/buttons/triggers.mdx
@@ -2,61 +2,91 @@
 title: "Triggers"
 sidebarTitle: "Overview"
 description: "Run a button or drawer from a webhook, cron schedule, or local hook."
-tag: "Design proposal"
+tag: "Available"
 ---
 
-Triggers define when a button or drawer runs automatically.
+Triggers fire a button or drawer automatically instead of you pressing it. There are **two
+independent trigger layers** — they live on different objects, run under different commands, and
+have different webhook semantics. Pick by what you want to fire:
+
+| Layer | Fires a… | Lives on | Kinds shipped | Runner | Webhook reach |
+| --- | --- | --- | --- | --- | --- |
+| **Button triggers** | button press | the button (`buttons trigger …`) | `cron`, `watch`, `webhook` | `buttons serve` | the local serve listener |
+| **Drawer triggers** | drawer press | the drawer (`buttons drawer … trigger …`) | `webhook` only | `buttons webhook listen` | a Cloudflare tunnel |
+
+There is no unified `buttons trigger <kind> <target>` surface and no `button/` vs `drawer/` target
+prefix — those are a [proposal](#proposed-unified-surface), not shipped. Use the command for the layer
+you want.
+
+## Button triggers — `buttons trigger`
+
+Attach a trigger to a **button**. Triggers fire under `buttons serve`'s in-process trigger engine, so
+nothing happens until a `buttons serve` is running (start it without the engine via
+`buttons serve --no-triggers`).
 
 ```bash
-buttons trigger webhook <target> [/path]
-buttons trigger cron <target> "<cron>"
-buttons trigger hook <target> --enable "<source>"
+# cron — 5-field schedule, in-process scheduler
+buttons trigger add slack-sync --cron --schedule "0 */2 * * *"
+
+# watch — fire when a file changes (polled, 500ms)
+buttons trigger add docs-sync --watch --path ./docs/changelog.md
+
+# webhook — mount a path on the serve listener
+buttons trigger add deploy --webhook --webhook-path /hooks/deploy --token "$DEPLOY_SECRET"
 ```
 
-`<target>` can be a button or a drawer. If the target is a button, Buttons can create a hidden one-step drawer wrapper internally. If the target is already a drawer, the trigger attaches directly to that drawer.
+Exactly one of `--cron` / `--watch` / `--webhook` is required per `add`. Pass `--arg key=value`
+(repeatable) to fix the args used every time the trigger fires.
 
-## Trigger kinds
-
-| Kind | Cause | Example |
+| Kind | Required flags | How it fires |
 | --- | --- | --- |
-| `webhook` | A remote service sends an HTTP POST. | GitHub, Stripe, Apify, Linear |
-| `cron` | A schedule fires. | nightly sync, hourly digest |
-| `hook` | A local event fires. | file changed, Git commit, button completed |
+| `cron` | `--schedule "<5-field cron>"` | In-process scheduler ticks the press. |
+| `watch` | `--path <file>` | Polls the file's mtime+size every 500 ms; fires on change. |
+| `webhook` | `--webhook-path </path>` | `POST <path>` on the serve listener; optional `--token`. |
 
-## Commands
+The webhook kind authenticates with a **single shared token** (`--token`), supplied as an
+`X-Buttons-Token` header **or** `?token=` query param and compared in constant time. This layer
+**does not map the request body into args** — the body is drained (capped at 1 MiB) and discarded; the
+press uses the trigger's configured `--arg` values. The endpoint returns `202 Accepted` immediately and
+fires the press in the background. There is no tunnel — the path is reachable over whatever interface
+`buttons serve` binds (loopback by default).
+
+### Manage button triggers
 
 ```bash
-buttons trigger webhook linkedin-sync /linkedin-sync
-buttons trigger cron slack-sync "0 */2 * * *"
-buttons trigger hook docs-sync --enable "file:docs/**/*.md"
+buttons trigger list            # every trigger across all buttons
+buttons trigger list slack-sync # just this button's triggers
+buttons trigger rm slack-sync <trigger-id>
 ```
 
-Management commands should work across every trigger kind:
+Only `add`, `list`, and `rm` exist — there is no `show`, `pause`, or `resume`. To disable a trigger,
+remove it. `rm` takes the button name **and** the trigger id (shown by `list`).
+
+## Drawer triggers — `buttons drawer … trigger webhook`
+
+Attach a **webhook** trigger to a **drawer**. This is the layer the project's CLAUDE.md documents: it
+runs under `buttons webhook listen`, which fronts the dispatcher with a Cloudflare tunnel so third-party
+services (GitHub, Stripe, Linear, Apify, …) can reach it.
 
 ```bash
-buttons trigger list
-buttons trigger show <id>
-buttons trigger remove <id>
-buttons trigger pause <id>
-buttons trigger resume <id>
-```
-
-## Target resolution
-
-If a button and drawer share a name, use an explicit target prefix:
-
-```bash
-buttons trigger webhook button/linkedin-sync /linkedin-sync
-buttons trigger webhook drawer/linkedin-sync-flow /linkedin-sync
-```
-
-## Current implementation
-
-The current CLI already supports webhook-triggered drawers:
-
-```bash
-buttons drawer <name> trigger webhook [/path]
+buttons drawer create github-pr-opened
+buttons drawer github-pr-opened add handle-github-pr
+buttons drawer github-pr-opened trigger webhook /github/pr-opened
 buttons webhook listen
 ```
 
-The `buttons trigger ...` command is the intended unified surface. It should compile down to the drawer trigger model so existing drawer workflows keep working.
+Only the `webhook` kind is implemented; `buttons drawer <name> trigger <other-kind>` errors with "not
+implemented". The default path is `/<drawer-name>`. Unlike the button layer, the drawer webhook
+**materializes the POST into the press** as `${inputs.webhook.body}` (plus `.headers`, `.query`,
+`.method`, `.path`, `.received_at`), and supports n8n-style auth (`none`/`basic`/`header`/`jwt`) with
+`$ENV{VAR}` secret references so `drawer.json` stays commit-safe. See [Webhook triggers](/buttons/webhook)
+for the auth flags and local dry-run with `--webhook-body`.
+
+To trigger a single button this way, wrap it in a one-step drawer.
+
+## Proposed unified surface
+
+A single `buttons trigger <kind> <target>` front-end — that would take a button *or* drawer, add a
+generic `hook` kind (file / git / runtime events), and add `show` / `pause` / `resume` management — is a
+**design proposal, not built**. Today, use `buttons trigger add` for button triggers and
+`buttons drawer … trigger webhook` for drawer triggers as above.

--- a/docs/buttons/webhook.mdx
+++ b/docs/buttons/webhook.mdx
@@ -2,12 +2,19 @@
 title: "Webhook triggers"
 sidebarTitle: "Webhook"
 description: "Run a button or drawer when an external service sends an HTTP POST."
-tag: "Partially available"
+tag: "Available"
 ---
 
 A webhook trigger turns a button or drawer into a receiver: an HTTP endpoint you can register with GitHub, Stripe, Linear, Apify, or any other service that sends webhooks.
 
 This is the inverse of an [HTTP API button](/buttons/http-api). HTTP API buttons send requests; webhook triggers receive them.
+
+There are two webhook layers, and they are deliberately different:
+
+- **Drawer webhook triggers** (`buttons drawer ... trigger webhook` + `buttons webhook listen`) — n8n-style auth, the request body delivered into the workflow as `${inputs.webhook.body}`, and an optional public Cloudflare URL. Use this when you need the payload.
+- **Button webhook triggers** (`buttons trigger add ... --webhook` + `buttons serve`) — a single shared token, no tunnel, and a body that is read then discarded (the press uses the trigger's own args). Use this for a simple body-less ping on a port you already serve.
+
+## Drawer webhook trigger
 
 ```bash
 buttons drawer create github-pr-opened
@@ -16,9 +23,11 @@ buttons drawer github-pr-opened trigger webhook /github/pr-opened
 buttons webhook listen
 ```
 
-Webhook triggers currently attach to drawers. If you want to trigger one button, put it in a one-step drawer.
+`buttons webhook listen` runs the foreground dispatcher and (unless you pass `--no-tunnel`) brings up a Cloudflare tunnel so third-party services can reach the path. When a POST arrives the drawer is pressed with the request materialized as `${inputs.webhook.body}` (plus `.headers`, `.query`, `.method`, `.path`, `.received_at`).
 
-## Flags
+Only the `webhook` kind is implemented for drawer triggers; other kinds error out. The tunnel requires `cloudflared` on PATH; run `buttons webhook setup` once to configure a stable named tunnel, or skip it and `buttons webhook listen` uses an ephemeral quick tunnel.
+
+### Flags
 
 ```bash
 buttons drawer <name> trigger webhook [/path]
@@ -29,11 +38,11 @@ buttons drawer <name> trigger webhook [/path]
              [--jwt-issuer <issuer>] [--jwt-audience <audience>]
 ```
 
-Default path: `/<drawer-name>`.
+Default path: `/<drawer-name>`. A path is globally unique across drawers; reusing one another drawer owns is rejected.
 
-Any secret-bearing value accepts `$ENV{VAR_NAME}` so committed `drawer.json` does not carry raw secrets.
+Any secret-bearing value accepts `$ENV{VAR_NAME}`, resolved at match time, so a committed `drawer.json` carries the auth *shape* but not the raw secret.
 
-## Auth example
+### Auth example
 
 ```bash
 buttons drawer stripe-receipts trigger webhook /stripe \
@@ -42,21 +51,32 @@ buttons drawer stripe-receipts trigger webhook /stripe \
   --auth-header-value '$ENV{STRIPE_WEBHOOK_TOKEN}'
 ```
 
-## Local testing
+### Local testing
 
-Dry-run a webhook drawer without the listener:
+Dry-run a webhook drawer without the listener — `--webhook-body` synthesizes `inputs.webhook`:
 
 ```bash
 buttons drawer github-pr-opened press --webhook-body '{"action":"opened"}'
 buttons drawer github-pr-opened press --webhook-body @fixture.json
 ```
 
-## Planned unified surface
+## Button webhook trigger
 
-The unified `buttons trigger webhook ...` surface should compile down to the same drawer trigger model.
+To fire a single button on a POST, attach a webhook trigger to it and run `buttons serve` (the local REST API server, which also runs the trigger engine unless you pass `--no-triggers`):
 
 ```bash
-buttons trigger webhook github-pr-opened /github/pr-opened
+buttons trigger add health-check \
+  --webhook \
+  --webhook-path /hooks/health \
+  --token "$HEALTH_TOKEN" \
+  --arg env=prod
+buttons serve
 ```
 
-If the target is a button, Buttons should create a hidden one-step drawer wrapper internally. If the target is a drawer, the trigger attaches directly to the drawer.
+Differences from the drawer layer:
+
+- **Auth** is the single shared `--token`, checked against the `X-Buttons-Token` header or `?token=` query param (constant-time). Omit `--token` for an open endpoint.
+- **The body is read and discarded** — v1 does not map it into args. The press uses the `--arg` values you configured on the trigger.
+- **No Cloudflare tunnel.** The path is mounted on whatever interface `buttons serve` binds (loopback by default), and the handler returns `202 Accepted` immediately.
+
+Manage triggers with `buttons trigger list [button]` and `buttons trigger rm <button> <trigger-id>`. The same `buttons trigger add` command also supports `--cron --schedule "0 */6 * * *"` and `--watch --path ./file`.

--- a/docs/buttons/workflows.mdx
+++ b/docs/buttons/workflows.mdx
@@ -91,6 +91,14 @@ buttons drawer deploy-flow press env=prod
 
 Explicit step args win. If a step arg is not set and a drawer input with the same name exists, Buttons fills it for that step.
 
+## Run modes
+
+By default a drawer runs its steps sequentially. Pass `--mode parallel` to run steps concurrently while honoring data dependencies — a step waits only for the steps its `${...}` refs actually name. `--concurrency N` caps how many run at once (`0` means `NumCPU`), and `--on-failure stop|continue` controls whether the first failure cancels in-flight siblings.
+
+```bash
+buttons drawer release-flow press --mode parallel --concurrency 4 --on-failure stop
+```
+
 ## Step kinds
 
 | Kind | Status | Purpose |
@@ -208,7 +216,7 @@ You can also set wait fields directly:
 
 ```bash
 buttons drawer retry-flow set wait.duration=2m
-buttons drawer deploy-window set wait.until=2026-06-28T21:00:00Z
+buttons drawer deploy-window set wait.until=2026-07-01T21:00:00Z
 ```
 
 Waits honor cancellation, so stopping the drawer does not leave a sleeping process behind.
@@ -229,7 +237,7 @@ By default, a failing step fails the drawer. Step-level `on_failure` can be auth
 }
 ```
 
-A drawer can also define `on_error` to call a separate error-handler drawer after failure. The handler receives `drawer`, `run_id`, `failed_step`, `error`, and redacted `inputs`. The failure still remains visible in the original drawer run history.
+A drawer can also declare `on_error` to point at a separate error-handler drawer, but this is **reserved**: the v1 executor parses it and does not yet run it. The field exists so a drawer can declare the intent ahead of the executor. When it ships, the handler will receive `drawer`, `run_id`, `failed_step`, `error`, and redacted `inputs`, and the failure will still remain visible in the original drawer run history.
 
 ```json
 {
@@ -264,7 +272,16 @@ ${inputs.webhook.path}
 ${inputs.webhook.received_at}
 ```
 
-The planned `buttons trigger webhook <target>` surface should compile down to this same drawer model. If the target is a button, Buttons can create a hidden one-step drawer wrapper.
+Webhook is the only trigger kind drawers support today; registering any other kind errors. The trigger can require auth — append `--auth basic|header|jwt` (plus the matching `--auth-user`/`--auth-pass`, `--auth-header-name`/`--auth-header-value`, or `--jwt-secret` flags) to `trigger webhook`; the default is `--auth none`. Secret values accept `$ENV{VAR}`, resolved at match time, so `drawer.json` stays commit-safe.
+
+`buttons webhook listen` runs the foreground dispatcher behind a Cloudflare tunnel, so it requires `cloudflared` on your PATH. Run `buttons webhook setup` once for a stable hostname, or let `listen` spin up an ephemeral `*.trycloudflare.com` URL per run.
+
+Test a webhook drawer without standing up the listener by synthesizing the request payload at press time:
+
+```bash
+buttons drawer on-apify-done press --webhook-body '{"datasetId":"abc"}'
+buttons drawer on-apify-done press --webhook-body @fixture.json
+```
 
 ## Inspect and debug
 

--- a/docs/concepts/arguments.mdx
+++ b/docs/concepts/arguments.mdx
@@ -13,7 +13,7 @@ Pass `--arg` once per argument during `buttons create`:
 buttons create send-alert \
   --url 'https://hooks.example.com/alert' \
   --method POST \
-  --body '{"channel": "{{channel}}", "message": "{{message}}", "urgent": {{urgent}}' \
+  --body '{"channel": "{{channel}}", "message": "{{message}}", "urgent": {{urgent}}}' \
   --arg channel:string:required \
   --arg message:string:required \
   --arg urgent:bool:optional \
@@ -22,6 +22,13 @@ buttons create send-alert \
 
 The format is `name:type:required` or `name:type:optional`.
 
+For an `enum` argument, append the allowed values as a final pipe-separated list:
+
+```bash
+buttons create deploy \
+  --arg env:enum:required:staging|prod
+```
+
 ## Supported types
 
 | Type | Accepted values |
@@ -29,8 +36,9 @@ The format is `name:type:required` or `name:type:optional`.
 | `string` | Any text |
 | `int` | Integer (e.g. `42`, `-7`) |
 | `bool` | `true` or `false` |
+| `enum` | One of a declared set, e.g. `--arg env:enum:required:staging\|prod` |
 
-Buttons validates types at press time and returns a `VALIDATION_ERROR` if the value does not match.
+Buttons validates types at press time and returns a `VALIDATION_ERROR` if the value does not match (including an `enum` value outside the declared set).
 
 ## Passing values at press time
 

--- a/docs/concepts/button-json.mdx
+++ b/docs/concepts/button-json.mdx
@@ -9,19 +9,19 @@ Every button has a `button.json` spec in its button folder. It is the source of 
 ~/.buttons/buttons/<name>/
   button.json
   main.sh | main.py | main.js
-  AGENT.md
+  AGENTS.md
   pressed/
 ```
 
-Project-local buttons use the same shape under `.buttons/buttons/<name>/`.
+Project-local buttons use the same shape under `.buttons/buttons/<name>/`. App buttons (created with `--app`) live under `apps/<name>/` instead — see [App buttons](#app-buttons). The agent prompt file is `AGENTS.md`; an older `AGENT.md` is still read as a fallback but never written.
 
 ## Example
 
 ```json
 {
-  "schema_version": 2,
-  "name": "deploy",
-  "description": "Deploy a tagged release",
+  "schema_version": 1,
+  "name": "release",
+  "description": "Ship a tagged release",
   "runtime": "shell",
   "args": [
     { "name": "env", "type": "enum", "required": true, "values": ["staging", "prod"] },
@@ -35,22 +35,27 @@ Project-local buttons use the same shape under `.buttons/buttons/<name>/`.
     }
   },
   "queue": {
-    "name": "deploys",
+    "name": "releases",
     "concurrency": 1
   }
 }
 ```
 
+Real files always carry `runtime`, `env`, `timeout_seconds`, and `mcp_enabled` even when empty or default; the example omits the zero-value ones for brevity.
+
 ## Core fields
 
 | Field | Meaning |
 | --- | --- |
-| `schema_version` | Button spec version. Newly created buttons use version `2`. |
+| `schema_version` | On-disk format counter. Currently `1`. Distinct from the packaging `version`. |
 | `name` | Kebab-case button name. |
 | `description` | One-line description surfaced by `buttons list`, `summary`, and the board. |
-| `runtime` | `shell`, `python`, `node`, `http`, or `prompt`. |
+| `kind` | `""`/`"button"` for a regular button (pressed); `"app"` for an app button under `apps/` (see [App buttons](#app-buttons)). |
+| `runtime` | `shell`, `python`, or `node`. HTTP buttons (created with `--url`) carry an empty runtime and are identified by `url`; prompt-only buttons (created with `--prompt`) use `prompt`. |
 | `args` | Typed press-time arguments. |
+| `env` | Static environment variables injected into every press. |
 | `timeout_seconds` | Default timeout for this button. |
+| `mcp_enabled` | When true, the button is exposed as a tool by `buttons mcp`. |
 | `created_at`, `updated_at` | UTC timestamps. |
 
 ## Code buttons
@@ -63,32 +68,54 @@ Arguments arrive as environment variables:
 BUTTONS_ARG_<NAME>
 ```
 
+Battery secrets arrive as `BUTTONS_BAT_<KEY>`.
+
 ## HTTP buttons
 
-HTTP buttons use `runtime: http`.
+HTTP buttons are created with `--url`. They have no `main.*` file and carry an empty `runtime`; the `url` field identifies them.
 
 | Field | Meaning |
 | --- | --- |
-| `url` | URL template created with `--url`. |
+| `url` | URL template created with `--url`. `{{arg}}` substitutes path/query/fragment only — never scheme or host. |
 | `method` | HTTP method. Defaults to `GET`. |
 | `headers` | Header templates. |
 | `body` | Request body template. |
 | `max_response_bytes` | Response body cap. Defaults to 10 MB for HTTP buttons. |
 | `allow_private_networks` | Allows loopback/RFC1918/link-local targets when true. |
-| `allowed_host` | Scheme/host lock derived at create time. Template args cannot redirect to a new host. |
+| `allowed_host` | Scheme/host lock derived from `url` at create time. Template args cannot redirect to a new host. A literal `"*"` opts out (requires `BUTTONS_ALLOW_ANY_HOST=1` at press). |
 
 ## Prompt buttons
 
-Prompt-only buttons use `runtime: prompt` and do not have a `main.*` file. Their instruction lives in `AGENT.md` and is returned in the `prompt` field when pressed.
+Prompt-only buttons use `runtime: prompt` and do not have a `main.*` file. Their instruction lives in `AGENTS.md` and is returned in the `prompt` field when pressed.
 
-Code and HTTP buttons can also carry `AGENT.md` instructions; in that case the command runs first and the prompt is attached to the result.
+Code and HTTP buttons can also carry `AGENTS.md` instructions; in that case the command runs first and the prompt is attached to the result.
+
+## App buttons
+
+App buttons set `kind: "app"` and live under `apps/<name>/` instead of `buttons/<name>/`. They are created by cloning a git URL or copying a local path:
+
+```bash
+buttons create my-app --app https://github.com/owner/repo
+```
+
+They have no `main.*` file. Instead they carry a `serve` block describing how the app builds and runs:
+
+| Field | Meaning |
+| --- | --- |
+| `type` | `"static"` (build, then serve the `output` dir) or `"dynamic"` (run a server on `$PORT`). |
+| `build` | Build command, e.g. `"pnpm install && pnpm build"`. |
+| `run` | Dynamic only — the long-running server command. |
+| `output` | Static only — the built directory to serve, e.g. `"dist"`. |
+| `port` | Dynamic only — local port. |
+
+`CreateApp` defaults `serve` to `{ "type": "static", "output": "dist" }`.
 
 ## Arguments
 
 Args are declared at create time:
 
 ```bash
-buttons create deploy \
+buttons create release \
   --arg env:enum:required:staging|prod \
   --arg version:string:required
 ```
@@ -130,16 +157,20 @@ Buttons sharing a queue name share the same slot pool. A `key` scopes that pool 
 
 ## Packaging fields
 
-Installed buttons can include package metadata:
+Installed buttons can include package metadata. Pinning is per-button: install stamps these fields into each installed `button.json` (there is no separate project manifest or lockfile).
 
 | Field | Meaning |
 | --- | --- |
 | `tags` | Groups used by `buttons install tag:<tag>`. |
-| `version` | Button content version. |
+| `version` | Button content version (semver). Required to `buttons publish` to a registry. |
 | `requires` | Other buttons to install with this one. |
 | `requires_batteries` | Battery keys the button needs. Values are never shipped. |
-| `source` | Install source reference. |
-| `content_hash` | Hash recorded at install time for drift/update checks. |
+| `source` | Install source reference (e.g. the registry URL or `local:<dir>`). |
+| `content_hash` | Hash recorded at install time for drift/update checks. Set by install tooling, never `create`. |
+
+## Triggers
+
+A button can carry a `triggers` array so it fires automatically on cron, file-watch, or webhook events. Triggers run under `buttons serve` and are managed with `buttons trigger add|list|rm`.
 
 ## Board metadata
 

--- a/docs/concepts/buttons.mdx
+++ b/docs/concepts/buttons.mdx
@@ -20,7 +20,7 @@ Each button owns:
 | --- | --- |
 | `button.json` | Name, args, runtime, timeout, metadata, and install fields. |
 | `main.*` | Optional executable code for shell, Python, or Node buttons. |
-| `AGENT.md` | Agent instructions and context for when to use the button. |
+| `AGENTS.md` | Agent instructions and context for when to use the button. |
 | `pressed/` | Per-machine run history. |
 
 Buttons live under `.buttons/buttons/<name>/` for a project or `~/.buttons/buttons/<name>/` globally.

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -3,49 +3,57 @@ title: "Folder structure"
 description: "How Buttons stores buttons, drawers, history, secrets, and runtime state."
 ---
 
-Buttons stores data under `~/.buttons/` by default. In a project initialized with `buttons init`, the active data directory is the closest `.buttons/` folder in the current directory tree.
+Buttons stores data under `~/.buttons/` by default. In a project initialized with `buttons init`, the active data directory is the closest `.buttons/` folder in the current directory tree. `BUTTONS_HOME` overrides both.
 
 Each button gets its own subdirectory with a spec file, optional code file, agent context, and run history. Drawers get the same pattern for workflow specs and workflow history.
 
 ## Directory layout
 
+`buttons init` creates `buttons/` and `drawers/` (mode `0700`). `apps/`, `idempotency/`, and `queues/` are created lazily the first time they are needed.
+
 ```
 ~/.buttons/ or .buttons/
-├── buttons.json              # project manifest; desired buttons and version policy
-├── buttons-lock.json         # resolved exact versions, hashes, and sources
-├── history.json              # local create/edit/install/update history; gitignored
+├── history.json              # local create/edit/install/update activity log; gitignored
+├── .gitignore                # written by `buttons init`
 ├── buttons/
 │   ├── deploy/
 │   │   ├── button.json       # button spec
 │   │   ├── main.sh           # script (code and file buttons)
-│   │   ├── AGENT.md          # agent instructions (agent buttons)
-│   │   └── pressed/
+│   │   ├── AGENTS.md         # agent instructions / prompt text
+│   │   └── pressed/          # one JSON per run; capped at 100, oldest pruned; gitignored
 │   │       ├── 2026-04-10T12-00-00Z.json
 │   │       └── 2026-04-10T14-32-11Z.json
 │   ├── get-user/
 │   │   ├── button.json
+│   │   ├── AGENTS.md
 │   │   └── pressed/
 │   └── summarize-pr/
 │       ├── button.json
-│       ├── AGENT.md
+│       ├── AGENTS.md
 │       └── pressed/
 ├── drawers/
 │   └── release-flow/
 │       ├── drawer.json
+│       ├── AGENTS.md
 │       └── pressed/
-├── batteries.json            # secret/env values; gitignored for project-local dirs
-├── webhook.json              # Cloudflare tunnel config; gitignored for project-local dirs
-├── idempotency/              # cached successful press results
-└── queues/                   # file-lock semaphore state
+├── apps/                     # lazy; app-kind buttons from `buttons create --app`
+│   └── site/
+│       ├── button.json       # kind=app + serve block
+│       ├── AGENTS.md
+│       └── ...               # cloned/copied app source (no main.*)
+├── batteries.json            # secret/env values; gitignored
+├── webhook.json              # Cloudflare tunnel config; gitignored
+├── idempotency/              # lazy; cached successful press results; gitignored
+└── queues/                   # lazy; file-lock semaphore state; gitignored
 ```
 
 ## button.json
 
-The spec file for a button. It describes the button type, arguments, runtime, and all other configuration. Newly created specs use `"schema_version": 2`.
+The spec file for a button. It describes the button type, arguments, runtime, and all other configuration. `schema_version` is the on-disk format counter — currently `1`, and distinct from the package `version` field.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "name": "deploy",
   "description": "Deploy a tagged release to an environment",
   "runtime": "shell",
@@ -57,7 +65,7 @@ The spec file for a button. It describes the button type, arguments, runtime, an
 }
 ```
 
-See [button.json](/concepts/button-json) for every field, including HTTP host locks, queues, output schemas, package metadata, and required batteries.
+See [button.json](/concepts/button-json) for every field, including HTTP host locks, queues, output schemas, the installed-package pin (`source` / `version` / `content_hash`), and required batteries.
 
 ## drawer.json
 
@@ -76,31 +84,31 @@ The workflow spec for a drawer. It stores inputs, steps, refs, triggers, return 
 
 See [drawer.json](/concepts/drawer-json) for the full workflow schema.
 
-## buttons.json and buttons-lock.json
+## Installed buttons and pinning
 
-`buttons.json` at the root of `.buttons/` declares the desired project buttons and version policy.
+There is no project-level manifest or lockfile. When you install a button with `buttons install <name>` (from `$BUTTONS_REGISTRY_URL`, or from a local directory via `--source`), the pin is written **into that button's own `button.json`**: `source` (where it came from), `version`, and `content_hash` (a SHA256 over the installed files). Each installed button carries its own provenance — that per-button stamp *is* the lock. Dependencies declared in `requires` are installed transitively from the same source.
 
-`buttons-lock.json` records the exact resolved versions, sources, and content hashes. Commit it with `buttons.json` so teammates can recreate the same installed buttons.
+To share buttons with a team, commit their folders under `buttons/` (and `drawers/`). Anyone who clones the repo gets the same specs, code, `AGENTS.md`, and pins. To push a button to a registry or a local source, use `buttons publish @desk/<name>` — registry publish needs a scoped `@desk/name` and a `version` in `button.json`, and pins immutable versions.
 
 ## history.json
 
-`history.json` records local create, edit, install, update, delete, rollback, and failed resolution events. Commands write explicit events; file hooks can record manual edits to tracked button and drawer files.
+`history.json` records local create, edit, install, update, delete, and rollback events. It is a per-machine audit log and is gitignored.
 
-In a team repo, commit `buttons.json`, `buttons-lock.json`, and authored button/drawer files. Do not commit `history.json`; it is a local runtime artifact.
-
-When installed buttons are generated entirely from a registry, the repo can recreate them from the manifest and lock file. When a button is authored directly in the project, commit its folder under `buttons/`.
+Commit the authored button and drawer folders — their `button.json` / `drawer.json` specs, code files, and `AGENTS.md`. Do **not** commit `history.json`, `batteries.json`, `webhook.json`, or the `pressed/` run traces; the `.gitignore` written by `buttons init` already excludes them.
 
 ## main.\*
 
-The script file for [code buttons](/buttons/code). The extension matches the runtime: `main.sh` for shell, `main.py` for Python, `main.js` for Node. HTTP and prompt-only buttons do not have a `main.*` file.
+The script file for [code buttons](/buttons/code). The extension matches the runtime: `main.sh` for shell, `main.py` for Python, `main.js` for Node. HTTP, prompt-only, and app buttons do not have a `main.*` file.
 
-## AGENT.md
+## AGENTS.md
 
-Present on every button. For [prompt buttons](/buttons/prompt), contains the raw instruction text stored at create time via `--prompt`; when pressed, the contents are returned in the `prompt` field of the JSON output. For other button types, AGENT.md holds notes and context an agent can read to understand when and how to press the button.
+Present on every button (and drawer). For [prompt buttons](/buttons/prompt), it contains the raw instruction text stored at create time via `--prompt`; when pressed, the contents are returned in the `prompt` field of the JSON output. For other button types, `AGENTS.md` holds notes and context an agent can read to understand when and how to press the button.
+
+Units created before the rename may have a singular `AGENT.md`; it is still read as a legacy fallback, but every write uses `AGENTS.md`.
 
 ## pressed/
 
-One JSON file per run, named by timestamp. Each file records the input arguments, exit code, stdout, stderr, duration, and whether the run succeeded.
+One JSON file per run, named by UTC timestamp. Each file records the input arguments, exit code, stdout, stderr (each truncated to 1 MB), duration, and status. The directory is capped at 100 runs — the oldest are pruned — and is gitignored because run traces may contain press-time argument values.
 
 ```json
 {
@@ -114,9 +122,13 @@ One JSON file per run, named by timestamp. Each file records the input arguments
 }
 ```
 
+## apps/
+
+Lazily created the first time you run `buttons create --app <git-url|path>`. The app source is cloned (shallow, `.git` dropped) or copied here alongside a `button.json` with `kind: "app"` and a `serve` block. App buttons have no `main.*` file.
+
 ## batteries.json
 
-Batteries are key/value pairs injected into button presses as `BUTTONS_BAT_<KEY>`.
+Batteries are key/value pairs injected into button presses as `BUTTONS_BAT_<KEY>`. Keys must match `[A-Z][A-Z0-9_]*`.
 
 Project-local batteries live at `.buttons/batteries.json`. Global batteries live at `~/.buttons/batteries.json`. Local values override global values on key collision.
 
@@ -126,11 +138,11 @@ Named webhook setup stores Cloudflare tunnel configuration in `webhook.json`. It
 
 ## idempotency/
 
-Successful presses with `--idempotency-key` are cached here until their TTL expires.
+Successful presses with `--idempotency-key` are cached here until their TTL expires. Created lazily.
 
 ## queues/
 
-Buttons with a `queue` declaration use file locks here to enforce concurrency limits.
+Buttons with a `queue` declaration use file locks here to enforce concurrency limits. Created lazily.
 
 ## Overriding the home directory
 
@@ -143,7 +155,7 @@ BUTTONS_HOME=/tmp/test-buttons buttons create test-btn --code 'echo ok' --runtim
 This is useful in CI, tests, or container environments where you want an isolated state directory.
 
 <Note>
-The `~/.buttons/` directory and all files inside it are created with mode `0700` / `0600`. Other users on the same system cannot read button specs or run history.
+The `~/.buttons/` directory and the files inside it are created with restrictive permissions (`0700` for directories, `0600` for secret files). Other users on the same system cannot read button specs or run history.
 </Note>
 
 ## Related

--- a/docs/concepts/history.mdx
+++ b/docs/concepts/history.mdx
@@ -1,25 +1,27 @@
 ---
 title: "History"
-description: "Local audit history for button creates, edits, installs, updates, and rollbacks."
+description: "Local audit log for button creates, edits, installs, and updates."
 ---
 
 `history.json` is the local audit log for a Buttons workspace.
 
-It records two kinds of changes:
+It records workspace mutations:
 
-- command-driven changes, like `buttons create`, `buttons install`, `buttons update`, `buttons delete`, and rollback
-- file-hook changes, like editing `button.json`, `main.sh`, `AGENT.md`, `drawer.json`, `buttons.json`, or `buttons-lock.json` directly
+- command-driven changes, like `buttons create`, `buttons install`, `buttons update`, and `buttons delete`
+- manual or agent edits to a button or drawer spec (`button.json`, `main.*`, `AGENTS.md`, `drawer.json`) outside a Buttons command
+
+It is a single top-level file and is **gitignored** — auditability is per-machine.
 
 ```text
 .buttons/
-  buttons.json
-  buttons-lock.json
-  history.json
   buttons/
   drawers/
+  history.json   # local audit log (gitignored)
 ```
 
 ## Event shape
+
+Each event looks roughly like this (an `install`):
 
 ```json
 {
@@ -29,7 +31,7 @@ It records two kinds of changes:
       "at": "2026-06-28T18:42:10Z",
       "action": "install",
       "target": "button:slack-sync",
-      "source": "git+https://github.com/autonoco/autono-buttons@main",
+      "source": "$BUTTONS_REGISTRY_URL",
       "from_version": null,
       "to_version": "1.2.4",
       "from_hash": null,
@@ -42,34 +44,30 @@ It records two kinds of changes:
 
 ## Actions
 
-History should record:
+History records:
 
 | Action | Cause |
 | --- | --- |
 | `create` | A button or drawer is created. |
-| `edit` | A tracked button, drawer, manifest, or lock file changes. |
+| `edit` | A tracked button or drawer spec changes (manual or agent edit). |
 | `delete` | A button or drawer is removed. |
-| `install` | A registry or source installs a button. |
-| `update` | An installed button resolves to a newer version/hash. |
-| `rollback` | A button is restored to an earlier locked version. |
-| `resolve_failed` | Registry/source resolution fails. |
+| `install` | A button is installed from a `--source` directory or the registry. |
+| `update` | An installed button — or the CLI itself (`buttons update`) — resolves to a newer version/hash. |
 
-## File-hook tracking
+## What's tracked
 
-Commands should write explicit history events when they mutate state. File hooks should catch manual edits and agent edits that happen outside a Buttons command.
+Commands write history events when they mutate state. Manual or agent edits to a spec file are captured as a single (debounced) `edit` event with a before/after content hash.
 
-The watcher should track:
+Tracked paths:
 
 ```text
-.buttons/buttons.json
-.buttons/buttons-lock.json
 .buttons/buttons/*/button.json
 .buttons/buttons/*/main.*
-.buttons/buttons/*/AGENT.md
+.buttons/buttons/*/AGENTS.md
 .buttons/drawers/*/drawer.json
 ```
 
-The watcher should ignore runtime and secret-bearing files:
+Ignored (runtime and secret-bearing):
 
 ```text
 .buttons/history.json
@@ -81,26 +79,21 @@ The watcher should ignore runtime and secret-bearing files:
 .buttons/queues/**
 ```
 
-For each file-hook event, Buttons can compute a before/after content hash and append one debounced `edit` event.
-
 ## Commit policy
 
 Commit:
 
-- `.buttons/buttons.json`
-- `.buttons/buttons-lock.json`
-- authored button and drawer files
+- your authored button and drawer specs — `button.json`, `drawer.json`, the code file, and `AGENTS.md`
 
 Do not commit:
 
 - `.buttons/history.json`
-- pressed run history
-- batteries or webhook config
+- pressed run history (`buttons/*/pressed/`, `drawers/*/pressed/`)
+- `batteries.json`, `webhook.json`, `idempotency/`, `queues/`
 
-The lock file gives the team shared reproducibility. `history.json` gives each machine local auditability.
+There is no separate dependency manifest or lockfile. An installed button is pinned **in place**: each installed `button.json` carries `source`, `version`, and `content_hash` (the SHA256 of its content at install time). Committing the button commits its pin, so a teammate gets the same version and content hash on checkout. `history.json` stays local — it is each machine's own audit trail.
 
 ## Related
 
 - [Registry](/concepts/registry)
-- [Hook triggers](/buttons/hook)
 - [Folder structure](/concepts/folder-structure)

--- a/docs/concepts/json-output.mdx
+++ b/docs/concepts/json-output.mdx
@@ -48,7 +48,7 @@ Every response is a JSON object with an `ok` boolean at the top level.
 }
 ```
 
-The shape of `data` varies by command, but `ok`, `error.code`, and `error.message` are always present and stable.
+The shape of `data` varies by command, but `ok` is always present, and on a failure `error.code` and `error.message` are always present and stable. Some errors also carry two optional fields: `error.hint` (a recovery suggestion, e.g. the exact command to run) and `error.spec` (structured context). Both are omitted when empty.
 
 ## Error codes
 
@@ -60,8 +60,11 @@ The shape of `data` varies by command, but `ok`, `error.code`, and `error.messag
 | `TIMEOUT` | The button execution exceeded its timeout |
 | `SCRIPT_ERROR` | The subprocess exited with a non-zero exit code |
 | `RUNTIME_MISSING` | The required interpreter (`python3`, `node`, etc.) is not on `$PATH` |
+| `QUEUE_TIMEOUT` | The press waited too long for a free slot in the button's concurrency queue |
 | `INTERNAL_ERROR` | An unexpected error inside the Buttons runtime |
-| `NOT_IMPLEMENTED` | The command or feature is not yet available in this version |
+| `KIND_NOT_IMPLEMENTED` | A drawer step used a step kind not yet implemented in the v1 executor |
+
+This is the common subset. Individual commands surface their own codes — for example `AMBIGUOUS` (`drawer connect`), `IMPORT_ERROR` (`import`), `INSTALL_ERROR` / `PUBLISH_ERROR` (registry), `DNS_CONFLICT` / `ZONE_MISMATCH` (`webhook setup`), and `NOT_APPLICABLE` (`board --json`).
 
 ## Checking exit codes
 

--- a/docs/concepts/registry.mdx
+++ b/docs/concepts/registry.mdx
@@ -1,122 +1,112 @@
 ---
 title: "Registry"
-description: "How Buttons resolves, installs, locks, and updates shared buttons."
+description: "How Buttons resolves, installs, pins, and publishes shared buttons."
 ---
 
 A registry is a catalog of installable buttons. It answers: "What buttons are available, what versions exist, what tags do they belong to, and what content hash should I install?"
 
-The registry does not contain runnable local buttons. Runnable buttons live in `.buttons/buttons/`. Desired dependencies live in `.buttons/buttons.json`; exact resolved versions live in `.buttons/buttons-lock.json`.
+The registry does not contain runnable local buttons. Runnable buttons live in `.buttons/buttons/`. Install copies a button out of a registry into that directory and stamps where it came from. There is **no project-level dependency manifest and no lockfile** — pinning is recorded **per button**, inside each installed `button.json`, as the `source`, `version`, and `content_hash` fields.
 
 ```text
 .buttons/
-  buttons.json
-  buttons-lock.json
-  history.json
+  history.json          # local activity log (gitignored)
   buttons/
     slack-sync/
-      button.json
+      button.json       # carries source / version / content_hash after install
       main.sh
-      AGENT.md
+      AGENTS.md
 ```
 
-## buttons.json
+## Two backends, one interface
 
-`buttons.json` is the project manifest. It lives at the root of `.buttons/` and is committed with the repo.
+The CLI codes against a swappable `Source` (read) / `Publisher` (write) interface, so the same `install` / `publish` path works against either backend:
 
-It declares trusted registries and desired buttons:
+| Backend | When | Read | Write |
+|---|---|---|---|
+| **Hosted registry** (HTTP, a Cloudflare Worker) | `$BUTTONS_REGISTRY_URL` is set | `install` | `publish` |
+| **Local directory** | `--source <dir>` or `$BUTTONS_SOURCE` | `install` | `publish` |
 
-```json
-{
-  "schema_version": 1,
-  "default_registry": "autono",
-  "registries": {
-    "autono": {
-      "type": "git",
-      "url": "https://github.com/autonoco/autono-buttons",
-      "ref": "main"
-    }
-  },
-  "dependencies": {
-    "imessage-sync": "latest",
-    "slack-sync": {
-      "version": "^1.2.0",
-      "auto_update": true
-    },
-    "plaid-sync": {
-      "version": "1.4.2",
-      "auto_update": false
-    }
-  }
-}
+The base URL is taken from `$BUTTONS_REGISTRY_URL` (trailing `/` trimmed). This repo is public, so docs never name a real host — substitute your own registry URL, or use a placeholder like `registry.example`.
+
+## Scoped names: `@desk/name`
+
+Registry identity is a **scoped name** of the form `@scope/name` (commonly `@desk/name`):
+
+- It must start with `@`, have a non-empty scope after `@`, and a single-segment name after `/`. `@/x`, `@desk/`, and `@desk/a/b` are rejected.
+- The scope is **registry identity only** — it is **not stored on disk**. On disk the button is found by its bare local name (e.g. `slack-sync`); `install` stamps the full scoped name back into the installed `button.json`.
+- In URLs the scope slash is preserved, so the path is `/v1/buttons/@desk/name` (two real segments), not an opaque escaped blob.
+
+## Auth: bearer + the battery split
+
+All hosted-registry requests are bearer-authed (`Authorization: Bearer <key>`). Read and write use **two distinct keys** stored as [batteries](/cli/buttons_batteries):
+
+| Operation | Battery | Press-time env override (wins) |
+|---|---|---|
+| `install` (read) | `REGISTRY_KEY` | `$BUTTONS_BAT_REGISTRY_KEY` |
+| `publish` (write) | `REGISTRY_WRITE_KEY` | `$BUTTONS_BAT_REGISTRY_WRITE_KEY` |
+
+```bash
+buttons batteries set REGISTRY_KEY <read-key>
+buttons batteries set REGISTRY_WRITE_KEY <write-key>
 ```
 
-The simple string form is enough for most buttons. The object form keeps room for per-button options like `auto_update`, channels, constraints, or rollout policy.
-
-## buttons-lock.json
-
-`buttons-lock.json` is the resolved lock file. It lives next to `buttons.json` and should be committed with the repo.
-
-```json
-{
-  "schema_version": 1,
-  "buttons": {
-    "slack-sync": {
-      "registry": "autono",
-      "source": "git+https://github.com/autonoco/autono-buttons@main",
-      "requested": "^1.2.0",
-      "version": "1.2.4",
-      "content_hash": "sha256:4f8c...",
-      "resolved_at": "2026-06-28T18:42:10Z"
-    }
-  }
-}
-```
-
-`buttons.json` is the desired state. `buttons-lock.json` is the exact resolved state.
-
-```text
-buttons.json          semver ranges, latest, registry config, auto_update policy
-buttons-lock.json     exact versions, hashes, resolved sources
-```
-
-This follows the same shape as package manifests and lock files: ranges are human-authored, exact versions are machine-resolved and committed for repeatability.
-
-## history.json
-
-`history.json` is local and should not be committed. It records what happened on one machine over time: creates, edits, installs, updates, rollbacks, deletes, and failed registry fetches.
-
-See [History](/concepts/history) for the event model.
+A missing key produces a precise error naming the exact `buttons batteries set …` command to run. Local-directory sources need no key.
 
 ## Install Flow
 
-When registry-backed install runs, Buttons should:
+`buttons install <name | name@version | tag:<x>>`.
 
-1. Read `.buttons/buttons.json` for registries, desired buttons, and version policy.
-2. Resolve the requested button, version, or tag from the configured registry.
-3. Fetch the button bundle, including `button.json`, `main.*`, `AGENT.md`, and support files.
-4. Install the runnable copy into `.buttons/buttons/<name>/`.
-5. Install required peer buttons from `requires`.
-6. Stamp `source`, `version`, and `content_hash` into the installed `button.json`.
-7. Update `.buttons/buttons-lock.json` with exact resolved versions and hashes.
-8. Append an event to `.buttons/history.json`.
+**Source resolution order:**
 
-## Resolution
+1. `--source <dir>` or `$BUTTONS_SOURCE` → local directory (dev wins).
+2. else `$BUTTONS_REGISTRY_URL` (with `REGISTRY_KEY`) → hosted registry.
+3. else error.
 
-Install requests can target a button, a pinned version, or a tag:
+Then install:
+
+1. Resolve the request: bare `name` → latest; `name@version` → that pinned version; `tag:<x>` → every catalog button carrying that tag.
+2. Fetch the button bundle (`button.json`, `main.*`, `AGENTS.md`, support files).
+3. Install the runnable copy into `.buttons/buttons/<name>/`.
+4. Install the dependency closure: each button's `button.json` `requires` is installed transitively from the same source (the version pin applies only to the explicitly-named root).
+5. Stamp `source`, `version`, and `content_hash` into each installed `button.json`. This per-button record **is** the pin.
+6. Append an event to `.buttons/history.json`.
 
 ```bash
-buttons install slack-sync
-buttons install slack-sync@1.2.0
-buttons install tag:autono-cal
+buttons install slack-sync          # latest
+buttons install slack-sync@1.2.0    # pinned version
+buttons install tag:autono-cal      # every button carrying this tag
 ```
 
-The intended source resolution order is:
+### Hardening on the way in
 
-1. `--source`, for explicit one-off local installs.
-2. `BUTTONS_SOURCE`, for a local default source.
-3. `.buttons/buttons.json`, for the project team contract.
+A registry is treated as untrusted. Bundles are size-capped (64 MiB compressed, 256 MiB uncompressed, 4096 files); extraction strips the single top-level wrapper dir, skips `pressed/`, `._*`, and `.DS_Store`, and rejects absolute or `../` paths. Every write path is re-validated against the button dir **before** any directory is created, so a rejected bundle leaves nothing partial.
 
-## Source Layout
+## Publish Flow
+
+`buttons publish <name | @desk/name>` is the inverse of install. Target resolution mirrors install:
+
+1. `--source <dir>` / `$BUTTONS_SOURCE` → local directory (a dev round-trip).
+2. else `$BUTTONS_REGISTRY_URL` (with `REGISTRY_WRITE_KEY`) → hosted registry.
+
+Publishing to the hosted registry:
+
+- Requires a **scoped** `@desk/name` (a bare name errors).
+- Requires a `version` in the button's `button.json` (versions are immutable; re-publishing the same `name@version` is rejected).
+- Bundles only `button.json` + code + `AGENTS.md` — **never** `pressed/` run history.
+- `--kind button|drawer` sets the catalog entry kind (default `button`); a drawer is publishable as a registry entry via this flag.
+
+If neither `--source`/`$BUTTONS_SOURCE` nor `$BUTTONS_REGISTRY_URL` is set, `publish` errors with "no publish target" — there is no default public registry baked in.
+
+## Content-hash pinning
+
+There are **two different hashes**; keep them straight:
+
+1. **Tarball hash** — `sha256` of the gzip bytes. It travels in the `X-Content-Sha256` header and the index `sha256` field, and is **what install verifies** before extracting: the downloaded bytes must equal it, or install hard-errors and writes nothing.
+2. **File-content hash** — computed over the extracted files (sorted, `name\x00len\x00bytes`). This is what gets **stamped into the installed `button.json` as `content_hash`**, the drift/update pin.
+
+Archives are deterministic — `publish` sorts filenames, zeroes mod-times, and fixes file mode — so identical content always yields an identical tarball hash on the round-trip from publish → registry → install.
+
+## Local source layout
 
 A local registry source is a directory of button folders:
 
@@ -125,17 +115,31 @@ button-source/
   slack-sync/
     button.json
     main.sh
-    AGENT.md
+    AGENTS.md
   calendar-sync/
     button.json
     main.sh
-    AGENT.md
+    AGENTS.md
 ```
 
-Each button folder must include `button.json`. Support files are copied into the installed button.
+Each button folder must include `button.json`; support files are copied into the installed button. The same directory is both a read source (`buttons install --source <dir>`) and a write target (`buttons publish --source <dir>`).
+
+## HTTP registry contract
+
+A hosted registry implements three routes (the Worker is the other half of the client). Errors on any route use the envelope `{ "error": { "code": "...", "message": "..." } }`.
+
+- `GET /v1/index` — catalog. Returns a JSON array of entries `{ name, kind, version, tags, sha256 }`, where `sha256` is the tarball hash. **Latest = the last entry for a given name.**
+- `GET /v1/buttons/<@desk/name>/<version>/download` — fetch the gzip tarball (`application/gzip`); should set `X-Content-Sha256` so the client can verify without a prior index round-trip.
+- `POST /v1/buttons/<@desk/name>/<version>` — publish. Body is the gzip tarball; headers `Content-Type: application/gzip`, `X-Content-Sha256: <sum>` (re-verified server-side), `X-Button-Kind: button|drawer`. Versions are immutable. Success is `200` or `201`.
+
+## history.json
+
+`history.json` is local and should not be committed. It records what happened on one machine over time: creates, edits, installs, updates, deletes, and failed registry fetches. See [History](/concepts/history) for the event model.
 
 ## Related
 
 - [History](/concepts/history)
 - [button.json](/concepts/button-json)
+- [Batteries](/cli/buttons_batteries)
 - [buttons install](/cli/buttons_install)
+- [buttons publish](/cli/buttons_publish)

--- a/docs/concepts/templates.mdx
+++ b/docs/concepts/templates.mdx
@@ -3,7 +3,11 @@ title: "URL and body templates"
 description: "How {{arg}} placeholders work in HTTP buttons with context-aware encoding."
 ---
 
-HTTP buttons use `{{name}}` placeholders in the URL, headers, and request body. When you press the button, each placeholder is replaced with the corresponding argument value. The substitution is context-aware: the encoding applied depends on where in the request the placeholder appears.
+HTTP buttons use `{{name}}` placeholders in the URL and request body. When you press the button, each placeholder is replaced with the corresponding argument value. The substitution is context-aware: the encoding applied depends on where in the request the placeholder appears.
+
+<Note>
+Placeholders are only allowed in the **path, query, and fragment** of the URL — never in the scheme or host. A host- or scheme-templated URL is rejected when the button is created, because letting an argument choose the target host would defeat host-locking. The scheme+host prefix is therefore never substituted at press time.
+</Note>
 
 ## How substitution works
 
@@ -11,11 +15,14 @@ At press time, Buttons walks the URL and body and replaces every `{{name}}` with
 
 | Location | Encoding |
 |---|---|
-| URL path segment (before `?`) | `url.PathEscape` |
+| URL path segment (after the host, before `?`) | `url.PathEscape` |
 | URL query parameter (after `?`) | `url.QueryEscape` |
-| JSON body (`Content-Type: application/json`) | JSON string escape (`\"`, `\\`, control chars) |
+| URL fragment (after `#`) | `url.PathEscape` |
+| JSON body (`Content-Type: application/json`, `text/json`, or unset) | JSON string escape (`\"`, `\\`, control chars) |
 | Form body (`Content-Type: application/x-www-form-urlencoded`) | `url.QueryEscape` |
-| Other body types | Raw (no encoding) |
+| Any other body `Content-Type` | Raw (no encoding) |
+
+The body's `Content-Type` is matched case-insensitively, and any `; charset=...` suffix is ignored. When no `Content-Type` header is set, the body is treated as JSON.
 
 ## Examples
 
@@ -57,15 +64,15 @@ JSON string escaping turns the quotes and commas into escape sequences, preventi
 
 ## Headers
 
-Header values also support `{{arg}}` substitution but are not encoded — they are passed as-is. This is appropriate for values like bearer tokens and API keys where encoding would break the value.
+Header values are **static** — `{{arg}}` substitution is **not** applied to them. Whatever you set with `--header "Key: Value"` is sent verbatim, so a header containing `{{token}}` would be transmitted with that literal text, not an argument value. Put fixed values like bearer tokens and API keys directly in the header; only the URL and body are templated.
 
 <Note>
-If you need to pass a literal `{{` or `}}` in a URL or body, escape it as `\{{` and `\}}`.
+A `{{name}}` that doesn't match any declared argument is left in the output unchanged — there is no separate escape syntax for literal double braces. If you need a literal `{{` in a URL or body, just don't declare an argument by that name.
 </Note>
 
 ## Raw body types
 
-For bodies with a `Content-Type` other than `application/json` or `application/x-www-form-urlencoded`, Buttons inserts values without encoding. Use this only when you control the full body format and know the values are safe.
+For bodies with a `Content-Type` other than `application/json`, `text/json`, or `application/x-www-form-urlencoded`, Buttons inserts values without encoding. Use this only when you control the full body format and know the values are safe.
 
 <Warning>
 Raw substitution provides no injection protection. If the body format has its own injection risks (e.g. XML, LDAP query syntax), validate or sanitize argument values before they reach the button.

--- a/docs/concepts/triggers.mdx
+++ b/docs/concepts/triggers.mdx
@@ -5,37 +5,51 @@ description: "Automatic ways to run buttons and drawers."
 
 A trigger runs a button or drawer when something happens.
 
-Triggers let Buttons move from manual commands to durable automation: webhooks for remote events, cron for schedules, and hooks for local events.
+Triggers let Buttons move from manual commands to durable automation: webhooks for remote events, cron for schedules, and file watches for local changes.
 
-```bash
-buttons trigger webhook linkedin-sync /linkedin-sync
-buttons trigger cron slack-sync "0 */2 * * *"
-buttons trigger hook docs-sync --enable "file:docs/**/*.md"
-```
+There are **two trigger layers**, because a trigger fires either a single **button** or a whole **drawer**, and each runs under its own long-running command.
 
 ## Trigger kinds
 
-| Kind | Cause | Example |
-| --- | --- | --- |
-| Webhook | A remote service sends an HTTP request. | GitHub, Stripe, Linear |
-| Cron | A schedule fires. | nightly sync, hourly digest |
-| Hook | A local event fires. | file changed, Git commit, button completed |
+| Kind | Fires | Cause | Runner |
+| --- | --- | --- | --- |
+| Cron | button | A 5-field schedule fires (`0 */6 * * *`). | `buttons serve` |
+| Watch | button | A watched file changes (polled every 500 ms). | `buttons serve` |
+| Webhook | button | A remote service POSTs to a path on the serve listener. | `buttons serve` |
+| Webhook | drawer | A remote service POSTs to a path on the webhook listener. | `buttons webhook listen` |
 
-## Target model
+## Button triggers
 
-A trigger targets a button or drawer. If it targets a button, Buttons can wrap it as a one-step drawer internally so the workflow runtime stays consistent.
+`buttons trigger add <button>` attaches a trigger to one button. Exactly one of `--cron`, `--watch`, or `--webhook` is required. These fire while `buttons serve` (the local REST API server) is running — its in-process engine runs the cron and file-watch triggers and mounts webhook trigger routes on the same listener. Skip the engine with `buttons serve --no-triggers`.
 
-```text
-event -> trigger -> drawer -> button steps
+```bash
+buttons trigger add slack-sync --cron --schedule "0 */2 * * *"
+buttons trigger add docs-sync --watch --path docs/notes.md
+buttons trigger add linkedin-sync --webhook --webhook-path /hooks/linkedin --token "$SECRET"
+buttons trigger list slack-sync
+buttons trigger rm slack-sync <trigger-id>
 ```
 
-## Current status
+Pass `--arg KEY=VALUE` (repeatable) to set the args the press receives when the trigger fires. Webhook auth at this layer is a single shared token: when `--token` is set, the request must carry it as the `X-Buttons-Token` header or a `?token=` query param. The POST **body is not mapped into args** — v1 uses the trigger's configured `--arg` values. The endpoint presses asynchronously and returns `202 Accepted`.
 
-Webhook-triggered drawers are implemented today. The unified `buttons trigger ...` command is the intended surface for webhook, cron, and hook triggers.
+## Drawer triggers
+
+`buttons drawer <name> trigger webhook [PATH]` attaches a webhook trigger to a drawer (default path `/<drawer-name>`). These fire under `buttons webhook listen`, a foreground dispatcher that — unless you pass `--no-tunnel` — runs behind a Cloudflare tunnel so third-party services can reach it. `webhook` is the only drawer trigger kind implemented today.
+
+```bash
+buttons drawer linkedin-sync trigger webhook /linkedin-sync
+buttons webhook listen
+```
+
+Drawer webhook auth mirrors n8n's four modes — `--auth none|basic|header|jwt` (with `--auth-user/--auth-pass`, `--auth-header-name/--auth-header-value`, or `--jwt-secret` and friends). Secret values accept `$ENV{VAR}` so `drawer.json` stays commit-safe. Unlike button triggers, the incoming POST **is** materialized into the drawer as `${inputs.webhook.body}` (plus `headers`, `query`, `method`, `path`, `received_at`).
+
+## Status
+
+Button cron, watch, and webhook triggers are shipped and run under `buttons serve`. Drawer webhook triggers are shipped and run under `buttons webhook listen`. Drawer `cron`/`file`/`mcp` trigger kinds are reserved in the schema but not yet implemented.
 
 ## Related
 
-- [Trigger guide](/buttons/triggers)
+- [Trigger commands](/buttons/triggers)
 - [Webhook](/buttons/webhook)
 - [Cron](/buttons/cron)
 - [Hook](/buttons/hook)

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -12,7 +12,9 @@ ghcr.io/autonoco/buttons:latest
 ghcr.io/autonoco/buttons:v0.1.0   # pinned version
 ```
 
-- **Base:** Alpine Linux
+- **Base:** Alpine Linux 3.20 (with `ca-certificates` + `tzdata`) — ~12 MB
+- **Runs as:** non-root user `buttons` (UID 1000), `WORKDIR /home/buttons`
+- **Entrypoint:** the `buttons` binary, so `docker run … <verb>` runs that command; bare `docker run …` defaults to `--help`
 - **Shell available:** `/bin/sh` — shell buttons work out of the box
 - **Python / Node:** not included — add via `apk add` in your derived image
 - **Architectures:** `linux/amd64`, `linux/arm64`
@@ -51,16 +53,18 @@ State created inside the container is discarded when the container exits.
 
 ## Pattern 3: Volume-mounted state
 
-Persist button state and run history to the host by mounting `~/.buttons`:
+Persist button state and run history to the host by mounting the data dir. The image runs as the non-root user `buttons` (UID 1000), so its `~/.buttons` resolves to `/home/buttons/.buttons` — mount there, not `/root`:
 
 ```bash
 docker run --rm \
-  -v "$HOME/.buttons:/root/.buttons" \
+  -v "$HOME/.buttons:/home/buttons/.buttons" \
   ghcr.io/autonoco/buttons:latest \
-  press deploy --arg env=staging --arg version=v1.4.2
+  press db-backup --arg env=staging --arg retention=7d
 ```
 
 This lets you manage buttons on the host and invoke them from containers, or share state between multiple containers.
+
+The mounted directory must be writable by UID 1000. If your host user has a different UID, either `chown` the directory to `1000` or add `--user "$(id -u)"` to the `docker run` invocation (combine with `-e BUTTONS_HOME=/home/buttons/.buttons` so the data dir is found regardless of that user's home).
 
 ## Adding Python or Node to a derived image
 

--- a/docs/deployment/install-script.mdx
+++ b/docs/deployment/install-script.mdx
@@ -3,13 +3,25 @@ title: "Install script"
 description: "How the install.sh script works and its configuration options."
 ---
 
-`install.sh` is a POSIX-compatible shell script that fetches the correct Buttons binary for your platform, verifies its integrity, and installs it. It works on macOS, Linux, Alpine, and BusyBox-based environments — anywhere `/bin/sh` is available.
+`install.sh` is a POSIX `sh` script that fetches the correct Buttons binary for your platform, verifies its integrity against the release `checksums.txt`, and installs it. It works on macOS and Linux — anywhere `/bin/sh` is available, including Alpine, Debian slim, and other BusyBox-based container images.
 
 ## Basic usage
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh | sh
 ```
+
+<Note>
+While the `autonoco/buttons` repository is private, the script downloads release
+assets through the authenticated GitHub API, so you must export a `GITHUB_TOKEN`
+with `contents:read` scope first. Once the repository is public this token
+becomes optional (it only raises the API rate limit).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh \
+  | GITHUB_TOKEN=$GH_TOKEN sh
+```
+</Note>
 
 ## Configuration via environment variables
 
@@ -22,32 +34,32 @@ curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh \
 
 | Variable | Default | Description |
 |---|---|---|
-| `BUTTONS_VERSION` | Latest release | Pin to a specific version tag (e.g. `v0.1.0`) |
-| `BUTTONS_INSTALL_DIR` | `/usr/local/bin` | Directory to install the `buttons` binary |
-| `GITHUB_TOKEN` | _(none)_ | GitHub personal access token for private repos or to avoid rate limits |
+| `BUTTONS_VERSION` | `latest` | Pin to a specific release tag (e.g. `v0.1.0`). `latest` resolves the newest release via the GitHub API. |
+| `BUTTONS_INSTALL_DIR` | `/usr/local/bin` | Directory to install the `buttons` binary. |
+| `GITHUB_TOKEN` | _(none)_ | GitHub token sent as `Authorization: Bearer`. Required while the repo is private (`contents:read` scope); optional afterward to avoid API rate limits. |
 
 ## What the script does
 
 <Steps>
 
 <Step title="Detect platform">
-The script identifies your OS (`darwin`, `linux`) and architecture (`amd64`, `arm64`) using `uname`. It exits with an error if the combination is unsupported.
+The script identifies your OS and architecture with `uname`. OS maps to `darwin` or `linux` (Windows is unsupported and errors out). Architecture maps to `x86_64` (accepting the `amd64` alias) or `arm64` (accepting `aarch64`). The supported targets are `darwin/arm64`, `darwin/x86_64`, `linux/arm64`, and `linux/x86_64`; any other combination exits with an error.
 </Step>
 
 <Step title="Resolve version">
-If `BUTTONS_VERSION` is not set, the script calls the GitHub Releases API to find the latest release tag. It passes `GITHUB_TOKEN` in the `Authorization` header if set.
+If `BUTTONS_VERSION` is `latest` (the default), the script calls the GitHub Releases API to find the newest release tag. Otherwise it uses your pinned tag as-is. Requests send `GITHUB_TOKEN` in the `Authorization` header when set.
 </Step>
 
 <Step title="Download archive">
-Downloads the matching `.tar.gz` archive and its `.sha256` checksum file from the GitHub Release assets.
+The script looks up the asset IDs for `buttons_<version>_<os>_<arch>.tar.gz` (the leading `v` is stripped to match the goreleaser numeric naming, e.g. `buttons_0.1.0_darwin_arm64.tar.gz`) and the release-wide `checksums.txt`, then downloads both by ID through `/releases/assets/<id>` with `Accept: application/octet-stream`. Going through the API (rather than a direct asset URL) is what lets the download work against a private repo.
 </Step>
 
 <Step title="Verify SHA256">
-Computes the SHA256 of the downloaded archive and compares it to the published checksum. The script exits immediately if they do not match — no binary is installed.
+The script reads the expected hash for the archive out of `checksums.txt`, computes the actual SHA256 with `sha256sum` (or `shasum -a 256` as a fallback), and compares them. On any mismatch — or a missing checksum entry — it exits immediately and installs nothing.
 </Step>
 
 <Step title="Extract and install">
-Extracts the `buttons` binary and copies it to `BUTTONS_INSTALL_DIR`. Uses `sudo` only if the target directory exists but is not writable by the current user.
+Extracts only the `buttons` binary from the archive and installs it with `install -m 0755` into `BUTTONS_INSTALL_DIR`. If that directory is not writable it retries with `sudo`; if `sudo` is unavailable it errors and tells you to point `BUTTONS_INSTALL_DIR` at a writable path. Afterward it runs the installed binary's `--version` as a sanity check and warns if the install directory is not on your `$PATH`.
 </Step>
 
 </Steps>
@@ -72,27 +84,28 @@ curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh \
   | BUTTONS_INSTALL_DIR=$HOME/.local/bin sh
 ```
 
-Make sure that directory is on your `$PATH`:
+The script warns if that directory is not on your `$PATH`. Add it so the `buttons` command resolves:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-## GitHub rate limits
+## GitHub authentication and rate limits
 
-The unauthenticated GitHub API allows 60 requests per hour per IP. In CI environments where many jobs run on shared egress IPs, you may hit this limit. Pass a token to raise the rate limit:
+All release metadata and asset downloads go through the GitHub API. While the repository is private, unauthenticated requests return 404, so `GITHUB_TOKEN` (with `contents:read`) is required. Once the repository is public, the token is optional but still useful: the unauthenticated API allows only 60 requests per hour per IP, which CI runners on shared egress IPs can exhaust. Pass a token to raise the limit:
 
 ```bash
-| GITHUB_TOKEN=$GH_TOKEN sh
+curl -fsSL https://raw.githubusercontent.com/autonoco/buttons/main/install.sh \
+  | GITHUB_TOKEN=$GH_TOKEN sh
 ```
 
 <Tip>
-In GitHub Actions, `GITHUB_TOKEN` is automatically available as a secret. Pass it directly: `GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}`.
+In GitHub Actions, `GITHUB_TOKEN` is provided automatically. Pass it directly — just make sure the workflow has `contents: read` permission for this repository: `GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}`.
 </Tip>
 
 ## Alpine and BusyBox compatibility
 
-The script uses only POSIX `sh` builtins and a small set of standard utilities (`uname`, `curl` or `wget`, `sha256sum` or `shasum`, `tar`). It runs in Alpine and BusyBox environments without modification.
+The script is plain POSIX `sh` and depends only on a small set of standard utilities: `curl`, `tar`, `uname`, `mktemp`, and one of `sha256sum` or `shasum`. It runs in Alpine, Debian slim, and BusyBox container images without modification.
 
 ## Related
 

--- a/docs/deployment/rest-api.mdx
+++ b/docs/deployment/rest-api.mdx
@@ -84,6 +84,22 @@ buttons serve --allow-http-buttons
 
 Code and prompt buttons are pressable without this flag.
 
+## Trigger engine
+
+`buttons serve` also runs the in-process button trigger engine and mounts webhook trigger routes alongside the API. Button triggers (`buttons trigger add`) fire here:
+
+- `cron` triggers run on their schedule.
+- `watch` triggers poll their watched file (mtime/size, 500ms).
+- `webhook` triggers mount a `POST <path>` route on the same listener, gated by the optional shared `--token` (`X-Buttons-Token` header or `?token=`).
+
+Disable the engine to run the API alone:
+
+```bash
+buttons serve --no-triggers
+```
+
+This is the button-trigger layer (single shared token, no tunnel). Drawer webhook triggers — n8n-style auth behind a Cloudflare tunnel — are a separate layer served by [`buttons webhook listen`](/cli/buttons_webhook).
+
 ## Related
 
 - [buttons serve](/cli/buttons_serve)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -28,7 +28,7 @@ Each button wraps a single action: a shell script, an HTTP API call, a Python/No
     Typed workflows that compose buttons.
   </Card>
   <Card title="Registry" icon="boxes" href="/concepts/registry">
-    Resolve, install, lock, and update shared buttons.
+    Install and publish shared buttons, pinned per-button by version and content hash.
   </Card>
   <Card title="History" icon="history" href="/concepts/history">
     Local audit history for creates, edits, installs, and updates.
@@ -62,17 +62,17 @@ Drawers chain buttons into typed workflows with refs, loops, sub-drawers, waits,
 
 ## Triggers
 
-Triggers are the planned unified surface for running buttons and drawers from external or local events.
+Triggers run buttons and drawers automatically — on a schedule (cron), on local file changes (watch), or from an inbound webhook. Button triggers fire under `buttons serve`; drawer webhook triggers fire under `buttons webhook listen`.
 
 <Columns cols={2}>
   <Card title="Trigger concept" icon="zap" href="/concepts/triggers">
-    Automatic ways to run buttons and drawers.
+    How buttons and drawers fire automatically.
   </Card>
   <Card title="Trigger guide" icon="list-checks" href="/buttons/triggers">
     Commands and management model.
   </Card>
   <Card title="Hook" icon="git-branch" href="/buttons/hook">
-    Local file, Git, and Buttons-runtime events.
+    Run on local events — design proposal.
   </Card>
 </Columns>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -26,7 +26,7 @@ cd buttons-demo
 buttons init --agent agents-md
 ```
 
-`buttons init` also writes `.buttons/AGENT.md` and adds a Buttons section to `AGENTS.md` so coding agents know to discover and press existing buttons before writing one-off commands.
+`buttons init` also writes `.buttons/AGENTS.md` and adds a Buttons section to `AGENTS.md` so coding agents know to discover and press existing buttons before writing one-off commands.
 
 </Step>
 

--- a/docs/security/overview.mdx
+++ b/docs/security/overview.mdx
@@ -18,6 +18,7 @@ The security controls in Buttons are aimed at preventing unintended execution or
 | Path traversal via argument values | `PathEscape` applied to URL path segments — see [template encoding](/security/template-encoding) |
 | Command injection via argument values | Args injected as env vars (`BUTTONS_ARG_<NAME>`), never interpolated into the shell body |
 | SSRF via HTTP buttons targeting internal services | Private network blocking by default — see [SSRF protection](/security/ssrf-protection) |
+| Exfiltration via webhook-supplied host redirection | HTTP buttons lock scheme+host at create time (`allowed_host`); `{{arg}}` is rejected in the scheme/host and may appear only in path/query/fragment, so a remote arg can't redirect the request to an attacker's host |
 | Credential leakage via run history | `pressed/*.json` created with mode `0600`; project-local secret-bearing files are gitignored |
 | Unauthorized reads of button specs | `~/.buttons/` created with mode `0700` |
 | Query/JSON injection via argument values | Context-aware encoding in URL and body templates |
@@ -27,7 +28,6 @@ The security controls in Buttons are aimed at preventing unintended execution or
 - **Malicious button specs:** Buttons does not validate whether a button's code is safe. If you import or run a button from an untrusted source, you are responsible for reviewing its contents.
 - **Privilege escalation:** Buttons runs as the invoking user. It does not attempt to drop privileges. If your agent runs as root, buttons run as root.
 - **Side-channel attacks:** Timing or memory side-channels are not in scope.
-- **Third-party MCP tools:** When a button wraps an MCP tool call, the security of that tool is the responsibility of the MCP server operator.
 
 ## Assumptions
 

--- a/docs/security/ssrf-protection.mdx
+++ b/docs/security/ssrf-protection.mdx
@@ -17,19 +17,40 @@ The following ranges are blocked by default:
 | `10.0.0.0/8` | RFC 1918 private |
 | `172.16.0.0/12` | RFC 1918 private |
 | `192.168.0.0/16` | RFC 1918 private |
-| `169.254.0.0/16` | Link-local (includes AWS/GCP metadata: `169.254.169.254`) |
+| `169.254.0.0/16` | RFC 3927 link-local (includes AWS/GCP/Azure metadata: `169.254.169.254`) |
+| `100.64.0.0/10` | RFC 6598 carrier-grade NAT |
+| `0.0.0.0/8` | "This network" (RFC 791) |
+| `224.0.0.0/4` | IPv4 multicast (RFC 5771) |
+| `240.0.0.0/4` | IPv4 reserved (RFC 1112) |
 | `::1/128` | IPv6 loopback |
 | `fc00::/7` | IPv6 unique local |
 | `fe80::/10` | IPv6 link-local |
+| `ff00::/8` | IPv6 multicast |
 
-Attempting to press an HTTP button that resolves to one of these ranges returns a `SCRIPT_ERROR`:
+## Two enforcement points
+
+A blocked target is caught at one of two places, depending on whether the URL's host is a literal IP or a hostname.
+
+**Literal IP, before any request.** If the post-substitution URL's host is a literal IP inside a blocked range, the press is refused before a connection is attempted. This surfaces as a `VALIDATION_ERROR`:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "refusing request: 169.254.169.254 resolves to a blocked private range"
+  }
+}
+```
+
+**Hostname, at dial time.** A hostname is resolved and every A/AAAA record is checked against the blocklist before the connection is dialed (see DNS rebinding below). A blocked address surfaces as a `SCRIPT_ERROR`:
 
 ```json
 {
   "ok": false,
   "error": {
     "code": "SCRIPT_ERROR",
-    "message": "request blocked: target address 169.254.169.254 is in a private network range"
+    "message": "request failed: SSRF blocked: metadata.internal.example resolves to private address 169.254.169.254 (set --allow-private-networks on the button or BUTTONS_ALLOW_PRIVATE_NETWORKS=1 to override)"
   }
 }
 ```
@@ -38,11 +59,13 @@ Attempting to press an HTTP button that resolves to one of these ranges returns 
 
 Validation happens after DNS resolution, not just on the literal URL. This prevents DNS rebinding attacks, where a public hostname resolves to a private IP.
 
-If the hostname `api.attacker.example` resolves to `10.0.0.1` at press time, the request is blocked even though the URL does not look like a private address.
+The safe dialer resolves the hostname once, rejects the request if **any** resolved A/AAAA record lands in a blocked range, and then dials by the resolved IP rather than re-resolving the hostname. Dialing by the already-checked IP closes the rebinding window where an attacker returns a public IP on the first lookup and a private IP on the second.
+
+So if the hostname `api.attacker.example` resolves to `10.0.0.1` at press time, the request is blocked even though the URL does not look like a private address.
 
 ## Escape hatch 1: per-button flag
 
-To allow a specific button to target a private address, pass `--allow-private-networks` at create time:
+To allow a specific button to target a private address, pass `--allow-private-networks` at create time. The flag applies only to HTTP (`--url`) buttons:
 
 ```bash
 buttons create local-health \

--- a/docs/security/template-encoding.mdx
+++ b/docs/security/template-encoding.mdx
@@ -3,7 +3,9 @@ title: "Template encoding"
 description: "How {{arg}} values are encoded to prevent injection attacks."
 ---
 
-When an HTTP button is pressed, every `{{name}}` placeholder is replaced with the corresponding argument value. The encoding applied to that value depends on where in the request the placeholder appears.
+When an HTTP button is pressed, every `{{name}}` placeholder in the **URL** and the **request body** is replaced with the corresponding argument value. The encoding applied to that value depends on where in the request the placeholder appears.
+
+Only the URL (`SubstituteURL`) and body (`SubstituteBody`) are templated. **Header values are not** — see [Header values](#header-values) below.
 
 This page documents the encoding rules and shows what each one prevents.
 
@@ -11,11 +13,24 @@ This page documents the encoding rules and shows what each one prevents.
 
 | Location | Encoding | Go function |
 |---|---|---|
-| URL path segment (before `?`) | Percent-encode all characters not safe in a path | `url.PathEscape` |
-| URL query parameter value (after `?`) | Percent-encode all characters not safe in a query | `url.QueryEscape` |
-| JSON body (`Content-Type: application/json`) | Escape `"`, `\`, and control characters | `json.Marshal` string encoding |
-| Form body (`application/x-www-form-urlencoded`) | Same as query parameter | `url.QueryEscape` |
-| Header value | None — passed raw | — |
+| URL scheme or host | **Not substitutable** — `{{arg}}` here is rejected when the button is created | — |
+| URL path segment (between the host and `?`/`#`) | Percent-encode all characters not safe in a path | `url.PathEscape` |
+| URL query (after `?`) | Percent-encode all characters not safe in a query | `url.QueryEscape` |
+| URL fragment (after `#`) | Percent-encode (same as path) | `url.PathEscape` |
+| JSON body (`application/json`, `text/json`, or no `Content-Type`) | Escape `"`, `\`, and control characters | `json.Marshal` string encoding |
+| Form body (`application/x-www-form-urlencoded`) | Same as query | `url.QueryEscape` |
+| Any other body `Content-Type` | None — substituted raw | — |
+| Header value | Not substituted at all — sent verbatim | — |
+
+The URL is split into a **locked scheme + host prefix** and a substitutable path/query/fragment suffix. The split happens on the first `://`, then the first `?` and `#`. The `Content-Type` lookup for the body is case-insensitive and ignores any `; charset=…` suffix.
+
+## Scheme and host are locked
+
+You cannot put a `{{arg}}` in the scheme or host of an HTTP button's URL. The button service derives an `allowed_host` from the literal scheme + authority **when the button is created**, and rejects a URL whose scheme or host contains a placeholder. Placeholders are only ever expanded in the path, query, and fragment.
+
+This is what stops a `{{arg}}` value sourced from an attacker (for example a value forwarded from a webhook body) from redirecting the request to a different host. If a hand-edited `button.json` somehow smuggles a placeholder into the scheme/host, the substitution step leaves it untouched and dispatch fails with a `VALIDATION_ERROR` rather than making the request.
+
+See [HTTP API buttons](/buttons/http-api) for the host-locking model in full.
 
 ## Attack scenario 1: URL query injection
 
@@ -93,22 +108,20 @@ The injected value breaks out of the string and introduces a duplicate key. Depe
 {"username": "\",\"role\":\"admin", "role": "viewer"}
 ```
 
-The quotes and commas are escaped. The server receives the attack string as a literal username value.
+The quotes and commas are escaped. The server receives the attack string as a literal username value. The body is escaped with `json.Marshal` and the outer quotes stripped, so the template's own quotes stay in place.
 
 ## Header values
 
-Header values are substituted without encoding. This is correct for tokens and API keys where encoding would break the value (e.g. a base64-encoded credential that contains `+` and `=`).
+Header values are **not** templated. `{{arg}}` placeholders inside a header value are not expanded — the header is sent exactly as stored in the button. A credential such as a token or API key is therefore set as a literal, static header value when the button is created, which is correct for values that encoding would break (e.g. a base64 credential containing `+` and `=`).
 
-<Warning>
-If a header value is user-controlled and the header has a structured format (e.g. a custom header that a downstream service parses as key=value pairs), you are responsible for validating the value before it reaches the button.
-</Warning>
+Because header values are static and never carry an argument, there is no per-press injection vector through them — but you are responsible for the value you store. Treat anything you put in a header as a committed part of the button spec.
 
 ## Raw body types
 
-For bodies with a `Content-Type` other than `application/json` or `application/x-www-form-urlencoded`, substitution is raw — no encoding is applied. Use this only when you fully control the body format.
+For bodies with a `Content-Type` other than `application/json` / `text/json` (or no `Content-Type` at all, which is treated as JSON) and `application/x-www-form-urlencoded`, substitution is raw — no encoding is applied. Use this only when you fully control the body format.
 
 ## Related
 
 - [URL and body templates](/concepts/templates) — how templates work at a conceptual level
-- [HTTP API buttons](/buttons/http-api) — full flag reference
+- [HTTP API buttons](/buttons/http-api) — full flag reference and host-locking
 - [Security overview](/security/overview) — threat model and assumptions


### PR DESCRIPTION
## What

A research-backed refresh of the Mintlify docs to match **shipped reality**. Ground
truth was derived from the actual code (commands, schema/folders, the real registry
model, triggers/security), then **every page was audited and fixed against it** —
**29 pages updated** (654+/441−).

## Highlights

- **`concepts/registry`** (the biggest fix) — it documented a fictional npm-style
  `buttons.json` / `buttons-lock.json` git-manifest model that **doesn't exist**.
  Rewritten to the real **HTTP `@desk/name` registry**: swappable `Source`/`Publisher`,
  bearer auth with the `REGISTRY_KEY` (read) / `REGISTRY_WRITE_KEY` (write) battery
  split, **per-button** `source`/`version`/`content_hash` pinning (no lockfile), the
  two-hash content model, install hardening, and the `/v1` route contract.
- **`concepts/button-json` + `concepts/folder-structure`** — now document **app
  buttons** (`kind` + the `serve` block) and the lazily-created **`apps/`** folder.
- **triggers / webhook / cron / hook** — replaced an invented unified `buttons trigger`
  surface and fake event sources with the **two real layers** (button triggers under
  `buttons serve`, drawer webhook triggers under `buttons webhook listen`), with honest
  "design proposal" labels where a feature isn't shipped.
- Swept `AGENT.md` → `AGENTS.md`; removed every `buttons add` / `buttons deploy` /
  lockfile claim.

## Guardrails enforced (and verified)

- **Public repo** → no real registry host anywhere; placeholder (`$BUTTONS_REGISTRY_URL`
  / `registry.example`) only. *(grep: 0 host references)*
- **Only shipped behavior** documented — no inventing `serve`/`deploy` for app buttons.
- **No broken links** — full markdown + `href` sweep passes (fixed one `/concepts/batteries`
  → CLI batteries reference). Frontmatter intact on all 29 pages.

## Not in scope

- Generated CLI reference (`docs/cli/*.md`) — left to the **docs-sync workflow**.
- A dedicated app-buttons *guide* page — held until `serve` ships (creation is covered
  in `button-json`; running an app isn't built yet).

The Mintlify preview deploy will validate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified docs for buttons, triggers, registries, templates, security, and deployment.
  * Added current guidance for cron, watch, webhook, MCP, prompt, HTTP, and CLI button behavior.
  * Updated references from `AGENT.md` to `AGENTS.md` and refreshed examples, limits, and command syntax.
  * Clarified how installs, pinning, histories, and run artifacts are handled.
  * Improved security docs for SSRF protection, template encoding, and webhook access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->