### PR TITLE
Install shell completions via Homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,6 +82,15 @@ homebrew_casks:
   - name: buttons
     binaries:
       - buttons
+    generate_completions_from_executable:
+      executable: buttons
+      shell_parameter_format: cobra
+      base_name: buttons
+      shells:
+        - bash
+        - zsh
+        - fish
+        - pwsh
     repository:
       owner: autonoco
       name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ brew install autonoco/tap/buttons
 ```
 
 Tap is auto-updated by goreleaser on every release. `brew upgrade buttons` to update.
+Homebrew installs shell completions automatically, so tab completion works without a separate setup step.
 
 ### Go
 

--- a/cmd/board.go
+++ b/cmd/board.go
@@ -38,8 +38,9 @@ new window runs until you close it.
 Use ` + "`--inline`" + ` to render the board in the current terminal instead —
 helpful when you're SSH'd somewhere, inside a screen / tmux session
 you want to stay in, or on a headless machine without a window server.`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runBoard,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
+	RunE:              runBoard,
 }
 
 func runBoard(cmd *cobra.Command, args []string) error {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/spf13/cobra"
+)
+
+func completeFirstButtonName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return completeButtonNames(cmd, args, toComplete)
+}
+
+func completeButtonNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	used := make(map[string]struct{}, len(args))
+	for _, arg := range args {
+		used[button.Slugify(arg)] = struct{}{}
+	}
+
+	buttons, err := button.NewService().List()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := make([]string, 0, len(buttons))
+	for _, btn := range buttons {
+		if _, ok := used[btn.Name]; ok {
+			continue
+		}
+		if strings.HasPrefix(btn.Name, toComplete) {
+			completions = append(completions, btn.Name)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/spf13/cobra"
+)
+
+func TestCompleteButtonNamesFiltersByPrefix(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	svc := button.NewService()
+	if _, err := svc.Create(button.CreateOpts{Name: "deploy", Code: "echo deploy", Runtime: "shell", TimeoutSeconds: 10}); err != nil {
+		t.Fatalf("create deploy: %v", err)
+	}
+	if _, err := svc.Create(button.CreateOpts{Name: "ship", Code: "echo ship", Runtime: "shell", TimeoutSeconds: 10}); err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+
+	got, directive := completeButtonNames(&cobra.Command{}, nil, "dep")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want NoFileComp", directive)
+	}
+	if len(got) != 1 || got[0] != "deploy" {
+		t.Fatalf("completions = %#v, want [deploy]", got)
+	}
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -26,7 +26,8 @@ Examples:
   buttons delete deploy
   buttons delete deploy -F
   buttons delete deploy --json`,
-	Args: exactArgs(1),
+	Args:              exactArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := button.Slugify(args[0])
 		svc := button.NewService()

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -25,7 +25,8 @@ Examples:
   buttons history deploy
   buttons history deploy --last 5
   buttons history --json`,
-	Args: cobra.MaximumNArgs(1),
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var runs []history.Run
 		var err error

--- a/cmd/ignore.go
+++ b/cmd/ignore.go
@@ -39,15 +39,17 @@ while iterating.
 
 The .buttons/.gitignore file is a standard gitignore scoped to the
 .buttons/ subtree — git applies it natively, no extra config.`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runIgnore,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
+	RunE:              runIgnore,
 }
 
 var unignoreCmd = &cobra.Command{
-	Use:   "unignore [name]",
-	Short: "Re-include a previously-ignored button or drawer in git",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runUnignore,
+	Use:               "unignore [name]",
+	Short:             "Re-include a previously-ignored button or drawer in git",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
+	RunE:              runUnignore,
 }
 
 func init() {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -36,8 +36,9 @@ long-running press live.
 Agent mode (--json or non-TTY) returns the full Run shape for
 non-follow calls. TTY mode prints a compact one-line-per-run table.
 The verb-first form (buttons logs NAME) still works as an alias.`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runLogs,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
+	RunE:              runLogs,
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {

--- a/cmd/press.go
+++ b/cmd/press.go
@@ -44,7 +44,8 @@ Examples:
   buttons press weather --arg city=Miami --json
   buttons press deploy --dry-run
   buttons press slow-task --timeout 120`,
-	Args: exactArgs(1),
+	Args:              exactArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		svc := button.NewService()

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -32,7 +32,8 @@ the read key install uses.
 
 Examples:
   BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello`,
-	Args: exactArgs(1),
+	Args:              exactArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 

--- a/cmd/smash.go
+++ b/cmd/smash.go
@@ -42,8 +42,9 @@ var smashCmd = &cobra.Command{
 
 JSON mode returns an array of per-button results; every run is recorded in
 history. Exits non-zero if any button failed.`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: runSmash,
+	Args:              cobra.MinimumNArgs(1),
+	ValidArgsFunction: completeButtonNames,
+	RunE:              runSmash,
 }
 
 func runSmash(_ *cobra.Command, args []string) error {

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -41,9 +41,10 @@ var triggerAddFlags struct {
 }
 
 var triggerAddCmd = &cobra.Command{
-	Use:   "add <button>",
-	Short: "Add a trigger to a button",
-	Args:  exactArgs(1),
+	Use:               "add <button>",
+	Short:             "Add a trigger to a button",
+	Args:              exactArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
@@ -82,9 +83,10 @@ var triggerAddCmd = &cobra.Command{
 }
 
 var triggerListCmd = &cobra.Command{
-	Use:   "list [button]",
-	Short: "List triggers (all buttons, or one)",
-	Args:  cobra.MaximumNArgs(1),
+	Use:               "list [button]",
+	Short:             "List triggers (all buttons, or one)",
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		svc := button.NewService()
 		if len(args) == 1 {
@@ -124,9 +126,10 @@ var triggerListCmd = &cobra.Command{
 }
 
 var triggerRmCmd = &cobra.Command{
-	Use:   "rm <button> <trigger-id>",
-	Short: "Remove a trigger from a button",
-	Args:  exactArgs(2),
+	Use:               "rm <button> <trigger-id>",
+	Short:             "Remove a trigger from a button",
+	Args:              exactArgs(2),
+	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		svc := button.NewService()
 		if err := trigger.Remove(svc, args[0], args[1]); err != nil {

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -75,6 +75,8 @@ brew install autonoco/tap/buttons
 
 The tap auto-publishes on every release, so `brew upgrade buttons` always gets you the newest version. Supports macOS and Linux on both Intel and Apple Silicon.
 
+Homebrew also installs shell completions automatically on install and upgrade, so tab completion works without a separate `buttons completion ...` setup step.
+
 ## npm / pnpm / bun
 
 ```bash


### PR DESCRIPTION
## Summary
- generate Homebrew cask shell completions at install/upgrade time
- add local button-name completions for button-taking commands
- document automatic Homebrew completion setup

## Validation
- go test ./...
- goreleaser check
- HOMEBREW_TAP_TOKEN='' goreleaser release --snapshot --clean --skip=docker --timeout=5m
- completion smoke: temp buttons returned deploy for __complete press dep
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic shell completions for Homebrew installs and upgrades, so tab completion works without extra setup.
  * Improved command-line autocomplete for button names across common actions like press, delete, logs, history, ignore/unignore, publish, trigger, board, and smash.
* **Bug Fixes**
  * Completion suggestions now better match typed prefixes and avoid duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->