### PR TITLE
feat: use simple button content versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Registry installs use a package-manager style manifest and lockfile:
 
 ```bash
 buttons add @your-desk/hello        # writes .buttons/buttons.json and installs latest
-buttons add @your-desk/deploy@1.2.3 # pins an exact version
+buttons add @your-desk/deploy@1     # pins an exact version
 buttons install                     # materializes .buttons/buttons.json
 buttons status                      # reports available CLI/content updates
 buttons update                      # updates floating dependencies
@@ -269,7 +269,7 @@ The root manifest is committed:
   "schema_version": 1,
   "dependencies": {
     "@your-desk/hello": "latest",
-    "@your-desk/deploy": "1.2.3"
+    "@your-desk/deploy": "1"
   }
 }
 ```
@@ -289,14 +289,18 @@ BUTTONS_REGISTRY_URL=https://registry.example buttons install
 Version flow:
 
 ```bash
-# Publisher publishes immutable v1.0.0 from a button.json with "version": "1.0.0"
+# Publisher creates and publishes immutable version 1.
+buttons create hello --code 'echo hello'
 BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
 
-# Agent workspace tracks latest and installs version 1.0.0
+# Agent workspace tracks latest and installs that published version.
 BUTTONS_REGISTRY_URL=https://registry.example buttons add @your-desk/hello
 
-# Publisher later changes button.json to "version": "1.1.0" and publishes again.
-# The agent workspace can see and apply the new version:
+# Publisher changes the source button and publishes again. If version 1 already
+# exists, publish bumps button.json to version 2 and retries automatically.
+BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
+
+# The agent workspace can see and apply the new version.
 buttons status
 buttons update
 ```

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,7 +23,7 @@ an exact immutable version.
 
 Examples:
   buttons add @your-desk/hello
-  buttons add @your-desk/hello@1.2.3`,
+  buttons add @your-desk/hello@1`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, name, requested, err := runAdd(context.Background(), args[0])

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,6 +44,10 @@ By default, 'buttons create <name>' scaffolds a shell button with a
 placeholder main.sh the agent can edit, then press. Use --runtime to
 scaffold a Python or Node button instead.
 
+New buttons start with package version 1 in button.json. Registry publish uses
+that version, then auto-bumps to the next number if that immutable version
+already exists.
+
 Provide a shortcut flag to skip the placeholder: --code for a one-line
 inline script, --file to copy an existing script, --url for an HTTP
 endpoint, or --prompt for a standalone instruction.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,7 +24,7 @@ to materialize the dependency manifest into .buttons/buttons/ and refresh
 Examples:
   buttons install
   buttons add @your-desk/hello
-  buttons add @your-desk/hello@1.2.3`,
+  buttons add @your-desk/hello@1`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return nil

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -25,9 +25,10 @@ ship a default registry host; the caller must configure the target explicitly.
 
 A registry publish takes a scoped name (@desk/name): the on-disk button is found
 by its bare name, and @desk is its registry namespace. The registry pins
-immutable versions, so button.json must carry a "version". Auth uses the *write*
-key (REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct
-from the read key install uses.
+immutable versions; publish starts at the button's current version and auto-bumps
+to the next number if that version already exists. Auth uses the *write* key
+(REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from
+the read key install uses.
 
 Examples:
   BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello`,

--- a/docs/cli/buttons_add.md
+++ b/docs/cli/buttons_add.md
@@ -19,7 +19,7 @@ an exact immutable version.
 
 ```bash
 buttons add @your-desk/hello
-buttons add @your-desk/hello@1.2.3
+buttons add @your-desk/hello@1
 ```
 
 ```

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -15,6 +15,10 @@ By default, 'buttons create `<name>`' scaffolds a shell button with a
 placeholder main.sh the agent can edit, then press. Use --runtime to
 scaffold a Python or Node button instead.
 
+New buttons start with package version 1 in button.json. Registry publish uses
+that version, then auto-bumps to the next number if that immutable version
+already exists.
+
 Provide a shortcut flag to skip the placeholder: --code for a one-line
 inline script, --file to copy an existing script, --url for an HTTP
 endpoint, or --prompt for a standalone instruction.

--- a/docs/cli/buttons_install.md
+++ b/docs/cli/buttons_install.md
@@ -20,7 +20,7 @@ to materialize the dependency manifest into .buttons/buttons/ and refresh
 ```bash
 buttons install
 buttons add @your-desk/hello
-buttons add @your-desk/hello@1.2.3
+buttons add @your-desk/hello@1
 ```
 
 ```

--- a/docs/cli/buttons_publish.md
+++ b/docs/cli/buttons_publish.md
@@ -18,9 +18,10 @@ ship a default registry host; the caller must configure the target explicitly.
 
 A registry publish takes a scoped name (@desk/name): the on-disk button is found
 by its bare name, and @desk is its registry namespace. The registry pins
-immutable versions, so button.json must carry a "version". Auth uses the *write*
-key (REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct
-from the read key install uses.
+immutable versions; publish starts at the button's current version and auto-bumps
+to the next number if that version already exists. Auth uses the *write* key
+(REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from
+the read key install uses.
 
 **Examples:**
 

--- a/docs/concepts/button-json.mdx
+++ b/docs/concepts/button-json.mdx
@@ -162,7 +162,7 @@ Buttons published to or installed from a registry can include package metadata. 
 | Field | Meaning |
 | --- | --- |
 | `tags` | Groups/categories exposed in registry discovery. |
-| `version` | Button content version (semver). Required to `buttons publish` to a registry. |
+| `version` | Button content version. New buttons start at `1`; registry publish auto-bumps to the next number when the current immutable version already exists. |
 | `requires` | Transitive package dependencies, keyed by scoped name and valued as `"latest"` or an exact version. |
 | `requires_batteries` | Battery keys the button needs. Values are never shipped. |
 
@@ -170,7 +170,7 @@ Example package fields:
 
 ```json
 {
-  "version": "1.0.0",
+  "version": "1",
   "requires": {
     "@your-desk/base": "latest",
     "@your-desk/deploy-lib": "2.0.1"
@@ -179,7 +179,7 @@ Example package fields:
 }
 ```
 
-If `@your-desk/hello` is later published as `1.1.0`, `buttons status` can report the newer version by reading `.buttons/buttons.json` and `.buttons/buttons-lock.json`. `buttons update` moves it only when the manifest requested `"latest"`.
+If `@your-desk/hello` is later published as `2`, `buttons status` can report it by reading `.buttons/buttons.json` and `.buttons/buttons-lock.json`. `buttons update` moves it only when the manifest requested `"latest"`.
 
 ## Triggers
 

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -96,7 +96,7 @@ Registry dependencies are tracked at the project root:
 
 When you install with `buttons add @desk/name` or `buttons install`, the runnable copy is written into `buttons/<name>/`, and the dependency resolution is written to the lockfile. Dependencies declared in `button.json` `requires` are installed transitively and recorded in the lockfile too.
 
-To share authored local buttons with a team, commit their folders under `buttons/` and `drawers/`. To share registry dependencies with a team, commit `buttons.json` and `buttons-lock.json` so teammates install the same resolved versions. To push a button to a registry, use `buttons publish @desk/<name>`; publish needs a scoped `@desk/name` and a `version` in `button.json`, and registry versions are immutable.
+To share authored local buttons with a team, commit their folders under `buttons/` and `drawers/`. To share registry dependencies with a team, commit `buttons.json` and `buttons-lock.json` so teammates install the same resolved versions. To push a button to a registry, use `buttons publish @desk/<name>`; versions are simple numbers starting at `1`, and registry versions are immutable.
 
 ## history.json
 

--- a/docs/concepts/history.mdx
+++ b/docs/concepts/history.mdx
@@ -38,7 +38,7 @@ The file has a schema version and an ordered `events` array:
           "name": "@autono/hello",
           "kind": "button",
           "requested": "latest",
-          "version": "1.2.3",
+          "version": "1",
           "content_hash": "4f8c...",
           "installed_name": "hello"
         }

--- a/docs/concepts/registry.mdx
+++ b/docs/concepts/registry.mdx
@@ -30,7 +30,7 @@ Registry installs use three different files:
   "schema_version": 1,
   "dependencies": {
     "@your-desk/hello": "latest",
-    "@your-desk/deploy": "1.2.3"
+    "@your-desk/deploy": "1"
   }
 }
 ```
@@ -40,9 +40,9 @@ Dependency keys must be scoped package names in the form `@desk/name`.
 | Value | Meaning |
 |---|---|
 | `"latest"` | Floating dependency. `buttons update`, passive OTA, and publish-triggered OTA may move it to the latest published version. |
-| `"1.2.3"` | Exact pin. Install resolves that immutable version; update/status may report newer versions as informational but must not mutate it. |
+| `"1"` | Exact pin. Install resolves that immutable version; update/status may report newer versions as informational but must not mutate it. |
 
-Semver ranges and per-dependency option objects are intentionally not part of the MVP.
+Version ranges and per-dependency option objects are intentionally not part of the MVP.
 
 ## Lockfile
 
@@ -55,7 +55,7 @@ Semver ranges and per-dependency option objects are intentionally not part of th
     "@your-desk/hello": {
       "kind": "button",
       "requested": "latest",
-      "version": "1.2.3",
+      "version": "1",
       "content_hash": "4f8c...",
       "installed_name": "hello",
       "resolved_at": "2026-07-01T12:00:00Z"
@@ -74,7 +74,7 @@ Each installed button still has its own runtime spec:
 {
   "schema_version": 1,
   "name": "hello",
-  "version": "1.2.3",
+  "version": "1",
   "description": "Say hello",
   "runtime": "shell",
   "args": [
@@ -97,14 +97,14 @@ Use the registry like a package manager:
 
 ```bash
 buttons add @your-desk/hello
-buttons add @your-desk/deploy@1.2.3
+buttons add @your-desk/deploy@1
 buttons install
 buttons status
 buttons update
 ```
 
 - `buttons add @desk/name` writes `.buttons/buttons.json` with `"latest"` and installs immediately.
-- `buttons add @desk/name@1.2.3` writes an exact pin and installs that immutable version.
+- `buttons add @desk/name@1` writes an exact pin and installs that immutable version.
 - `buttons install` takes no package argument. It reads `.buttons/buttons.json` and honors `.buttons/buttons-lock.json` for repeatability.
 - `buttons status` reports available CLI and content updates.
 - `buttons update` updates the CLI and floating button dependencies only.
@@ -130,21 +130,21 @@ The registry base URL comes from `$BUTTONS_REGISTRY_URL`. This public repo does 
 BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
 ```
 
-The on-disk button is found by its bare local name (`hello`), while `@your-desk/hello` is the registry identity. Published versions are immutable, so the source button's `button.json` must include an exact `version`.
+The on-disk button is found by its bare local name (`hello`), while `@your-desk/hello` is the registry identity. Published versions are immutable. New buttons start at version `1`; if that version already exists, publish bumps `button.json` to the next number and retries.
 
 Publishing bundles `button.json`, code files, and `AGENTS.md`. It does not upload `pressed/` run history or battery values.
 
 ## Version Example
 
-1. Publisher sets `"version": "1.0.0"` in `.buttons/buttons/hello/button.json`.
+1. Publisher runs `buttons create hello --code 'echo hello'`.
 2. Publisher runs `buttons publish @your-desk/hello`.
 3. Agent workspace runs `buttons add @your-desk/hello`.
-4. Agent lockfile resolves `@your-desk/hello` to `1.0.0`.
-5. Publisher changes the source button to `"version": "1.1.0"` and publishes again.
+4. Agent lockfile resolves `@your-desk/hello` to version `1`.
+5. Publisher changes the source button and publishes again. Publish auto-bumps to version `2` if `1` already exists.
 6. Agent workspace runs `buttons status` to see the available update.
-7. Agent workspace runs `buttons update` to move the floating dependency to `1.1.0`.
+7. Agent workspace runs `buttons update` to move the floating dependency to the new version.
 
-If the agent had run `buttons add @your-desk/hello@1.0.0`, step 7 would leave it pinned at `1.0.0`.
+If the agent had run `buttons add @your-desk/hello@1`, step 7 would leave it pinned at that exact version.
 
 ## Hardening
 

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -19,10 +19,10 @@ type Button struct {
 	// (e.g. "finance", "sync"). Omitted when empty so existing buttons
 	// don't grow a noisy field.
 	Tags []string `json:"tags,omitempty"`
-	// Version is the button's content release (semver), distinct from
+	// Version is the button's generated content release, distinct from
 	// SchemaVersion (the on-disk format counter). Published and installed
-	// registry buttons must carry an exact immutable version.
-	// Empty for hand-authored local buttons (treated as "unversioned").
+	// registry buttons carry an exact immutable version.
+	// Older or hand-authored local buttons may be empty (treated as unversioned).
 	Version              string            `json:"version,omitempty"`
 	Runtime              string            `json:"runtime"`
 	URL                  string            `json:"url,omitempty"`

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -332,6 +332,7 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 		SchemaVersion:        2,
 		Name:                 name,
 		Description:          opts.Description,
+		Version:              InitialContentVersion,
 		Runtime:              runtime,
 		URL:                  opts.URL,
 		Method:               method,

--- a/internal/button/service_test.go
+++ b/internal/button/service_test.go
@@ -45,6 +45,9 @@ func TestService_Create(t *testing.T) {
 	if btn.SchemaVersion != 2 {
 		t.Errorf("schema_version = %d, want 2", btn.SchemaVersion)
 	}
+	if btn.Version != "1" {
+		t.Errorf("version = %q, want 1", btn.Version)
+	}
 	if btn.Runtime != "shell" {
 		t.Errorf("runtime = %q, want %q", btn.Runtime, "shell")
 	}
@@ -98,6 +101,9 @@ func TestService_Create(t *testing.T) {
 	json.Unmarshal(data, &saved)
 	if saved.SchemaVersion != 2 {
 		t.Errorf("saved schema_version = %d, want 2", saved.SchemaVersion)
+	}
+	if saved.Version != "1" {
+		t.Errorf("saved version = %q, want 1", saved.Version)
 	}
 	if len(saved.Args) != 1 || saved.Args[0].Name != "url" {
 		t.Errorf("saved args = %+v, want [{url string true}]", saved.Args)

--- a/internal/button/version.go
+++ b/internal/button/version.go
@@ -1,0 +1,19 @@
+package button
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const InitialContentVersion = "1"
+
+// NextVersion bumps the simple button content version used for registry
+// publishes: 1, 2, 3, and so on.
+func NextVersion(version string) (string, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(version))
+	if err != nil || n < 1 {
+		return "", fmt.Errorf("version %q is not a positive integer", version)
+	}
+	return strconv.Itoa(n + 1), nil
+}

--- a/internal/manifest/lock.go
+++ b/internal/manifest/lock.go
@@ -106,7 +106,7 @@ func (l *Lockfile) Validate() error {
 			return fmt.Errorf("%s requested: %w", name, err)
 		}
 		if entry.Version == "" || !exactVersionPattern.MatchString(entry.Version) {
-			return fmt.Errorf("%s version must be exact semver, got %q", name, entry.Version)
+			return fmt.Errorf("%s version must be an exact number, got %q", name, entry.Version)
 		}
 		if entry.Kind != "button" && entry.Kind != "drawer" {
 			return fmt.Errorf("%s kind must be button or drawer, got %q", name, entry.Kind)

--- a/internal/manifest/lock_test.go
+++ b/internal/manifest/lock_test.go
@@ -12,7 +12,7 @@ func TestLockfileSaveLoad(t *testing.T) {
 		"@autono/hello": {
 			Kind:          "button",
 			Requested:     "latest",
-			Version:       "1.2.3",
+			Version:       "1",
 			ContentHash:   "sha256:abc",
 			InstalledName: "hello",
 			ResolvedAt:    "2026-07-01T12:00:00Z",
@@ -26,7 +26,7 @@ func TestLockfileSaveLoad(t *testing.T) {
 		t.Fatalf("load: %v", err)
 	}
 	entry := got.Dependencies["@autono/hello"]
-	if entry.Version != "1.2.3" || entry.Requested != "latest" || entry.InstalledName != "hello" {
+	if entry.Version != "1" || entry.Requested != "latest" || entry.InstalledName != "hello" {
 		t.Fatalf("loaded entry = %+v", entry)
 	}
 	info, err := os.Stat(path)
@@ -42,7 +42,7 @@ func TestLockfileValidation(t *testing.T) {
 	valid := LockEntry{
 		Kind:          "button",
 		Requested:     "latest",
-		Version:       "1.2.3",
+		Version:       "1",
 		ContentHash:   "sha256:abc",
 		InstalledName: "hello",
 		ResolvedAt:    "2026-07-01T12:00:00Z",

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -13,7 +13,7 @@ import (
 
 const SchemaVersion = 1
 
-var exactVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+var exactVersionPattern = regexp.MustCompile(`^[0-9]+$`)
 
 type Manifest struct {
 	SchemaVersion int               `json:"schema_version"`
@@ -125,7 +125,7 @@ func ValidateRequest(requested string) error {
 	if requested == "latest" || exactVersionPattern.MatchString(requested) {
 		return nil
 	}
-	return fmt.Errorf("version must be latest or an exact semver like 1.2.3, got %q", requested)
+	return fmt.Errorf("version must be latest or an exact number like 1, got %q", requested)
 }
 
 func IsFloating(requested string) bool {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -18,7 +18,7 @@ func TestManifestLoadMissing(t *testing.T) {
 func TestManifestValidateDependencies(t *testing.T) {
 	m := &Manifest{SchemaVersion: 1, Dependencies: map[string]string{
 		"@autono/hello":  "latest",
-		"@autono/deploy": "1.2.3",
+		"@autono/deploy": "1",
 	}}
 	if err := m.Validate(); err != nil {
 		t.Fatalf("valid manifest rejected: %v", err)
@@ -32,6 +32,7 @@ func TestManifestValidateDependencies(t *testing.T) {
 		{"empty-scope", map[string]string{"@/hello": "latest"}},
 		{"nested", map[string]string{"@autono/a/b": "latest"}},
 		{"range-not-mvp", map[string]string{"@autono/hello": "^1.2.0"}},
+		{"dotted-version", map[string]string{"@autono/hello": "1.2.3"}},
 		{"bad-version", map[string]string{"@autono/hello": "v1.2.3"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -47,7 +48,7 @@ func TestManifestSaveLoadStable(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "buttons.json")
 	m := &Manifest{SchemaVersion: 1, Dependencies: map[string]string{
 		"@autono/hello":  "latest",
-		"@autono/deploy": "1.2.3",
+		"@autono/deploy": "1",
 	}}
 	if err := SavePath(path, m); err != nil {
 		t.Fatalf("save: %v", err)
@@ -56,7 +57,7 @@ func TestManifestSaveLoadStable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if got.Dependencies["@autono/hello"] != "latest" || got.Dependencies["@autono/deploy"] != "1.2.3" {
+	if got.Dependencies["@autono/hello"] != "latest" || got.Dependencies["@autono/deploy"] != "1" {
 		t.Fatalf("loaded deps = %+v", got.Dependencies)
 	}
 	data, err := os.ReadFile(path)
@@ -82,8 +83,7 @@ func TestParsePackageSpec(t *testing.T) {
 		requested string
 	}{
 		{"@autono/hello", "@autono/hello", "latest"},
-		{"@autono/hello@1.2.3", "@autono/hello", "1.2.3"},
-		{"@autono/hello@1.2.3-beta.1", "@autono/hello", "1.2.3-beta.1"},
+		{"@autono/hello@1", "@autono/hello", "1"},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			name, requested, err := ParsePackageSpec(tc.in)
@@ -95,7 +95,7 @@ func TestParsePackageSpec(t *testing.T) {
 			}
 		})
 	}
-	for _, bad := range []string{"hello", "@autono/hello@latest", "@autono/hello@v1.2.3", "@autono"} {
+	for _, bad := range []string{"hello", "@autono/hello@latest", "@autono/hello@1.2.3", "@autono/hello@v1.2.3", "@autono"} {
 		if _, _, err := ParsePackageSpec(bad); err == nil {
 			t.Fatalf("ParsePackageSpec(%q) should fail", bad)
 		}

--- a/internal/store/http_publish_test.go
+++ b/internal/store/http_publish_test.go
@@ -98,11 +98,11 @@ func (m *mockRegistry) handler() http.Handler {
 
 func sampleBundle() (map[string][]byte, *Bundle) {
 	files := map[string][]byte{
-		"button.json": []byte(`{"schema_version":1,"name":"hello","runtime":"shell","version":"1.0.0"}`),
+		"button.json": []byte(`{"schema_version":1,"name":"hello","runtime":"shell","version":"1"}`),
 		"main.sh":     []byte("#!/bin/sh\necho hi\n"),
 		"AGENTS.md":   []byte("# hello\n"),
 	}
-	return files, &Bundle{Name: "@autono/hello", Version: "1.0.0", SHA256: hashFiles(files), Files: files}
+	return files, &Bundle{Name: "@autono/hello", Version: "1", SHA256: hashFiles(files), Files: files}
 }
 
 // TestPublishThenFetchRoundTrip is the whole point: an artifact published by
@@ -118,7 +118,7 @@ func TestPublishThenFetchRoundTrip(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	got, err := (&HTTPSource{BaseURL: srv.URL, Key: "rk"}).Fetch("@autono/hello", "1.0.0")
+	got, err := (&HTTPSource{BaseURL: srv.URL, Key: "rk"}).Fetch("@autono/hello", "1")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestPublishThenFetchRoundTrip(t *testing.T) {
 	}
 	// version "" must also resolve to the just-published one via the index.
 	latest, err := (&HTTPSource{BaseURL: srv.URL, Key: "rk"}).Fetch("@autono/hello", "")
-	if err != nil || latest.Version != "1.0.0" {
+	if err != nil || latest.Version != "1" {
 		t.Fatalf("latest resolve: ver=%q err=%v", latest.Version, err)
 	}
 }
@@ -172,7 +172,7 @@ func TestHTTPPublisherRequiresNameAndVersion(t *testing.T) {
 	if err := pub.Publish(&Bundle{Name: "@autono/hello", Files: map[string][]byte{"button.json": []byte("{}")}}); err == nil {
 		t.Error("missing version should error before any network call")
 	}
-	if err := pub.Publish(&Bundle{Version: "1.0.0", Files: map[string][]byte{"button.json": []byte("{}")}}); err == nil {
+	if err := pub.Publish(&Bundle{Version: "1", Files: map[string][]byte{"button.json": []byte("{}")}}); err == nil {
 		t.Error("missing name should error before any network call")
 	}
 }

--- a/internal/store/http_source.go
+++ b/internal/store/http_source.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -76,9 +77,28 @@ func registryError(what string, resp *http.Response) error {
 		} `json:"error"`
 	}
 	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
-		return fmt.Errorf("registry %s: %d %s (%s)", what, resp.StatusCode, env.Error.Message, env.Error.Code)
+		return &registryResponseError{what: what, statusCode: resp.StatusCode, code: env.Error.Code, message: env.Error.Message}
 	}
-	return fmt.Errorf("registry %s: %d %s", what, resp.StatusCode, strings.TrimSpace(string(body)))
+	return &registryResponseError{what: what, statusCode: resp.StatusCode, message: strings.TrimSpace(string(body))}
+}
+
+type registryResponseError struct {
+	what       string
+	statusCode int
+	code       string
+	message    string
+}
+
+func (e *registryResponseError) Error() string {
+	if e.code != "" {
+		return fmt.Sprintf("registry %s: %d %s (%s)", e.what, e.statusCode, e.message, e.code)
+	}
+	return fmt.Sprintf("registry %s: %d %s", e.what, e.statusCode, e.message)
+}
+
+func isVersionExists(err error) bool {
+	var regErr *registryResponseError
+	return errors.As(err, &regErr) && regErr.statusCode == http.StatusConflict && regErr.code == "VERSION_EXISTS"
 }
 
 // indexEntry is one row of the Worker's /v1/index (a superset of ButtonRef).

--- a/internal/store/http_source_test.go
+++ b/internal/store/http_source_test.go
@@ -84,7 +84,7 @@ func TestHTTPSourceIndexAndFetch(t *testing.T) {
 		"AGENTS.md":   "# hello\n",
 	}
 	tb := makeTarball(t, "hello", files)
-	entries := []indexEntry{{Name: "@autono/hello", Kind: "button", Version: "0.1.0", SHA256: sha(tb)}}
+	entries := []indexEntry{{Name: "@autono/hello", Kind: "button", Version: "1", SHA256: sha(tb)}}
 	srv := registryServer(t, key, entries, map[string][]byte{"@autono/hello": tb})
 	defer srv.Close()
 
@@ -94,7 +94,7 @@ func TestHTTPSourceIndexAndFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Index: %v", err)
 	}
-	if len(refs) != 1 || refs[0].Name != "@autono/hello" || refs[0].Version != "0.1.0" {
+	if len(refs) != 1 || refs[0].Name != "@autono/hello" || refs[0].Version != "1" {
 		t.Fatalf("unexpected refs: %+v", refs)
 	}
 
@@ -103,8 +103,8 @@ func TestHTTPSourceIndexAndFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	if b.Version != "0.1.0" {
-		t.Errorf("version = %q, want 0.1.0", b.Version)
+	if b.Version != "1" {
+		t.Errorf("version = %q, want 1", b.Version)
 	}
 	if got := string(b.Files["main.sh"]); got != "echo hi\n" {
 		t.Errorf("main.sh = %q", got)
@@ -143,7 +143,7 @@ func TestHTTPSourceRejectsHashMismatch(t *testing.T) {
 	defer srv.Close()
 
 	src := &HTTPSource{BaseURL: srv.URL, Key: key}
-	_, err := src.Fetch("x", "1.0.0") // pinned version → goes straight to download
+	_, err := src.Fetch("x", "1") // pinned version → goes straight to download
 	if err == nil || !strings.Contains(err.Error(), "content hash mismatch") {
 		t.Fatalf("expected content hash mismatch, got %v", err)
 	}
@@ -170,7 +170,7 @@ func TestHTTPSourceUsesContextForRequests(t *testing.T) {
 	cancel()
 
 	src := &HTTPSource{BaseURL: srv.URL, Client: srv.Client(), Context: ctx}
-	_, err := src.Fetch("@autono/hello", "1.0.0")
+	_, err := src.Fetch("@autono/hello", "1")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Fetch error = %v, want context canceled", err)
 	}
@@ -199,11 +199,11 @@ func TestHTTPSourceSkipsMacJunk(t *testing.T) {
 		".DS_Store":     "finder-junk",
 	}
 	tb := makeTarball(t, "hello", files)
-	entries := []indexEntry{{Name: "@autono/hello", Version: "0.1.0", SHA256: sha(tb)}}
+	entries := []indexEntry{{Name: "@autono/hello", Version: "1", SHA256: sha(tb)}}
 	srv := registryServer(t, key, entries, map[string][]byte{"@autono/hello": tb})
 	defer srv.Close()
 
-	b, err := (&HTTPSource{BaseURL: srv.URL, Key: key}).Fetch("@autono/hello", "0.1.0")
+	b, err := (&HTTPSource{BaseURL: srv.URL, Key: key}).Fetch("@autono/hello", "1")
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -44,7 +44,8 @@ func Publish(dst Publisher, name string) (*PublishResult, error) {
 // PublishToRegistry publishes a local button to the hosted registry under a
 // scoped identity (@desk/name). The on-disk button is found by its bare name;
 // the @desk scope is registry identity, assigned here (not stored on disk). A
-// version is required — the registry pins immutable versions.
+// publish stamps a simple integer version because the registry pins immutable
+// versions and users should not have to hand-edit release counters.
 func PublishToRegistry(dst Publisher, ref string) (*PublishResult, error) {
 	_, localName, err := splitScoped(ref)
 	if err != nil {
@@ -54,13 +55,29 @@ func PublishToRegistry(dst Publisher, ref string) (*PublishResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if bundle.Version == "" {
-		return nil, fmt.Errorf("registry publish requires a version: set \"version\" in %q's button.json", localName)
+	version := strings.TrimSpace(bundle.Version)
+	if version == "" {
+		version = button.InitialContentVersion
 	}
-	if err := dst.Publish(bundle); err != nil {
-		return nil, err
+
+	for attempts := 0; attempts < 1000; attempts++ {
+		if err := stampLocalBundleVersion(localName, bundle, version); err != nil {
+			return nil, err
+		}
+		if err := dst.Publish(bundle); err != nil {
+			if !isVersionExists(err) {
+				return nil, err
+			}
+			next, bumpErr := button.NextVersion(version)
+			if bumpErr != nil {
+				return nil, fmt.Errorf("registry version %q already exists and cannot be auto-bumped: %w", version, bumpErr)
+			}
+			version = next
+			continue
+		}
+		return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
 	}
-	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+	return nil, fmt.Errorf("registry publish could not find an unused version after 1000 attempts")
 }
 
 // loadLocalBundle reads a local button folder into a Bundle. localName locates
@@ -103,6 +120,36 @@ func loadLocalBundle(localName, identity string) (*Bundle, error) {
 		name = identity
 	}
 	return &Bundle{Name: name, Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
+}
+
+func stampLocalBundleVersion(localName string, bundle *Bundle, version string) error {
+	specData, ok := bundle.Files["button.json"]
+	if !ok {
+		return fmt.Errorf("button %q has no button.json", localName)
+	}
+	var spec button.Button
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return fmt.Errorf("button %q: invalid button.json: %w", localName, err)
+	}
+	spec.Version = version
+	data, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %q button.json: %w", localName, err)
+	}
+
+	bundle.Version = version
+	bundle.Files["button.json"] = data
+	bundle.SHA256 = hashFiles(bundle.Files)
+
+	dir, err := config.ButtonDir(button.Slugify(localName))
+	if err != nil {
+		return err
+	}
+	// #nosec G306 -- button.json is user-owned metadata in the configured button dir.
+	if err := os.WriteFile(filepath.Join(dir, "button.json"), data, 0o600); err != nil {
+		return fmt.Errorf("write %q button.json: %w", localName, err)
+	}
+	return nil
 }
 
 // splitScoped parses a registry identity @desk/name into its parts, rejecting

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/autonoco/buttons/internal/button"
 )
 
+type capturePublisher struct {
+	bundle *Bundle
+}
+
+func (p *capturePublisher) Publish(b *Bundle) error {
+	p.bundle = b
+	return nil
+}
+
+type duplicateOncePublisher struct {
+	versions []string
+}
+
+func (p *duplicateOncePublisher) Publish(b *Bundle) error {
+	p.versions = append(p.versions, b.Version)
+	if len(p.versions) == 1 {
+		return &registryResponseError{statusCode: 409, code: "VERSION_EXISTS", message: "versions are immutable", what: "publish"}
+	}
+	return nil
+}
+
 // writeInstalledButton drops a local button into BUTTONS_HOME (as if created).
 func writeInstalledButton(t *testing.T, home string, b button.Button, body string) {
 	t.Helper()
@@ -66,5 +87,79 @@ func TestPublishMissingButton(t *testing.T) {
 	t.Setenv("BUTTONS_HOME", t.TempDir())
 	if _, err := Publish(&LocalSource{Root: t.TempDir()}, "ghost"); err == nil {
 		t.Fatal("publishing a missing button should error")
+	}
+}
+
+func TestPublishToRegistryStampsAutomaticVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledButton(t, home, button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell"}, "#!/bin/sh\necho hello\n")
+
+	pub := &capturePublisher{}
+	res, err := PublishToRegistry(pub, "@autono/hello")
+	if err != nil {
+		t.Fatalf("publish to registry: %v", err)
+	}
+	if res.Name != "@autono/hello" {
+		t.Fatalf("name = %q, want @autono/hello", res.Name)
+	}
+	if res.Version != "1" {
+		t.Fatalf("version = %q, want 1", res.Version)
+	}
+	if pub.bundle == nil {
+		t.Fatal("publisher did not receive bundle")
+	}
+	if pub.bundle.Version != res.Version {
+		t.Fatalf("bundle version = %q, want %q", pub.bundle.Version, res.Version)
+	}
+
+	var bundled button.Button
+	if err := json.Unmarshal(pub.bundle.Files["button.json"], &bundled); err != nil {
+		t.Fatalf("bundled button.json: %v", err)
+	}
+	if bundled.Version != res.Version {
+		t.Fatalf("bundled button.json version = %q, want %q", bundled.Version, res.Version)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, "buttons", "hello", "button.json"))
+	if err != nil {
+		t.Fatalf("read local button.json: %v", err)
+	}
+	var local button.Button
+	if err := json.Unmarshal(data, &local); err != nil {
+		t.Fatalf("local button.json: %v", err)
+	}
+	if local.Version != res.Version {
+		t.Fatalf("local button.json version = %q, want %q", local.Version, res.Version)
+	}
+}
+
+func TestPublishToRegistryBumpsSimpleVersionOnConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledButton(t, home, button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell", Version: "1"}, "#!/bin/sh\necho hello\n")
+
+	pub := &duplicateOncePublisher{}
+	res, err := PublishToRegistry(pub, "@autono/hello")
+	if err != nil {
+		t.Fatalf("publish to registry: %v", err)
+	}
+	if res.Version != "2" {
+		t.Fatalf("version = %q, want 2", res.Version)
+	}
+	if got, want := pub.versions, []string{"1", "2"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("published versions = %v, want %v", got, want)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, "buttons", "hello", "button.json"))
+	if err != nil {
+		t.Fatalf("read local button.json: %v", err)
+	}
+	var local button.Button
+	if err := json.Unmarshal(data, &local); err != nil {
+		t.Fatalf("local button.json: %v", err)
+	}
+	if local.Version != "2" {
+		t.Fatalf("local button.json version = %q, want 2", local.Version)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -71,23 +71,23 @@ func TestInstallManifestWithDepsWritesLock(t *testing.T) {
 		SchemaVersion: 1,
 		Name:          "alpha",
 		Runtime:       "shell",
-		Version:       "1.0.0",
+		Version:       "1",
 		Requires:      map[string]string{"@autono/beta": "latest"},
 	}, "#!/bin/sh\necho alpha\n")
 	beta := sourceBundle(t, "@autono/beta", button.Button{
 		SchemaVersion: 1,
 		Name:          "beta",
 		Runtime:       "shell",
-		Version:       "2.0.0",
+		Version:       "2",
 	}, "#!/bin/sh\necho beta\n")
 	src := memorySource{
 		refs: []ButtonRef{
-			{Name: "@autono/alpha", Kind: "button", Version: "1.0.0"},
-			{Name: "@autono/beta", Kind: "button", Version: "2.0.0"},
+			{Name: "@autono/alpha", Kind: "button", Version: "1"},
+			{Name: "@autono/beta", Kind: "button", Version: "2"},
 		},
 		bundles: map[string]*Bundle{
-			"@autono/alpha@1.0.0": alpha,
-			"@autono/beta@2.0.0":  beta,
+			"@autono/alpha@1": alpha,
+			"@autono/beta@2":  beta,
 		},
 	}
 
@@ -101,8 +101,8 @@ func TestInstallManifestWithDepsWritesLock(t *testing.T) {
 		t.Fatalf("want [alpha beta], got %v", res.Installed)
 	}
 	a := installedSpec(t, home, "alpha")
-	if a.Version != "1.0.0" {
-		t.Fatalf("alpha version = %q, want 1.0.0", a.Version)
+	if a.Version != "1" {
+		t.Fatalf("alpha version = %q, want 1", a.Version)
 	}
 	data, err := os.ReadFile(filepath.Join(home, "buttons", "alpha", "button.json"))
 	if err != nil {
@@ -112,10 +112,10 @@ func TestInstallManifestWithDepsWritesLock(t *testing.T) {
 		t.Fatalf("installed button.json should not contain source/content hash metadata: %s", data)
 	}
 	entry := lock.Dependencies["@autono/alpha"]
-	if entry.Requested != "latest" || entry.Version != "1.0.0" || entry.ContentHash == "" || entry.InstalledName != "alpha" || entry.ResolvedAt != now.Format(time.RFC3339) {
+	if entry.Requested != "latest" || entry.Version != "1" || entry.ContentHash == "" || entry.InstalledName != "alpha" || entry.ResolvedAt != now.Format(time.RFC3339) {
 		t.Fatalf("bad alpha lock entry: %+v", entry)
 	}
-	if dep := lock.Dependencies["@autono/beta"]; dep.Version != "2.0.0" || dep.Requested != "latest" {
+	if dep := lock.Dependencies["@autono/beta"]; dep.Version != "2" || dep.Requested != "latest" {
 		t.Fatalf("bad beta lock entry: %+v", dep)
 	}
 	info, err := os.Stat(filepath.Join(home, "buttons", "alpha", "main.sh"))
@@ -131,28 +131,28 @@ func TestInstallManifestHonorsExistingLock(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("BUTTONS_HOME", home)
 
-	v1 := sourceBundle(t, "@autono/hello", button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell", Version: "1.0.0"}, "#!/bin/sh\necho v1\n")
-	v2 := sourceBundle(t, "@autono/hello", button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell", Version: "1.1.0"}, "#!/bin/sh\necho v2\n")
+	v1 := sourceBundle(t, "@autono/hello", button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell", Version: "1"}, "#!/bin/sh\necho v1\n")
+	v2 := sourceBundle(t, "@autono/hello", button.Button{SchemaVersion: 1, Name: "hello", Runtime: "shell", Version: "2"}, "#!/bin/sh\necho v2\n")
 	src := memorySource{
 		refs: []ButtonRef{
-			{Name: "@autono/hello", Kind: "button", Version: "1.0.0"},
-			{Name: "@autono/hello", Kind: "button", Version: "1.1.0"},
+			{Name: "@autono/hello", Kind: "button", Version: "1"},
+			{Name: "@autono/hello", Kind: "button", Version: "2"},
 		},
 		bundles: map[string]*Bundle{
-			"@autono/hello@1.0.0": v1,
-			"@autono/hello@1.1.0": v2,
+			"@autono/hello@1": v1,
+			"@autono/hello@2": v2,
 		},
 	}
 	m := &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{"@autono/hello": "latest"}}
 	prior := &manifest.Lockfile{SchemaVersion: 1, Dependencies: map[string]manifest.LockEntry{
-		"@autono/hello": {Kind: "button", Requested: "latest", Version: "1.0.0", ContentHash: "old", InstalledName: "hello", ResolvedAt: "then"},
+		"@autono/hello": {Kind: "button", Requested: "latest", Version: "1", ContentHash: "old", InstalledName: "hello", ResolvedAt: "then"},
 	}}
 
 	_, lock, err := InstallManifest(src, m, prior, InstallOptions{})
 	if err != nil {
 		t.Fatalf("install honoring lock: %v", err)
 	}
-	if got := lock.Dependencies["@autono/hello"].Version; got != "1.0.0" {
+	if got := lock.Dependencies["@autono/hello"].Version; got != "1" {
 		t.Fatalf("install should honor locked version, got %s", got)
 	}
 
@@ -160,23 +160,23 @@ func TestInstallManifestHonorsExistingLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh install: %v", err)
 	}
-	if got := lock.Dependencies["@autono/hello"].Version; got != "1.1.0" {
+	if got := lock.Dependencies["@autono/hello"].Version; got != "2" {
 		t.Fatalf("refresh should resolve latest, got %s", got)
 	}
 }
 
 func TestResolveExactAndLatest(t *testing.T) {
 	src := memorySource{refs: []ButtonRef{
-		{Name: "@autono/hello", Kind: "button", Version: "1.0.0"},
-		{Name: "@autono/hello", Kind: "button", Version: "1.1.0"},
+		{Name: "@autono/hello", Kind: "button", Version: "1"},
+		{Name: "@autono/hello", Kind: "button", Version: "2"},
 	}}
 	ref, err := Resolve(src, "@autono/hello", "")
-	if err != nil || ref.Version != "1.1.0" {
-		t.Fatalf("latest = %+v/%v, want 1.1.0", ref, err)
+	if err != nil || ref.Version != "2" {
+		t.Fatalf("latest = %+v/%v, want 2", ref, err)
 	}
-	ref, err = Resolve(src, "@autono/hello", "1.0.0")
-	if err != nil || ref.Version != "1.0.0" {
-		t.Fatalf("exact = %+v/%v, want 1.0.0", ref, err)
+	ref, err = Resolve(src, "@autono/hello", "1")
+	if err != nil || ref.Version != "1" {
+		t.Fatalf("exact = %+v/%v, want 1", ref, err)
 	}
 	if _, err := Resolve(src, "@autono/hello", "9.9.9"); err == nil {
 		t.Fatal("missing exact version should error")
@@ -186,7 +186,7 @@ func TestResolveExactAndLatest(t *testing.T) {
 type traversalSource struct{}
 
 func (traversalSource) Index() ([]ButtonRef, error) {
-	return []ButtonRef{{Name: "@autono/evil", Kind: "button", Version: "1.0.0"}}, nil
+	return []ButtonRef{{Name: "@autono/evil", Kind: "button", Version: "1"}}, nil
 }
 func (traversalSource) Fetch(name, version string) (*Bundle, error) {
 	bj, _ := json.Marshal(button.Button{SchemaVersion: 1, Name: "evil", Runtime: "shell", Version: version})
@@ -201,7 +201,7 @@ func (traversalSource) Fetch(name, version string) (*Bundle, error) {
 func TestInstallRejectsTraversalBundle(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("BUTTONS_HOME", home)
-	_, _, err := InstallManifest(traversalSource{}, &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{"@autono/evil": "1.0.0"}}, nil, InstallOptions{})
+	_, _, err := InstallManifest(traversalSource{}, &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{"@autono/evil": "1"}}, nil, InstallOptions{})
 	if err == nil {
 		t.Fatal("install should reject a bundle file that escapes the button dir")
 	}
@@ -227,7 +227,7 @@ func writeSourceButton(t *testing.T, root string, b button.Button) {
 
 func TestFetchRejectsTraversalName(t *testing.T) {
 	src := t.TempDir()
-	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "ok", Runtime: "shell", Version: "1.0.0"})
+	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "ok", Runtime: "shell", Version: "1"})
 	ls := &LocalSource{Root: src}
 	for _, bad := range []string{"../escape", "..", ".", "a/b", "/abs"} {
 		if _, err := ls.Fetch(bad, ""); err == nil {
@@ -241,12 +241,12 @@ func TestFetchRejectsTraversalName(t *testing.T) {
 
 func TestFetchVersionMismatch(t *testing.T) {
 	src := t.TempDir()
-	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "pin", Runtime: "shell", Version: "1.0.0"})
+	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "pin", Runtime: "shell", Version: "1"})
 	ls := &LocalSource{Root: src}
 	if _, err := ls.Fetch("pin", "9.9.9"); err == nil {
 		t.Error("Fetch with mismatched version pin should error")
 	}
-	if _, err := ls.Fetch("pin", "1.0.0"); err != nil {
+	if _, err := ls.Fetch("pin", "1"); err != nil {
 		t.Errorf("Fetch with matching version pin should succeed: %v", err)
 	}
 	if _, err := ls.Fetch("pin", ""); err != nil {
@@ -274,7 +274,7 @@ func TestSafeJoin(t *testing.T) {
 
 func TestFetchSkipsSymlinks(t *testing.T) {
 	src := t.TempDir()
-	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "ok", Runtime: "shell", Version: "1.0.0"})
+	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "ok", Runtime: "shell", Version: "1"})
 	secret := filepath.Join(t.TempDir(), "secret.txt")
 	if err := os.WriteFile(secret, []byte("top secret"), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/updater/content_test.go
+++ b/internal/updater/content_test.go
@@ -167,13 +167,13 @@ func installFromRegistry(t *testing.T, home, url, key string, deps map[string]st
 func TestApplyContentUpdateFromManifest(t *testing.T) {
 	home := t.TempDir()
 	reg := newTestRegistry("rk")
-	reg.addButton(t, "@autono/hello", "hello", "1.0.0", "#!/bin/sh\necho v1\n")
+	reg.addButton(t, "@autono/hello", "hello", "1", "#!/bin/sh\necho v1\n")
 	srv := httptest.NewServer(reg.handler())
 	defer srv.Close()
 
 	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/hello": "latest"})
 
-	reg.addButton(t, "@autono/hello", "hello", "1.1.0", "#!/bin/sh\necho v2\n")
+	reg.addButton(t, "@autono/hello", "hello", "2", "#!/bin/sh\necho v2\n")
 	report, err := Check(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
 	if err != nil {
 		t.Fatalf("check: %v", err)
@@ -189,27 +189,27 @@ func TestApplyContentUpdateFromManifest(t *testing.T) {
 	if len(result.UpdatedButtons) != 1 || result.UpdatedButtons[0] != "hello" {
 		t.Fatalf("updated buttons = %v, want [hello]", result.UpdatedButtons)
 	}
-	if got := readInstalledButton(t, home, "hello"); got.Version != "1.1.0" {
-		t.Fatalf("installed version = %q, want 1.1.0", got.Version)
+	if got := readInstalledButton(t, home, "hello"); got.Version != "2" {
+		t.Fatalf("installed version = %q, want 2", got.Version)
 	}
 	lock, err := manifest.LoadLockfile()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := lock.Dependencies["@autono/hello"].Version; got != "1.1.0" {
-		t.Fatalf("lock version = %q, want 1.1.0", got)
+	if got := lock.Dependencies["@autono/hello"].Version; got != "2" {
+		t.Fatalf("lock version = %q, want 2", got)
 	}
 }
 
 func TestPinnedContentDoesNotUpdate(t *testing.T) {
 	home := t.TempDir()
 	reg := newTestRegistry("rk")
-	reg.addButton(t, "@autono/hello", "hello", "1.0.0", "#!/bin/sh\necho v1\n")
+	reg.addButton(t, "@autono/hello", "hello", "1", "#!/bin/sh\necho v1\n")
 	srv := httptest.NewServer(reg.handler())
 	defer srv.Close()
 
-	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/hello": "1.0.0"})
-	reg.addButton(t, "@autono/hello", "hello", "1.1.0", "#!/bin/sh\necho v2\n")
+	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/hello": "1"})
+	reg.addButton(t, "@autono/hello", "hello", "2", "#!/bin/sh\necho v2\n")
 
 	report, err := Check(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
 	if err != nil {
@@ -225,15 +225,15 @@ func TestPinnedContentDoesNotUpdate(t *testing.T) {
 	if len(result.UpdatedButtons) != 0 {
 		t.Fatalf("updated pinned buttons = %v, want none", result.UpdatedButtons)
 	}
-	if got := readInstalledButton(t, home, "hello"); got.Version != "1.0.0" {
-		t.Fatalf("pinned installed version = %q, want 1.0.0", got.Version)
+	if got := readInstalledButton(t, home, "hello"); got.Version != "1" {
+		t.Fatalf("pinned installed version = %q, want 1", got.Version)
 	}
 }
 
 func TestApplyContentUpdateSkipsLocalEdits(t *testing.T) {
 	home := t.TempDir()
 	reg := newTestRegistry("rk")
-	reg.addButton(t, "@autono/hello", "hello", "1.0.0", "#!/bin/sh\necho v1\n")
+	reg.addButton(t, "@autono/hello", "hello", "1", "#!/bin/sh\necho v1\n")
 	srv := httptest.NewServer(reg.handler())
 	defer srv.Close()
 
@@ -241,7 +241,7 @@ func TestApplyContentUpdateSkipsLocalEdits(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(home, "buttons", "hello", "main.sh"), []byte("#!/bin/sh\necho local\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	reg.addButton(t, "@autono/hello", "hello", "1.1.0", "#!/bin/sh\necho v2\n")
+	reg.addButton(t, "@autono/hello", "hello", "2", "#!/bin/sh\necho v2\n")
 
 	result, err := Apply(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
 	if err != nil {

--- a/internal/updater/version_test.go
+++ b/internal/updater/version_test.go
@@ -12,6 +12,7 @@ func TestCompareVersions(t *testing.T) {
 		{"1.2.3", "1.2.4", -1},
 		{"1.10.0", "1.9.9", 1},
 		{"1.2", "1.2.0", 0},
+		{"1", "2", -1},
 		{"dev", "v1.0.0", 1},
 	}
 	for _, c := range cases {

--- a/test/integration/ota_update_test.go
+++ b/test/integration/ota_update_test.go
@@ -236,7 +236,7 @@ func TestUpdateRefreshesFloatingDependency(t *testing.T) {
 	publisher := newTestEnv(t)
 	agent := newTestEnv(t)
 
-	writeOTAPublishButton(t, publisher.home, "hello", "1.0.0", "#!/bin/sh\necho v1\n")
+	writeOTAPublishButton(t, publisher.home, "hello", "1", "#!/bin/sh\necho v1\n")
 	res := publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/hello", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("publish v1 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
@@ -249,11 +249,11 @@ func TestUpdateRefreshesFloatingDependency(t *testing.T) {
 	if got := readManifestDependency(t, agent.home, "@autono/hello"); got != "latest" {
 		t.Fatalf("manifest dependency = %q, want latest", got)
 	}
-	if got := readInstalledVersion(t, agent.home, "hello"); got != "1.0.0" {
-		t.Fatalf("installed version = %q, want 1.0.0", got)
+	if got := readInstalledVersion(t, agent.home, "hello"); got != "1" {
+		t.Fatalf("installed version = %q, want 1", got)
 	}
-	if got := readLockVersion(t, agent.home, "@autono/hello"); got != "1.0.0" {
-		t.Fatalf("lock version = %q, want 1.0.0", got)
+	if got := readLockVersion(t, agent.home, "@autono/hello"); got != "1" {
+		t.Fatalf("lock version = %q, want 1", got)
 	}
 	events := readLifecycleEvents(t, agent.home)
 	if len(events) != 1 || events[0].Action != "add" || events[0].PackageName != "@autono/hello" || events[0].Requested != "latest" {
@@ -269,7 +269,7 @@ func TestUpdateRefreshesFloatingDependency(t *testing.T) {
 		t.Fatalf("history after install = %+v, want second action install", events)
 	}
 
-	writeOTAPublishButton(t, publisher.home, "hello", "1.1.0", "#!/bin/sh\necho v2\n")
+	writeOTAPublishButton(t, publisher.home, "hello", "1", "#!/bin/sh\necho v2\n")
 	res = publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/hello", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("publish v2 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
@@ -291,11 +291,11 @@ func TestUpdateRefreshesFloatingDependency(t *testing.T) {
 	if update.ExitCode != 0 {
 		t.Fatalf("update failed: stdout=%s stderr=%s", update.Stdout, update.Stderr)
 	}
-	if got := readInstalledVersion(t, agent.home, "hello"); got != "1.1.0" {
-		t.Fatalf("updated version = %q, want 1.1.0", got)
+	if got := readInstalledVersion(t, agent.home, "hello"); got != "2" {
+		t.Fatalf("updated version = %q, want 2", got)
 	}
-	if got := readLockVersion(t, agent.home, "@autono/hello"); got != "1.1.0" {
-		t.Fatalf("updated lock version = %q, want 1.1.0", got)
+	if got := readLockVersion(t, agent.home, "@autono/hello"); got != "2" {
+		t.Fatalf("updated lock version = %q, want 2", got)
 	}
 	body, err := os.ReadFile(filepath.Join(agent.home, "buttons", "hello", "main.sh"))
 	if err != nil {
@@ -314,34 +314,34 @@ func TestUpdateDoesNotMoveExactPin(t *testing.T) {
 	publisher := newTestEnv(t)
 	agent := newTestEnv(t)
 
-	writeOTAPublishButton(t, publisher.home, "hello", "1.0.0", "#!/bin/sh\necho v1\n")
+	writeOTAPublishButton(t, publisher.home, "hello", "1", "#!/bin/sh\necho v1\n")
 	res := publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/hello", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("publish v1 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
 	}
-	writeOTAPublishButton(t, publisher.home, "hello", "1.1.0", "#!/bin/sh\necho v2\n")
+	writeOTAPublishButton(t, publisher.home, "hello", "1", "#!/bin/sh\necho v2\n")
 	res = publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/hello", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("publish v2 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
 	}
 
-	res = agent.runWithEnv(registryEnv(srv.URL), "add", "@autono/hello@1.0.0", "--json")
+	res = agent.runWithEnv(registryEnv(srv.URL), "add", "@autono/hello@1", "--json")
 	if res.ExitCode != 0 {
 		t.Fatalf("add exact pin failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
 	}
-	if got := readManifestDependency(t, agent.home, "@autono/hello"); got != "1.0.0" {
-		t.Fatalf("manifest dependency = %q, want 1.0.0", got)
+	if got := readManifestDependency(t, agent.home, "@autono/hello"); got != "1" {
+		t.Fatalf("manifest dependency = %q, want 1", got)
 	}
-	if got := readInstalledVersion(t, agent.home, "hello"); got != "1.0.0" {
-		t.Fatalf("installed version = %q, want 1.0.0", got)
+	if got := readInstalledVersion(t, agent.home, "hello"); got != "1" {
+		t.Fatalf("installed version = %q, want 1", got)
 	}
 
 	update := agent.runWithEnv(registryEnv(srv.URL), "update", "--json")
 	if update.ExitCode != 0 {
 		t.Fatalf("update failed: stdout=%s stderr=%s", update.Stdout, update.Stderr)
 	}
-	if got := readInstalledVersion(t, agent.home, "hello"); got != "1.0.0" {
-		t.Fatalf("pinned version moved to %q, want 1.0.0", got)
+	if got := readInstalledVersion(t, agent.home, "hello"); got != "1" {
+		t.Fatalf("pinned version moved to %q, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- create new buttons with `version: "1"` in `button.json`
- publish the current integer version, and if the registry reports `VERSION_EXISTS`, bump to the next number and retry
- update local manifest/lock validation, install/add help, generated CLI docs, and registry docs to use integer pins like `@desk/name@1`

## Why

Users should not have to manage semver-style `0.1.0` values or read timestamp-like versions. Button content releases should be simple: `1`, `2`, `3`.

## Validation

- RED: `go test ./internal/button -run TestService_Create -count=1` failed while create still wrote `0.1.0` / timestamp versions
- RED: `go test ./internal/store -run TestPublishToRegistryStampsAutomaticVersion -count=1` failed while registry publish still required pre-set versions
- `go test ./internal/button -run TestService_Create -count=1`
- `go test ./internal/store -run 'TestPublishToRegistry(StampsAutomaticVersion|BumpsSimpleVersionOnConflict)' -count=1`\n- `go test ./internal/manifest ./internal/updater -count=1`\n- `go test -count=1 ./test/integration/...`\n- `go test ./...`\n- `git diff --check`\n- regenerated CLI docs: `go run ./internal/tools/docgen -out ./docs/cli -format markdown -frontmatter`\n- regenerated skill: `go run ./internal/tools/skillgen -out ./.agents/skills/buttons/SKILL.md`\n- temp-project smoke: built local binary, ran `buttons init`, `buttons create ota-smoke --code 'echo "ota smoke"'`, and verified `.buttons/buttons/ota-smoke/button.json` has `version: "1"`\n\nCompanion registry PR: https://github.com/autonoco/buttons-registry/pull/15\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button versions now start at `1`, and publishing can automatically move to the next version when a version already exists.
  * Exact version pins now use simple numbers like `@name@1`.

* **Bug Fixes**
  * Improved registry publishing and install/update flows so exact pins stay fixed while floating references can resolve to newer versions.

* **Documentation**
  * Updated CLI and concept docs to reflect the new versioning and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->