### PR TITLE
Opt into package-manager CLI auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ buttons update           # install available CLI/content updates
 buttons update --json    # structured output
 ```
 
-`buttons update` checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`. Normal interactive commands also pass through the passive auto-update gate: floating button dependencies can refresh before the command runs, while CLI binary checks stay throttled. Homebrew installs are auto-detected — you'll be told to `brew upgrade buttons` instead. Docker users re-pull the image.
+`buttons update` checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`. Normal interactive commands can also update before they run: `buttons-auto-update` refreshes floating button dependencies and defaults on; `cli-auto-update` updates the CLI binary when the throttle allows and defaults off. Homebrew installs are auto-detected and left to Homebrew unless `cli-auto-update` is enabled. To opt in, run `buttons config set cli-auto-update true` or set `BUTTONS_CLI_AUTO_UPDATE=1`. Docker users re-pull the image.
 
 ## Verify the installation
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -25,8 +25,12 @@ Known keys:
                     an explicit --timeout flag (fallback: 300)
   theme             board TUI theme: default | paper | phosphor | amber
                     (fallback: default — adapts to terminal background)
-  auto-update       true | false; passive update checks before CLI commands
-                    (fallback: true)
+  buttons-auto-update
+                    true | false; refresh floating installed buttons before
+                    CLI commands (fallback: true)
+  cli-auto-update   true | false; update the CLI binary before commands when
+                    the throttle allows it; Homebrew uses brew upgrade
+                    (fallback: false)
 
 Running ` + "`buttons config`" + ` with no subcommand prints the current values.
 
@@ -37,7 +41,8 @@ Examples:
   buttons config
   buttons config set default-timeout 600
   buttons config set theme amber
-  buttons config set auto-update false
+  buttons config set buttons-auto-update false
+  buttons config set cli-auto-update true
   buttons config unset theme`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return showConfig()
@@ -105,7 +110,8 @@ func showConfig() error {
 		if v, ok := st.Theme(); ok {
 			payload[settings.KeyTheme] = v
 		}
-		payload[settings.KeyAutoUpdate] = st.AutoUpdateEnabled()
+		payload[settings.KeyButtonsAutoUpdate] = st.ButtonsAutoUpdateEnabled()
+		payload[settings.KeyCLIAutoUpdate] = st.CLIAutoUpdateEnabled()
 		return config.WriteJSON(payload)
 	}
 
@@ -126,7 +132,8 @@ func showConfig() error {
 	} else {
 		render(settings.KeyTheme, nil, "default (adaptive)")
 	}
-	render(settings.KeyAutoUpdate, st.AutoUpdateEnabled(), "")
+	render(settings.KeyButtonsAutoUpdate, st.ButtonsAutoUpdateEnabled(), "")
+	render(settings.KeyCLIAutoUpdate, st.CLIAutoUpdateEnabled(), "")
 	return nil
 }
 

--- a/cmd/passive_update.go
+++ b/cmd/passive_update.go
@@ -37,11 +37,13 @@ func maybeRunPassiveUpdate(cmd *cobra.Command) {
 	if err != nil {
 		return
 	}
+	opts.CLIAutoUpdate = st.CLIAutoUpdateEnabled() || force
 	plan := passiveUpdatePlan(st, force, time.Now())
 	if !plan.run {
 		return
 	}
 	opts.SkipBinary = plan.skipBinary
+	opts.SkipContent = plan.skipContent
 	if plan.recordCheck {
 		if err := svc.SetLastUpdateCheckUnix(plan.now.Unix()); err != nil {
 			return
@@ -56,22 +58,43 @@ func maybeRunPassiveUpdate(cmd *cobra.Command) {
 type passiveUpdateDecision struct {
 	run         bool
 	skipBinary  bool
+	skipContent bool
 	recordCheck bool
 	now         time.Time
 }
 
 func passiveUpdatePlan(st *settings.Settings, force bool, now time.Time) passiveUpdateDecision {
-	if force {
-		return passiveUpdateDecision{run: true, recordCheck: true, now: now}
-	}
-	if st == nil || !st.AutoUpdateEnabled() {
+	if st == nil {
 		return passiveUpdateDecision{}
+	}
+	buttonsEnabled := st.ButtonsAutoUpdateEnabled()
+	cliEnabled := st.CLIAutoUpdateEnabled() || force
+	if !buttonsEnabled && !cliEnabled {
+		return passiveUpdateDecision{}
+	}
+	decision := passiveUpdateDecision{
+		run:         true,
+		skipBinary:  !cliEnabled,
+		skipContent: !buttonsEnabled,
+		now:         now,
+	}
+	if !cliEnabled {
+		return decision
+	}
+	if force {
+		decision.recordCheck = true
+		return decision
 	}
 	last := st.LastUpdateCheckUnixOrZero()
 	if last > 0 && now.Sub(time.Unix(last, 0)) < passiveUpdateThrottle {
-		return passiveUpdateDecision{run: true, skipBinary: true, now: now}
+		decision.skipBinary = true
+		if decision.skipContent {
+			decision.run = false
+		}
+		return decision
 	}
-	return passiveUpdateDecision{run: true, recordCheck: true, now: now}
+	decision.recordCheck = true
+	return decision
 }
 
 func shouldSkipPassiveUpdate() bool {

--- a/cmd/passive_update_test.go
+++ b/cmd/passive_update_test.go
@@ -38,12 +38,14 @@ func TestPassiveUpdateSkipsCIWithoutRegistryProbe(t *testing.T) {
 }
 
 func TestPassiveUpdatePlanRunsContentInsideBinaryThrottle(t *testing.T) {
-	autoUpdate := true
+	buttonsAutoUpdate := true
+	cliAutoUpdate := true
 	now := time.Unix(2000, 0)
 	last := now.Add(-time.Minute).Unix()
 	st := &settings.Settings{
 		Defaults: settings.Defaults{
-			AutoUpdate:          &autoUpdate,
+			ButtonsAutoUpdate:   &buttonsAutoUpdate,
+			CLIAutoUpdate:       &cliAutoUpdate,
 			LastUpdateCheckUnix: &last,
 		},
 	}
@@ -57,5 +59,30 @@ func TestPassiveUpdatePlanRunsContentInsideBinaryThrottle(t *testing.T) {
 	}
 	if plan.recordCheck {
 		t.Fatal("content-only passive update should not refresh binary throttle timestamp")
+	}
+}
+
+func TestPassiveUpdatePlanRunsButtonsWhenCLIAutoUpdateDisabled(t *testing.T) {
+	buttonsAutoUpdate := true
+	cliAutoUpdate := false
+	st := &settings.Settings{
+		Defaults: settings.Defaults{
+			ButtonsAutoUpdate: &buttonsAutoUpdate,
+			CLIAutoUpdate:     &cliAutoUpdate,
+		},
+	}
+
+	plan := passiveUpdatePlan(st, false, time.Unix(2000, 0))
+	if !plan.run {
+		t.Fatal("passive button update should run")
+	}
+	if !plan.skipBinary {
+		t.Fatal("CLI binary update should be skipped")
+	}
+	if plan.skipContent {
+		t.Fatal("button content update should not be skipped")
+	}
+	if plan.recordCheck {
+		t.Fatal("button-only passive update should not refresh CLI throttle timestamp")
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,9 +15,10 @@ var statusCmd = &cobra.Command{
 	Short: "Show available CLI and button updates",
 	Long: `Show whether the buttons CLI or manifest dependencies have updates.
 
-Like every user-invoked command, status also enters the passive auto-update
-gate before it prints. Floating button dependencies may refresh before status
-reports. Use 'buttons update' to force the full update path immediately.`,
+Like every user-invoked command, status also enters enabled passive update
+paths before it prints. buttons-auto-update may refresh floating button
+dependencies; cli-auto-update may update the CLI binary when the throttle
+allows. Use 'buttons update' to force the full update path immediately.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		report, err := updater.Check(context.Background(), updater.Options{

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/settings"
 	"github.com/autonoco/buttons/internal/updater"
 	"github.com/spf13/cobra"
 )
@@ -24,12 +26,7 @@ Examples:
   buttons update --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := updater.Apply(context.Background(), updater.Options{
-			CurrentVersion: version,
-			RegistryURL:    registryURL(),
-			RegistryKey:    registryKey(),
-			Writer:         os.Stderr,
-		})
+		result, err := updater.Apply(context.Background(), updaterOptions(os.Stderr))
 		if err != nil {
 			if jsonOutput {
 				_ = config.WriteJSONError("UPDATE_ERROR", err.Error())
@@ -43,6 +40,21 @@ Examples:
 		printUpdateResult(result)
 		return nil
 	},
+}
+
+func updaterOptions(writer io.Writer) updater.Options {
+	opts := updater.Options{
+		CurrentVersion: version,
+		RegistryURL:    registryURL(),
+		RegistryKey:    registryKey(),
+		Writer:         writer,
+	}
+	if svc, err := settings.NewServiceFromEnv(); err == nil {
+		if st, err := svc.Load(); err == nil {
+			opts.CLIAutoUpdate = st.CLIAutoUpdateEnabled()
+		}
+	}
+	return opts
 }
 
 func printUpdateResult(result *updater.Result) {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"io"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/settings"
+)
+
+func TestUpdaterOptionsReadsCLIAutoUpdateSetting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+
+	svc := settings.NewService(home)
+	if err := svc.Set(settings.KeyCLIAutoUpdate, "true"); err != nil {
+		t.Fatalf("set cli-auto-update: %v", err)
+	}
+
+	opts := updaterOptions(io.Discard)
+	if !opts.CLIAutoUpdate {
+		t.Fatal("CLIAutoUpdate = false, want true")
+	}
+}

--- a/docs/cli/buttons_config.md
+++ b/docs/cli/buttons_config.md
@@ -23,8 +23,12 @@ Known keys:
                     an explicit --timeout flag (fallback: 300)
   theme             board TUI theme: default | paper | phosphor | amber
                     (fallback: default — adapts to terminal background)
-  auto-update       true | false; passive update checks before CLI commands
-                    (fallback: true)
+  buttons-auto-update
+                    true | false; refresh floating installed buttons before
+                    CLI commands (fallback: true)
+  cli-auto-update   true | false; update the CLI binary before commands when
+                    the throttle allows it; Homebrew uses brew upgrade
+                    (fallback: false)
 ```
 
 Running `buttons config` with no subcommand prints the current values.
@@ -38,7 +42,8 @@ then settings, then default. Env override keeps A/B comparison easy.
 buttons config
 buttons config set default-timeout 600
 buttons config set theme amber
-buttons config set auto-update false
+buttons config set buttons-auto-update false
+buttons config set cli-auto-update true
 buttons config unset theme
 ```
 
@@ -65,4 +70,3 @@ buttons config [flags]
 * [buttons](buttons.md)	 - Deterministic workflow engine for agents
 * [buttons config set](buttons_config_set.md)	 - Set a setting
 * [buttons config unset](buttons_config_unset.md)	 - Clear a setting (revert to built-in default)
-

--- a/docs/cli/buttons_status.md
+++ b/docs/cli/buttons_status.md
@@ -11,9 +11,10 @@ Show available CLI and button updates
 
 Show whether the buttons CLI or manifest dependencies have updates.
 
-Like every user-invoked command, status also enters the passive auto-update
-gate before it prints. Floating button dependencies may refresh before status
-reports. Use 'buttons update' to force the full update path immediately.
+Like every user-invoked command, status also enters enabled passive update
+paths before it prints. buttons-auto-update may refresh floating button
+dependencies; cli-auto-update may update the CLI binary when the throttle
+allows. Use 'buttons update' to force the full update path immediately.
 
 ```
 buttons status [flags]

--- a/docs/cli/buttons_update.md
+++ b/docs/cli/buttons_update.md
@@ -15,6 +15,14 @@ The CLI binary is updated from GitHub Releases. Button dependencies are
 refreshed from .buttons/buttons.json and .buttons/buttons-lock.json. Exact
 versions are pins; update moves only dependencies requested as "latest".
 
+Homebrew-managed installs are left to Homebrew by default. To let Buttons update
+the CLI through Homebrew and run passive CLI binary updates when the throttle
+allows, run:
+
+```bash
+buttons config set cli-auto-update true
+```
+
 **Examples:**
 
 ```bash
@@ -43,4 +51,3 @@ buttons update [flags]
 ### SEE ALSO
 
 * [buttons](buttons.md)	 - Deterministic workflow engine for agents
-

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -108,7 +108,7 @@ buttons update
 
 This checks GitHub Releases for the CLI and refreshes floating button dependencies from `.buttons/buttons.json` and `.buttons/buttons-lock.json`.
 
-Normal interactive commands also pass through the passive auto-update gate. Floating button dependencies can refresh before the command runs; CLI binary checks stay throttled so every command does not hit GitHub.
+Normal interactive commands can also update before they run. `buttons-auto-update` refreshes floating button dependencies and defaults on. `cli-auto-update` updates the CLI binary when the throttle allows and defaults off, so every command does not hit GitHub or Homebrew.
 
 You can also update through your original install channel:
 
@@ -122,5 +122,7 @@ You can also update through your original install channel:
 | npm | `npm update -g @autono/buttons` |
 
 <Note>
-If you installed via Homebrew, `buttons update` detects this and asks you to use `brew upgrade` instead.
+If you installed via Homebrew, `buttons update` detects this and asks you to use `brew upgrade` by default.
+To let Buttons update the CLI through Homebrew, run `buttons config set cli-auto-update true`
+or set `BUTTONS_CLI_AUTO_UPDATE=1`.
 </Note>

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -35,7 +35,8 @@ type Settings struct {
 type Defaults struct {
 	TimeoutSeconds      *int    `json:"timeout_seconds,omitempty"`
 	Theme               *string `json:"theme,omitempty"`
-	AutoUpdate          *bool   `json:"auto_update,omitempty"`
+	ButtonsAutoUpdate   *bool   `json:"buttons_auto_update,omitempty"`
+	CLIAutoUpdate       *bool   `json:"cli_auto_update,omitempty"`
 	LastUpdateCheckUnix *int64  `json:"last_update_check_unix,omitempty"`
 }
 
@@ -74,9 +75,10 @@ var ErrUnknownKey = errors.New("unknown settings key")
 // Known flat keys. Kept in one place so the CLI, Get, and Set agree
 // on what exists.
 const (
-	KeyDefaultTimeout = "default-timeout"
-	KeyTheme          = "theme"
-	KeyAutoUpdate     = "auto-update"
+	KeyDefaultTimeout    = "default-timeout"
+	KeyTheme             = "theme"
+	KeyButtonsAutoUpdate = "buttons-auto-update"
+	KeyCLIAutoUpdate     = "cli-auto-update"
 )
 
 // validThemes lists accepted theme names. Kept in settings (not tui)
@@ -153,12 +155,18 @@ func (s *Service) Set(key, value string) error {
 		}
 		v := value
 		st.Defaults.Theme = &v
-	case KeyAutoUpdate:
+	case KeyButtonsAutoUpdate:
 		v, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("%s expects true or false, got %q", key, value)
 		}
-		st.Defaults.AutoUpdate = &v
+		st.Defaults.ButtonsAutoUpdate = &v
+	case KeyCLIAutoUpdate:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("%s expects true or false, got %q", key, value)
+		}
+		st.Defaults.CLIAutoUpdate = &v
 	default:
 		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
 	}
@@ -176,8 +184,10 @@ func (s *Service) Unset(key string) error {
 		st.Defaults.TimeoutSeconds = nil
 	case KeyTheme:
 		st.Defaults.Theme = nil
-	case KeyAutoUpdate:
-		st.Defaults.AutoUpdate = nil
+	case KeyButtonsAutoUpdate:
+		st.Defaults.ButtonsAutoUpdate = nil
+	case KeyCLIAutoUpdate:
+		st.Defaults.CLIAutoUpdate = nil
 	default:
 		return fmt.Errorf("%w: %q", ErrUnknownKey, key)
 	}
@@ -204,13 +214,20 @@ func (st *Settings) Theme() (string, bool) {
 	return *st.Defaults.Theme, true
 }
 
-// AutoUpdateEnabled returns true unless the user explicitly disables the
-// passive update gate.
-func (st *Settings) AutoUpdateEnabled() bool {
-	if st == nil || st.Defaults.AutoUpdate == nil {
+// ButtonsAutoUpdateEnabled returns true unless the user explicitly disables
+// passive updates for installed button content.
+func (st *Settings) ButtonsAutoUpdateEnabled() bool {
+	if st == nil || st.Defaults.ButtonsAutoUpdate == nil {
 		return true
 	}
-	return *st.Defaults.AutoUpdate
+	return *st.Defaults.ButtonsAutoUpdate
+}
+
+func (st *Settings) CLIAutoUpdateEnabled() bool {
+	if st == nil || st.Defaults.CLIAutoUpdate == nil {
+		return false
+	}
+	return *st.Defaults.CLIAutoUpdate
 }
 
 func (st *Settings) LastUpdateCheckUnixOrZero() int64 {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -70,42 +70,79 @@ func TestService_Set_Theme(t *testing.T) {
 	}
 }
 
-func TestService_AutoUpdateDefaultsOn(t *testing.T) {
+func TestService_ButtonsAutoUpdateDefaultsOn(t *testing.T) {
 	svc := NewService(t.TempDir())
 	st, err := svc.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !st.AutoUpdateEnabled() {
-		t.Fatal("auto-update should default on")
+	if !st.ButtonsAutoUpdateEnabled() {
+		t.Fatal("buttons-auto-update should default on")
 	}
 }
 
-func TestService_SetAutoUpdate(t *testing.T) {
+func TestService_SetButtonsAutoUpdate(t *testing.T) {
 	svc := NewService(t.TempDir())
-	if err := svc.Set(KeyAutoUpdate, "false"); err != nil {
+	if err := svc.Set(KeyButtonsAutoUpdate, "false"); err != nil {
 		t.Fatalf("set false: %v", err)
 	}
 	st, err := svc.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.AutoUpdateEnabled() {
-		t.Fatal("auto-update should be disabled")
+	if st.ButtonsAutoUpdateEnabled() {
+		t.Fatal("buttons-auto-update should be disabled")
 	}
 
-	if err := svc.Set(KeyAutoUpdate, "true"); err != nil {
+	if err := svc.Set(KeyButtonsAutoUpdate, "true"); err != nil {
 		t.Fatalf("set true: %v", err)
 	}
 	st, err = svc.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !st.AutoUpdateEnabled() {
-		t.Fatal("auto-update should be enabled")
+	if !st.ButtonsAutoUpdateEnabled() {
+		t.Fatal("buttons-auto-update should be enabled")
 	}
 
-	if err := svc.Set(KeyAutoUpdate, "maybe"); err == nil {
+	if err := svc.Set(KeyButtonsAutoUpdate, "maybe"); err == nil {
+		t.Fatal("invalid bool should fail")
+	}
+}
+
+func TestService_SetCLIAutoUpdate(t *testing.T) {
+	svc := NewService(t.TempDir())
+	st, err := svc.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.CLIAutoUpdateEnabled() {
+		t.Fatal("cli-auto-update should default off")
+	}
+
+	if err := svc.Set(KeyCLIAutoUpdate, "true"); err != nil {
+		t.Fatalf("set true: %v", err)
+	}
+	st, err = svc.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.CLIAutoUpdateEnabled() {
+		t.Fatal("cli-auto-update should be enabled")
+	}
+
+	if err := svc.Set(KeyCLIAutoUpdate, "false"); err != nil {
+		t.Fatalf("set false: %v", err)
+	}
+	st, err = svc.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.CLIAutoUpdateEnabled() {
+		t.Fatal("cli-auto-update should be disabled")
+	}
+
+	if err := svc.Set(KeyCLIAutoUpdate, "maybe"); err == nil {
 		t.Fatal("invalid bool should fail")
 	}
 }

--- a/internal/updater/binary.go
+++ b/internal/updater/binary.go
@@ -8,16 +8,19 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
 
 const releasesAPI = "https://api.github.com/repos/autonoco/buttons/releases/latest"
+const cliAutoUpdateEnv = "BUTTONS_CLI_AUTO_UPDATE"
 
 type ghRelease struct {
 	TagName string    `json:"tag_name"`
@@ -76,6 +79,13 @@ func applyBinary(ctx context.Context, opts Options, report BinaryReport) (bool, 
 	}
 	if isHomebrewManaged(execPath) {
 		report.HomebrewManaged = true
+		if cliAutoUpdateEnabled(opts) {
+			if err := runHomebrewUpgrade(ctx, opts); err != nil {
+				report.Error = err.Error()
+				return false, report
+			}
+			return true, report
+		}
 		report.Error = "this binary is managed by Homebrew; run 'brew upgrade buttons' instead"
 		return false, report
 	}
@@ -284,4 +294,28 @@ func isHomebrewManaged(path string) bool {
 	return strings.Contains(path, "/Cellar/") ||
 		strings.Contains(path, "/opt/homebrew/") ||
 		strings.Contains(path, "/usr/local/Cellar/")
+}
+
+func cliAutoUpdateEnabled(opts Options) bool {
+	if opts.CLIAutoUpdate {
+		return true
+	}
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(cliAutoUpdateEnv)))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}
+
+func runHomebrewUpgrade(ctx context.Context, opts Options) error {
+	out := opts.output()
+	fmt.Fprintln(out, "Updating buttons via Homebrew")
+	// #nosec G204 G702 -- command and args are fixed; Homebrew delegation only runs after CLI auto-update opt-in.
+	cmd := exec.CommandContext(ctx, "brew", "upgrade", "buttons")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("CLI auto-update is enabled but brew was not found on PATH")
+		}
+		return fmt.Errorf("brew upgrade buttons failed: %w", err)
+	}
+	return nil
 }

--- a/internal/updater/binary_test.go
+++ b/internal/updater/binary_test.go
@@ -108,3 +108,62 @@ func TestApplyBinaryUsesCheckedReleaseSnapshot(t *testing.T) {
 		t.Fatalf("binary mode = %o, want 700", got)
 	}
 }
+
+func TestApplyBinaryHomebrewUsesPackageManagerWhenOptedIn(t *testing.T) {
+	releaseJSON := []byte(`{"tag_name":"v2.0.0","assets":[]}`)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() == releasesAPI {
+			return testHTTPResponse(http.StatusOK, releaseJSON), nil
+		}
+		return testHTTPResponse(http.StatusNotFound, nil), nil
+	})}
+
+	binDir := filepath.Join(t.TempDir(), "opt", "homebrew", "Cellar", "buttons", "1.0.0", "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	execPath := filepath.Join(binDir, "buttons")
+	if err := os.WriteFile(execPath, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := t.TempDir()
+	argvPath := filepath.Join(t.TempDir(), "brew-argv")
+	brewPath := filepath.Join(fakeBin, "brew")
+	brewScript := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\n", argvPath)
+	if err := os.WriteFile(brewPath, []byte(brewScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	result, err := Apply(context.Background(), Options{
+		CurrentVersion: "1.0.0",
+		Client:         client,
+		ExecutablePath: execPath,
+		SkipContent:    true,
+		CLIAutoUpdate:  true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !result.UpdatedBinary {
+		t.Fatalf("UpdatedBinary = false, result = %+v", result)
+	}
+	if result.Binary == nil || !result.Binary.HomebrewManaged {
+		t.Fatalf("HomebrewManaged not reported: %+v", result.Binary)
+	}
+	argv, err := os.ReadFile(argvPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(argv), "upgrade\nbuttons\n"; got != want {
+		t.Fatalf("brew argv = %q, want %q", got, want)
+	}
+}
+
+func TestApplyBinaryHomebrewUsesPackageManagerWithEnvOptIn(t *testing.T) {
+	t.Setenv("BUTTONS_CLI_AUTO_UPDATE", "1")
+	if !cliAutoUpdateEnabled(Options{}) {
+		t.Fatal("env opt-in should enable CLI auto-update")
+	}
+}

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -14,6 +14,7 @@ type Options struct {
 	ExecutablePath string
 	SkipBinary     bool
 	SkipContent    bool
+	CLIAutoUpdate  bool
 }
 
 type Report struct {


### PR DESCRIPTION
## Summary
- add `package-manager-auto-update` as an explicit opt-in setting for Homebrew-managed CLI self-updates
- allow `BUTTONS_PACKAGE_MANAGER_AUTO_UPDATE=1` as a Claude Code-style env override
- delegate Homebrew-managed CLI updates to `brew upgrade buttons` without shell interpolation
- document the default Homebrew behavior and opt-in flow

## Validation
- `go test ./...`
- `git diff --check`