### PR TITLE
Apply passive button updates on every command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ buttons update           # install available CLI/content updates
 buttons update --json    # structured output
 ```
 
-`buttons update` checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`. Use `buttons status` for a read-only check. Homebrew installs are auto-detected — you'll be told to `brew upgrade buttons` instead. Docker users re-pull the image.
+`buttons update` checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`. Normal interactive commands also pass through the passive auto-update gate: floating button dependencies can refresh before the command runs, while CLI binary checks stay throttled. Homebrew installs are auto-detected — you'll be told to `brew upgrade buttons` instead. Docker users re-pull the image.
 
 ## Verify the installation
 

--- a/cmd/passive_update.go
+++ b/cmd/passive_update.go
@@ -34,21 +34,44 @@ func maybeRunPassiveUpdate(cmd *cobra.Command) {
 		return
 	}
 	st, err := svc.Load()
-	if err != nil || (!force && !st.AutoUpdateEnabled()) {
+	if err != nil {
 		return
 	}
-	now := time.Now()
-	last := st.LastUpdateCheckUnixOrZero()
-	if !force && last > 0 && now.Sub(time.Unix(last, 0)) < passiveUpdateThrottle {
+	plan := passiveUpdatePlan(st, force, time.Now())
+	if !plan.run {
 		return
 	}
-	if err := svc.SetLastUpdateCheckUnix(now.Unix()); err != nil {
-		return
+	opts.SkipBinary = plan.skipBinary
+	if plan.recordCheck {
+		if err := svc.SetLastUpdateCheckUnix(plan.now.Unix()); err != nil {
+			return
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 	_, _ = updater.Apply(ctx, opts)
+}
+
+type passiveUpdateDecision struct {
+	run         bool
+	skipBinary  bool
+	recordCheck bool
+	now         time.Time
+}
+
+func passiveUpdatePlan(st *settings.Settings, force bool, now time.Time) passiveUpdateDecision {
+	if force {
+		return passiveUpdateDecision{run: true, recordCheck: true, now: now}
+	}
+	if st == nil || !st.AutoUpdateEnabled() {
+		return passiveUpdateDecision{}
+	}
+	last := st.LastUpdateCheckUnixOrZero()
+	if last > 0 && now.Sub(time.Unix(last, 0)) < passiveUpdateThrottle {
+		return passiveUpdateDecision{run: true, skipBinary: true, now: now}
+	}
+	return passiveUpdateDecision{run: true, recordCheck: true, now: now}
 }
 
 func shouldSkipPassiveUpdate() bool {

--- a/cmd/passive_update_test.go
+++ b/cmd/passive_update_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/autonoco/buttons/internal/settings"
 	"github.com/spf13/cobra"
 )
 
@@ -32,5 +34,28 @@ func TestPassiveUpdateSkipsCIWithoutRegistryProbe(t *testing.T) {
 
 	if got := hits.Load(); got != 0 {
 		t.Fatalf("registry probe count = %d, want 0", got)
+	}
+}
+
+func TestPassiveUpdatePlanRunsContentInsideBinaryThrottle(t *testing.T) {
+	autoUpdate := true
+	now := time.Unix(2000, 0)
+	last := now.Add(-time.Minute).Unix()
+	st := &settings.Settings{
+		Defaults: settings.Defaults{
+			AutoUpdate:          &autoUpdate,
+			LastUpdateCheckUnix: &last,
+		},
+	}
+
+	plan := passiveUpdatePlan(st, false, now)
+	if !plan.run {
+		t.Fatal("passive content update should run even when binary check is throttled")
+	}
+	if !plan.skipBinary {
+		t.Fatal("binary update should stay throttled")
+	}
+	if plan.recordCheck {
+		t.Fatal("content-only passive update should not refresh binary throttle timestamp")
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,7 +16,8 @@ var statusCmd = &cobra.Command{
 	Long: `Show whether the buttons CLI or manifest dependencies have updates.
 
 Like every user-invoked command, status also enters the passive auto-update
-gate before it prints. Use 'buttons update' to force an update immediately.`,
+gate before it prints. Floating button dependencies may refresh before status
+reports. Use 'buttons update' to force the full update path immediately.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		report, err := updater.Check(context.Background(), updater.Options{

--- a/docs/cli/buttons_status.md
+++ b/docs/cli/buttons_status.md
@@ -12,7 +12,8 @@ Show available CLI and button updates
 Show whether the buttons CLI or manifest dependencies have updates.
 
 Like every user-invoked command, status also enters the passive auto-update
-gate before it prints. Use 'buttons update' to force an update immediately.
+gate before it prints. Floating button dependencies may refresh before status
+reports. Use 'buttons update' to force the full update path immediately.
 
 ```
 buttons status [flags]
@@ -35,4 +36,3 @@ buttons status [flags]
 ### SEE ALSO
 
 * [buttons](buttons.md)	 - Deterministic workflow engine for agents
-

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -106,7 +106,9 @@ The fastest way to update is the built-in self-update command:
 buttons update
 ```
 
-This checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`. Use `buttons status` for a read-only check.
+This checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`.
+
+Normal interactive commands also pass through the passive auto-update gate. Floating button dependencies can refresh before the command runs; CLI binary checks stay throttled so every command does not hit GitHub.
 
 You can also update through your original install channel:
 


### PR DESCRIPTION
## Summary
- keep passive CLI binary checks throttled
- allow floating registry button updates to run on every interactive command
- update status/help/docs wording so status is not described as purely read-only under auto-update

## Validation
- go test ./...
- git diff --check