### PR TITLE
feat: support drawer registry packages

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -14,12 +14,13 @@ import (
 
 var addCmd = &cobra.Command{
 	Use:   "add @desk/name[@version]",
-	Short: "Add a button dependency",
-	Long: `Add a registry button dependency to .buttons/buttons.json and install it.
+	Short: "Add a registry package dependency",
+	Long: `Add a registry package dependency to .buttons/buttons.json and install it.
 
 Bare package names are not supported in the MVP. Use scoped names like
-@autono/hello. Omit @version to track latest; include @version to pin
-an exact immutable version.
+@autono/hello. A package can be a button or a drawer; the registry index
+declares its kind. Omit @version to track latest; include @version to pin an
+exact immutable version.
 
 Examples:
   buttons add @your-desk/hello
@@ -43,7 +44,7 @@ Examples:
 		}
 		fmt.Fprintf(os.Stderr, "Added %s@%s\n", name, requested)
 		if len(res.Installed) > 0 {
-			fmt.Fprintf(os.Stderr, "Installed %d button(s): %s\n", len(res.Installed), strings.Join(res.Installed, ", "))
+			fmt.Fprintf(os.Stderr, "Installed %d package item(s): %s\n", len(res.Installed), strings.Join(res.Installed, ", "))
 		}
 		printNextHint("buttons status")
 		return nil

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -14,12 +14,12 @@ import (
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Install buttons from .buttons/buttons.json",
-	Long: `Install buttons declared in .buttons/buttons.json.
+	Short: "Install packages from .buttons/buttons.json",
+	Long: `Install packages declared in .buttons/buttons.json.
 
 Use 'buttons add @desk/name' to add a dependency. Use 'buttons install'
-to materialize the dependency manifest into .buttons/buttons/ and refresh
-.buttons/buttons-lock.json.
+to materialize the dependency manifest into .buttons/buttons/ and
+.buttons/drawers/ and refresh .buttons/buttons-lock.json.
 
 Examples:
   buttons install
@@ -43,7 +43,7 @@ Examples:
 		if jsonOutput {
 			return config.WriteJSON(res)
 		}
-		fmt.Fprintf(os.Stderr, "Installed %d button(s): %s\n", len(res.Installed), strings.Join(res.Installed, ", "))
+		fmt.Fprintf(os.Stderr, "Installed %d package item(s): %s\n", len(res.Installed), strings.Join(res.Installed, ", "))
 		printNextHint("buttons list")
 		return nil
 	},

--- a/cmd/passive_update.go
+++ b/cmd/passive_update.go
@@ -19,7 +19,7 @@ func maybeRunPassiveUpdate(cmd *cobra.Command) {
 	if isUpdateCommand(cmd) || passiveUpdatesDisabledByEnv() {
 		return
 	}
-	if shouldSkipPassiveUpdate() {
+	if shouldSkipPassiveUpdateFunc() {
 		return
 	}
 	opts := updater.Options{
@@ -96,6 +96,8 @@ func passiveUpdatePlan(st *settings.Settings, force bool, now time.Time) passive
 	decision.recordCheck = true
 	return decision
 }
+
+var shouldSkipPassiveUpdateFunc = shouldSkipPassiveUpdate
 
 func shouldSkipPassiveUpdate() bool {
 	if os.Getenv("CI") != "" {

--- a/cmd/passive_update_test.go
+++ b/cmd/passive_update_test.go
@@ -1,13 +1,26 @@
 package cmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/manifest"
 	"github.com/autonoco/buttons/internal/settings"
+	"github.com/autonoco/buttons/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +50,56 @@ func TestPassiveUpdateSkipsCIWithoutRegistryProbe(t *testing.T) {
 	}
 }
 
+func TestPassiveUpdateAppliesDrawerPackage(t *testing.T) {
+	oldVersion := version
+	version = "1"
+	t.Cleanup(func() { version = oldVersion })
+
+	oldSkip := shouldSkipPassiveUpdateFunc
+	shouldSkipPassiveUpdateFunc = func() bool { return false }
+	t.Cleanup(func() { shouldSkipPassiveUpdateFunc = oldSkip })
+
+	home := t.TempDir()
+	reg := newPassiveRegistry("read")
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "1")
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	t.Setenv("BUTTONS_HOME", home)
+	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
+	t.Setenv("BUTTONS_BAT_REGISTRY_KEY", "read")
+	t.Setenv("BUTTONS_NO_UPDATE", "")
+	t.Setenv("CI", "")
+
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion, Dependencies: map[string]string{"@autono/deploy-pack": "latest"}}
+	if err := manifest.Save(m); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	src := &store.HTTPSource{BaseURL: srv.URL, Key: "read", Client: srv.Client()}
+	_, lock, err := store.InstallManifest(src, m, nil, store.InstallOptions{RefreshFloating: true})
+	if err != nil {
+		t.Fatalf("install drawer v1: %v", err)
+	}
+	if err := manifest.SaveLockfile(lock); err != nil {
+		t.Fatalf("save lockfile: %v", err)
+	}
+
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "2")
+	maybeRunPassiveUpdate(&cobra.Command{Use: "status"})
+
+	data, err := os.ReadFile(filepath.Join(home, "drawers", "deploy-pack", "drawer.json"))
+	if err != nil {
+		t.Fatalf("read installed drawer: %v", err)
+	}
+	var got drawer.Drawer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse installed drawer: %v", err)
+	}
+	if got.Version != "2" {
+		t.Fatalf("passive update installed drawer version %q, want 2", got.Version)
+	}
+}
+
 func TestPassiveUpdatePlanRunsContentInsideBinaryThrottle(t *testing.T) {
 	buttonsAutoUpdate := true
 	cliAutoUpdate := true
@@ -60,6 +123,109 @@ func TestPassiveUpdatePlanRunsContentInsideBinaryThrottle(t *testing.T) {
 	if plan.recordCheck {
 		t.Fatal("content-only passive update should not refresh binary throttle timestamp")
 	}
+}
+
+type passiveRegistry struct {
+	key     string
+	entries []passiveRegistryEntry
+	blobs   map[string][]byte
+}
+
+type passiveRegistryEntry struct {
+	Name    string `json:"name"`
+	Kind    string `json:"kind"`
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+func newPassiveRegistry(key string) *passiveRegistry {
+	return &passiveRegistry{key: key, blobs: map[string][]byte{}}
+}
+
+func (r *passiveRegistry) addDrawer(t *testing.T, pkg, localName, version string) {
+	t.Helper()
+	spec := drawer.Drawer{SchemaVersion: drawer.SchemaVersion, Name: localName, Version: version}
+	data, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{"drawer.json": append(data, '\n')}
+	blob := passiveTarball(t, localName, files)
+	sum := passiveSHA(blob)
+	r.entries = append(r.entries, passiveRegistryEntry{Name: pkg, Kind: "drawer", Version: version, SHA256: sum})
+	r.blobs[pkg+"@"+version] = blob
+}
+
+func (r *passiveRegistry) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "Bearer "+r.key {
+			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"read key required"}}`, http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/meta":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"service":"buttons-registry"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/index":
+			_ = json.NewEncoder(w).Encode(r.entries)
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/buttons/") && strings.HasSuffix(req.URL.Path, "/download"):
+			mid := req.URL.Path[len("/v1/buttons/"):]
+			mid = mid[:len(mid)-len("/download")]
+			i := lastSlash(mid)
+			if i < 0 {
+				http.NotFound(w, req)
+				return
+			}
+			name, ver := mid[:i], mid[i+1:]
+			blob, ok := r.blobs[name+"@"+ver]
+			if !ok {
+				http.NotFound(w, req)
+				return
+			}
+			w.Header().Set("X-Content-Sha256", passiveSHA(blob))
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(blob)
+		default:
+			http.NotFound(w, req)
+		}
+	})
+}
+
+func passiveTarball(t *testing.T, wrapper string, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, data := range files {
+		hdr := &tar.Header{Name: path.Join(wrapper, name), Mode: 0o644, Size: int64(len(data)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func passiveSHA(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func lastSlash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestPassiveUpdatePlanRunsButtonsWhenCLIAutoUpdateDisabled(t *testing.T) {

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -15,23 +15,26 @@ var (
 
 var publishCmd = &cobra.Command{
 	Use:   "publish <name | @desk/name>",
-	Short: "Publish a local button to the registry",
-	Long: `Publish a button. The button folder
-(button.json + code + AGENTS.md, never its run history) is content-hashed and
-uploaded so others can add and install it.
+	Short: "Publish a local button or drawer to the registry",
+	Long: `Publish a local package. A package can be a button
+(.buttons/buttons/<name>/button.json + code + AGENTS.md) or a drawer
+(.buttons/drawers/<name>/drawer.json + AGENTS.md). Run history under pressed/
+is never published.
 
 Publish uses $BUTTONS_REGISTRY_URL as the registry base URL. This repo does not
 ship a default registry host; the caller must configure the target explicitly.
 
-A registry publish takes a scoped name (@desk/name): the on-disk button is found
-by its bare name, and @desk is its registry namespace. The registry pins
-immutable versions; publish starts at the button's current version and auto-bumps
-to the next number if that version already exists. Auth uses the *write* key
-(REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from
-the read key install uses.
+A registry publish takes a scoped name (@desk/name): the on-disk package is
+found by its bare name, and @desk is its registry namespace. The CLI detects
+whether the local package is a button or drawer from button.json or drawer.json.
+The registry pins immutable versions; publish starts at the package's current
+version and auto-bumps to the next number if that version already exists. Auth
+uses the *write* key (REGISTRY_WRITE_KEY battery or
+$BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from the read key install uses.
 
 Examples:
-  BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello`,
+  BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
+  BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/my-pack`,
 	Args:              exactArgs(1),
 	ValidArgsFunction: completeFirstButtonName,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -101,5 +104,6 @@ func registryWriteKey() string {
 
 func init() {
 	publishCmd.Flags().StringVar(&publishKind, "kind", "button", "registry entry kind: button | drawer")
+	_ = publishCmd.Flags().MarkHidden("kind")
 	rootCmd.AddCommand(publishCmd)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -12,11 +12,11 @@ import (
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show available CLI and button updates",
+	Short: "Show available CLI and package updates",
 	Long: `Show whether the buttons CLI or manifest dependencies have updates.
 
 Like every user-invoked command, status also enters enabled passive update
-paths before it prints. buttons-auto-update may refresh floating button
+paths before it prints. buttons-auto-update may refresh floating package
 dependencies; cli-auto-update may update the CLI binary when the throttle
 allows. Use 'buttons update' to force the full update path immediately.`,
 	Args: cobra.NoArgs,
@@ -59,25 +59,33 @@ func printStatus(report *updater.Report) {
 	}
 	available := 0
 	for _, b := range report.Buttons {
+		label := packageKindLabel(b.Kind)
 		switch {
 		case b.Pinned && b.CurrentVersion == "":
-			fmt.Fprintf(os.Stderr, "Button %s: pinned at %s (not installed; run buttons install)\n", b.PackageName, b.Requested)
+			fmt.Fprintf(os.Stderr, "%s %s: pinned at %s (not installed; run buttons install)\n", label, b.PackageName, b.Requested)
 		case b.Pinned && b.LatestVersion != "" && b.CurrentVersion != "" && b.LatestVersion != b.CurrentVersion:
-			fmt.Fprintf(os.Stderr, "Button %s: pinned at %s (latest %s)\n", b.Name, b.CurrentVersion, b.LatestVersion)
+			fmt.Fprintf(os.Stderr, "%s %s: pinned at %s (latest %s)\n", label, b.Name, b.CurrentVersion, b.LatestVersion)
 		case b.Pinned:
-			fmt.Fprintf(os.Stderr, "Button %s: pinned at %s\n", b.Name, b.CurrentVersion)
+			fmt.Fprintf(os.Stderr, "%s %s: pinned at %s\n", label, b.Name, b.CurrentVersion)
 		case b.Skipped:
-			fmt.Fprintf(os.Stderr, "Button %s: skipped (%s)\n", b.Name, b.SkipReason)
+			fmt.Fprintf(os.Stderr, "%s %s: skipped (%s)\n", label, b.Name, b.SkipReason)
 		case b.Error != "":
-			fmt.Fprintf(os.Stderr, "Button %s: check failed: %s\n", b.Name, b.Error)
+			fmt.Fprintf(os.Stderr, "%s %s: check failed: %s\n", label, b.Name, b.Error)
 		case b.UpdateAvailable:
 			available++
-			fmt.Fprintf(os.Stderr, "Button %s: update available %s -> %s\n", b.Name, b.CurrentVersion, b.LatestVersion)
+			fmt.Fprintf(os.Stderr, "%s %s: update available %s -> %s\n", label, b.Name, b.CurrentVersion, b.LatestVersion)
 		}
 	}
 	if available == 0 {
 		fmt.Fprintln(os.Stderr, "Buttons: up to date")
 	}
+}
+
+func packageKindLabel(kind string) string {
+	if kind == "drawer" {
+		return "Drawer"
+	}
+	return "Button"
 }
 
 func init() {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -77,7 +77,7 @@ func printStatus(report *updater.Report) {
 		}
 	}
 	if available == 0 {
-		fmt.Fprintln(os.Stderr, "Buttons: up to date")
+		fmt.Fprintln(os.Stderr, "Installed packages already up to date.")
 	}
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/autonoco/buttons/internal/config"
 	"github.com/autonoco/buttons/internal/settings"
@@ -14,12 +15,18 @@ import (
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update the CLI and floating button dependencies",
-	Long: `Install available updates for the buttons CLI and floating button dependencies.
+	Short: "Update the CLI and floating package dependencies",
+	Long: `Install available updates for the buttons CLI and floating package dependencies.
 
-The CLI binary is updated from GitHub Releases. Button dependencies are
+The CLI binary is updated from GitHub Releases. Package dependencies are
 refreshed from .buttons/buttons.json and .buttons/buttons-lock.json. Exact
 versions are pins; update moves only dependencies requested as "latest".
+
+Homebrew-managed installs are left to Homebrew by default. To let Buttons update
+the CLI through Homebrew and run passive CLI binary updates when the throttle
+allows, run:
+
+  buttons config set cli-auto-update true
 
 Examples:
   buttons update
@@ -77,26 +84,27 @@ func printUpdateResult(result *updater.Result) {
 	}
 	updated := 0
 	for _, b := range result.Buttons {
+		label := packageKindLabel(b.Kind)
 		switch {
 		case b.Updated:
 			updated++
-			fmt.Fprintf(os.Stderr, "Updated %s to %s\n", b.Name, b.LatestVersion)
+			fmt.Fprintf(os.Stderr, "Updated %s %s to %s\n", strings.ToLower(label), b.Name, b.LatestVersion)
 		case b.Pinned && b.CurrentVersion == "":
-			fmt.Fprintf(os.Stderr, "Button %s pinned at %s (not installed; run buttons install)\n", b.PackageName, b.Requested)
+			fmt.Fprintf(os.Stderr, "%s %s pinned at %s (not installed; run buttons install)\n", label, b.PackageName, b.Requested)
 		case b.Pinned && b.LatestVersion != "" && b.CurrentVersion != "" && b.LatestVersion != b.CurrentVersion:
-			fmt.Fprintf(os.Stderr, "Button %s pinned at %s (latest %s)\n", b.Name, b.CurrentVersion, b.LatestVersion)
+			fmt.Fprintf(os.Stderr, "%s %s pinned at %s (latest %s)\n", label, b.Name, b.CurrentVersion, b.LatestVersion)
 		case b.Pinned:
-			fmt.Fprintf(os.Stderr, "Button %s pinned at %s\n", b.Name, b.CurrentVersion)
+			fmt.Fprintf(os.Stderr, "%s %s pinned at %s\n", label, b.Name, b.CurrentVersion)
 		case b.Skipped:
-			fmt.Fprintf(os.Stderr, "Button %s skipped: %s\n", b.Name, b.SkipReason)
+			fmt.Fprintf(os.Stderr, "%s %s skipped: %s\n", label, b.Name, b.SkipReason)
 		case b.Error != "":
-			fmt.Fprintf(os.Stderr, "Button %s skipped: %s\n", b.Name, b.Error)
+			fmt.Fprintf(os.Stderr, "%s %s skipped: %s\n", label, b.Name, b.Error)
 		case b.UpdateAvailable:
-			fmt.Fprintf(os.Stderr, "Button update available: %s %s -> %s\n", b.Name, b.CurrentVersion, b.LatestVersion)
+			fmt.Fprintf(os.Stderr, "%s update available: %s %s -> %s\n", label, b.Name, b.CurrentVersion, b.LatestVersion)
 		}
 	}
 	if updated == 0 {
-		fmt.Fprintln(os.Stderr, "Installed buttons already up to date.")
+		fmt.Fprintln(os.Stderr, "Installed packages already up to date.")
 	}
 }
 

--- a/docs/cli/buttons.md
+++ b/docs/cli/buttons.md
@@ -26,7 +26,7 @@ buttons [flags]
 
 ### SEE ALSO
 
-* [buttons add](buttons_add.md)	 - Add a button dependency
+* [buttons add](buttons_add.md)	 - Add a registry package dependency
 * [buttons batteries](buttons_batteries.md)	 - Manage environment variables and secrets
 * [buttons board](buttons_board.md)	 - Open the button board in a new terminal window
 * [buttons config](buttons_config.md)	 - Read and write per-user settings
@@ -37,20 +37,20 @@ buttons [flags]
 * [buttons ignore](buttons_ignore.md)	 - Keep a button or drawer out of git (writes .buttons/.gitignore)
 * [buttons import](buttons_import.md)	 - Create buttons from external sources (skill, code, url)
 * [buttons init](buttons_init.md)	 - Initialize a project-local .buttons directory
-* [buttons install](buttons_install.md)	 - Install buttons from .buttons/buttons.json
+* [buttons install](buttons_install.md)	 - Install packages from .buttons/buttons.json
 * [buttons list](buttons_list.md)	 - List all buttons
 * [buttons logs](buttons_logs.md)	 - View past runs for a button or tail the live progress stream
 * [buttons mcp](buttons_mcp.md)	 - Run an MCP server over stdio (expose buttons to agents)
 * [buttons press](buttons_press.md)	 - Run a button
-* [buttons publish](buttons_publish.md)	 - Publish a local button to the registry
+* [buttons publish](buttons_publish.md)	 - Publish a local button or drawer to the registry
 * [buttons serve](buttons_serve.md)	 - Run a REST API server exposing buttons over HTTP
 * [buttons smash](buttons_smash.md)	 - Run multiple buttons in parallel
-* [buttons status](buttons_status.md)	 - Show available CLI and button updates
+* [buttons status](buttons_status.md)	 - Show available CLI and package updates
 * [buttons summary](buttons_summary.md)	 - Print a workspace snapshot (buttons, drawers, recent runs)
 * [buttons tail](buttons_tail.md)	 - Follow the progress JSONL of a press
 * [buttons trigger](buttons_trigger.md)	 - Manage button triggers (cron, watch, webhook)
 * [buttons unignore](buttons_unignore.md)	 - Re-include a previously-ignored button or drawer in git
-* [buttons update](buttons_update.md)	 - Update the CLI and floating button dependencies
+* [buttons update](buttons_update.md)	 - Update the CLI and floating package dependencies
 * [buttons version](buttons_version.md)	 - Print build version, commit, and date
 * [buttons webhook](buttons_webhook.md)	 - Expose a local URL via Cloudflare to receive webhook callbacks
 

--- a/docs/cli/buttons_add.md
+++ b/docs/cli/buttons_add.md
@@ -5,15 +5,16 @@ description: "CLI reference for buttons add"
 
 ## buttons add
 
-Add a button dependency
+Add a registry package dependency
 
 ### Synopsis
 
-Add a registry button dependency to .buttons/buttons.json and install it.
+Add a registry package dependency to .buttons/buttons.json and install it.
 
 Bare package names are not supported in the MVP. Use scoped names like
-@autono/hello. Omit @version to track latest; include @version to pin
-an exact immutable version.
+@autono/hello. A package can be a button or a drawer; the registry index
+declares its kind. Omit @version to track latest; include @version to pin an
+exact immutable version.
 
 **Examples:**
 

--- a/docs/cli/buttons_install.md
+++ b/docs/cli/buttons_install.md
@@ -5,15 +5,15 @@ description: "CLI reference for buttons install"
 
 ## buttons install
 
-Install buttons from .buttons/buttons.json
+Install packages from .buttons/buttons.json
 
 ### Synopsis
 
-Install buttons declared in .buttons/buttons.json.
+Install packages declared in .buttons/buttons.json.
 
 Use 'buttons add @desk/name' to add a dependency. Use 'buttons install'
-to materialize the dependency manifest into .buttons/buttons/ and refresh
-.buttons/buttons-lock.json.
+to materialize the dependency manifest into .buttons/buttons/ and
+.buttons/drawers/ and refresh .buttons/buttons-lock.json.
 
 **Examples:**
 

--- a/docs/cli/buttons_publish.md
+++ b/docs/cli/buttons_publish.md
@@ -5,28 +5,31 @@ description: "CLI reference for buttons publish"
 
 ## buttons publish
 
-Publish a local button to the registry
+Publish a local button or drawer to the registry
 
 ### Synopsis
 
-Publish a button. The button folder
-(button.json + code + AGENTS.md, never its run history) is content-hashed and
-uploaded so others can add and install it.
+Publish a local package. A package can be a button
+(.buttons/buttons/`<name>`/button.json + code + AGENTS.md) or a drawer
+(.buttons/drawers/`<name>`/drawer.json + AGENTS.md). Run history under pressed/
+is never published.
 
 Publish uses $BUTTONS_REGISTRY_URL as the registry base URL. This repo does not
 ship a default registry host; the caller must configure the target explicitly.
 
-A registry publish takes a scoped name (@desk/name): the on-disk button is found
-by its bare name, and @desk is its registry namespace. The registry pins
-immutable versions; publish starts at the button's current version and auto-bumps
-to the next number if that version already exists. Auth uses the *write* key
-(REGISTRY_WRITE_KEY battery or $BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from
-the read key install uses.
+A registry publish takes a scoped name (@desk/name): the on-disk package is
+found by its bare name, and @desk is its registry namespace. The CLI detects
+whether the local package is a button or drawer from button.json or drawer.json.
+The registry pins immutable versions; publish starts at the package's current
+version and auto-bumps to the next number if that version already exists. Auth
+uses the *write* key (REGISTRY_WRITE_KEY battery or
+$BUTTONS_BAT_REGISTRY_WRITE_KEY) — distinct from the read key install uses.
 
 **Examples:**
 
 ```bash
 BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
+BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/my-pack
 ```
 
 ```
@@ -36,8 +39,7 @@ buttons publish <name | @desk/name> [flags]
 ### Options
 
 ```
-  -h, --help          help for publish
-      --kind string   registry entry kind: button | drawer (default "button")
+  -h, --help   help for publish
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/buttons_status.md
+++ b/docs/cli/buttons_status.md
@@ -5,14 +5,14 @@ description: "CLI reference for buttons status"
 
 ## buttons status
 
-Show available CLI and button updates
+Show available CLI and package updates
 
 ### Synopsis
 
 Show whether the buttons CLI or manifest dependencies have updates.
 
 Like every user-invoked command, status also enters enabled passive update
-paths before it prints. buttons-auto-update may refresh floating button
+paths before it prints. buttons-auto-update may refresh floating package
 dependencies; cli-auto-update may update the CLI binary when the throttle
 allows. Use 'buttons update' to force the full update path immediately.
 

--- a/docs/cli/buttons_update.md
+++ b/docs/cli/buttons_update.md
@@ -5,13 +5,13 @@ description: "CLI reference for buttons update"
 
 ## buttons update
 
-Update the CLI and floating button dependencies
+Update the CLI and floating package dependencies
 
 ### Synopsis
 
-Install available updates for the buttons CLI and floating button dependencies.
+Install available updates for the buttons CLI and floating package dependencies.
 
-The CLI binary is updated from GitHub Releases. Button dependencies are
+The CLI binary is updated from GitHub Releases. Package dependencies are
 refreshed from .buttons/buttons.json and .buttons/buttons-lock.json. Exact
 versions are pins; update moves only dependencies requested as "latest".
 

--- a/docs/concepts/drawer-json.mdx
+++ b/docs/concepts/drawer-json.mdx
@@ -19,6 +19,7 @@ Project-local drawers use the same shape under `.buttons/drawers/<name>/`.
 {
   "schema_version": 1,
   "name": "release-flow",
+  "version": "1",
   "inputs": [
     { "name": "env", "type": "enum", "required": true, "values": ["staging", "prod"] }
   ],
@@ -48,6 +49,7 @@ Project-local drawers use the same shape under `.buttons/drawers/<name>/`.
 | `schema_version` | Drawer spec version. Current version is `1`. |
 | `name` | Drawer name. |
 | `description` | Human-readable one-liner. |
+| `version` | Drawer package content version. New drawers start at `1`; registry publish auto-bumps to the next number when the current immutable version already exists. |
 | `inputs` | Values supplied at drawer press time. |
 | `steps` | Ordered workflow steps. |
 | `output_schema` | Optional JSON Schema for values exposed when called as a sub-drawer. |

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -93,10 +93,11 @@ Registry dependencies are tracked at the project root:
 - `.buttons/buttons.json` is desired state: scoped package names mapped to `"latest"` or an exact version.
 - `.buttons/buttons-lock.json` is resolved state: exact versions, content hashes, local installed names, and timestamps.
 - `.buttons/buttons/<name>/button.json` is the installed button's runtime/package spec.
+- `.buttons/drawers/<name>/drawer.json` is the installed drawer's workflow/package spec.
 
-When you install with `buttons add @desk/name` or `buttons install`, the runnable copy is written into `buttons/<name>/`, and the dependency resolution is written to the lockfile. Dependencies declared in `button.json` `requires` are installed transitively and recorded in the lockfile too.
+When you install with `buttons add @desk/name` or `buttons install`, button packages are written into `buttons/<name>/`, drawer packages are written into `drawers/<name>/`, and the dependency resolution is written to the lockfile. A drawer package also installs every button referenced by its steps. Dependencies declared in `button.json` `requires` are installed transitively and recorded in the lockfile too.
 
-To share authored local buttons with a team, commit their folders under `buttons/` and `drawers/`. To share registry dependencies with a team, commit `buttons.json` and `buttons-lock.json` so teammates install the same resolved versions. To push a button to a registry, use `buttons publish @desk/<name>`; versions are simple numbers starting at `1`, and registry versions are immutable.
+To share authored local buttons and drawers with a team, commit their folders under `buttons/` and `drawers/`. To share registry dependencies with a team, commit `buttons.json` and `buttons-lock.json` so teammates install the same resolved versions. To push a button or drawer to a registry, use `buttons publish @desk/<name>`; versions are simple numbers starting at `1`, and registry versions are immutable.
 
 ## history.json
 

--- a/docs/concepts/registry.mdx
+++ b/docs/concepts/registry.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Registry"
-description: "How Buttons resolves, installs, pins, and publishes shared buttons."
+description: "How Buttons resolves, installs, pins, and publishes shared packages."
 ---
 
-A registry is a catalog of installable buttons. It answers: "What packages are available, what immutable versions exist, and what content hash should I install?"
+A registry is a catalog of installable packages. A package can be a button or a drawer. The registry answers: "What packages are available, what kind are they, what immutable versions exist, and what content hash should I install?"
 
 Registry installs use three different files:
 
@@ -12,14 +12,18 @@ Registry installs use three different files:
   buttons.json          # desired dependencies; commit this
   buttons-lock.json     # exact resolved versions/hashes; commit this
   history.json          # local activity log; gitignored
-  buttons/
-    hello/
-      button.json       # runtime/package spec
-      main.sh
-      AGENTS.md
+	  buttons/
+	    hello/
+	      button.json       # runtime/package spec
+	      main.sh
+	      AGENTS.md
+	  drawers/
+	    deploy-pack/
+	      drawer.json       # drawer/package spec
+	      AGENTS.md
 ```
 
-`buttons.json` is the project manifest. `buttons-lock.json` is the repeatable resolution. Installed `button.json` files stay focused on runtime and package metadata; they do not store registry URLs, bearer keys, or the dependency source of truth.
+`buttons.json` is the project manifest. `buttons-lock.json` is the repeatable resolution. Installed `button.json` and `drawer.json` files stay focused on the local package spec; they do not store registry URLs, bearer keys, or the dependency source of truth.
 
 ## Manifest
 
@@ -27,15 +31,16 @@ Registry installs use three different files:
 
 ```json
 {
-  "schema_version": 1,
-  "dependencies": {
-    "@your-desk/hello": "latest",
-    "@your-desk/deploy": "1"
-  }
-}
+	  "schema_version": 1,
+	  "dependencies": {
+	    "@your-desk/hello": "latest",
+	    "@your-desk/deploy-pack": "1"
+	  }
+	}
 ```
 
 Dependency keys must be scoped package names in the form `@desk/name`.
+Names are unique per desk across buttons and drawers. The package `kind` is registry metadata, not part of the name.
 
 | Value | Meaning |
 |---|---|
@@ -91,23 +96,41 @@ Each installed button still has its own runtime spec:
 
 `requires` uses the same version policy as the root manifest: `"latest"` or an exact version. Transitive dependencies are resolved into the lockfile beside root dependencies.
 
+## drawer.json
+
+Each installed drawer has its own workflow/package spec:
+
+```json
+{
+  "schema_version": 1,
+  "name": "deploy-pack",
+  "version": "1",
+  "steps": [
+    { "id": "build", "kind": "button", "button": "build" },
+    { "id": "ship", "kind": "button", "button": "ship" }
+  ]
+}
+```
+
+Installing a drawer writes `.buttons/drawers/<name>/drawer.json` and installs every button referenced by its steps. Step button names are local names; package resolution uses the drawer's desk namespace. For example, `@your-desk/deploy-pack` with step `"button": "build"` installs `@your-desk/build`.
+
 ## Command Flow
 
 Use the registry like a package manager:
 
 ```bash
 buttons add @your-desk/hello
-buttons add @your-desk/deploy@1
+buttons add @your-desk/deploy-pack@1
 buttons install
 buttons status
 buttons update
 ```
 
-- `buttons add @desk/name` writes `.buttons/buttons.json` with `"latest"` and installs immediately.
+- `buttons add @desk/name` writes `.buttons/buttons.json` with `"latest"` and installs immediately. The package can be a button or drawer.
 - `buttons add @desk/name@1` writes an exact pin and installs that immutable version.
 - `buttons install` takes no package argument. It reads `.buttons/buttons.json` and honors `.buttons/buttons-lock.json` for repeatability.
 - `buttons status` reports available CLI and content updates.
-- `buttons update` updates the CLI and floating button dependencies only.
+- `buttons update` updates the CLI and floating package dependencies only.
 
 `buttons install @desk/name` is intentionally invalid. Use `buttons add @desk/name` to add a dependency.
 
@@ -124,15 +147,16 @@ The registry base URL comes from `$BUTTONS_REGISTRY_URL`. This public repo does 
 
 ## Publish Flow
 
-`buttons publish @desk/name` publishes a local button folder to the configured registry:
+`buttons publish @desk/name` publishes a local button or drawer folder to the configured registry:
 
 ```bash
 BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/hello
+BUTTONS_REGISTRY_URL=https://registry.example buttons publish @your-desk/deploy-pack
 ```
 
-The on-disk button is found by its bare local name (`hello`), while `@your-desk/hello` is the registry identity. Published versions are immutable. New buttons start at version `1`; if that version already exists, publish bumps `button.json` to the next number and retries.
+The on-disk package is found by its bare local name (`hello` or `deploy-pack`), while `@your-desk/name` is the registry identity. Publish detects the package kind from `button.json` or `drawer.json`. Published versions are immutable. New buttons and drawers start at version `1`; if that version already exists, publish bumps the local package spec to the next number and retries.
 
-Publishing bundles `button.json`, code files, and `AGENTS.md`. It does not upload `pressed/` run history or battery values.
+Publishing a button bundles `button.json`, code files, and `AGENTS.md`. Publishing a drawer bundles `drawer.json` and `AGENTS.md`. Neither path uploads `pressed/` run history or battery values.
 
 ## Version Example
 
@@ -150,14 +174,14 @@ If the agent had run `buttons add @your-desk/hello@1`, step 7 would leave it pin
 
 A registry is treated as untrusted. Downloads are size-capped, tarball hashes are verified before extraction, file-content hashes are written to the lockfile, and extraction rejects absolute paths, traversal paths, macOS sidecar files, and run history.
 
-Before overwriting an installed button, update compares the current local files with the lockfile/install-state hash. Local edits are skipped, not overwritten.
+Before overwriting an installed package, update compares the current local files with the lockfile/install-state hash. Local edits are skipped, not overwritten.
 
 ## HTTP Contract
 
 A hosted registry implements:
 
 - `GET /v1/meta` — optional registry metadata, including minimum CLI version.
-- `GET /v1/index` — catalog entries `{ name, kind, version, tags, sha256 }`, where `sha256` is the tarball hash. Latest is the last entry for a given name.
+- `GET /v1/index` — catalog entries `{ name, kind, version, tags, sha256 }`, where `kind` is `button` or `drawer` and `sha256` is the tarball hash. Latest is the last entry for a given name.
 - `GET /v1/buttons/<@desk/name>/<version>/download` — download the gzip tarball; should set `X-Content-Sha256`.
 - `POST /v1/buttons/<@desk/name>/<version>` — publish an immutable version with headers `Content-Type: application/gzip`, `X-Content-Sha256`, and `X-Button-Kind`.
 

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -381,6 +381,10 @@
     "updated_at": {
       "format": "date-time",
       "type": "string"
+    },
+    "version": {
+      "description": "Drawer package content version",
+      "type": "string"
     }
   },
   "required": [

--- a/internal/button/service.go
+++ b/internal/button/service.go
@@ -126,6 +126,11 @@ func (s *Service) CreateApp(opts AppOpts) (*Button, error) {
 	if name == "" {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "app name is empty after slugification"}
 	}
+	if exists, err := drawerSpecExists(name); err != nil {
+		return nil, err
+	} else if exists {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("button already exists as a drawer: %s", name)}
+	}
 	dir, err := config.AppDir(name)
 	if err != nil {
 		return nil, err
@@ -209,6 +214,11 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 	name := Slugify(opts.Name)
 	if name == "" {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "button name is empty after slugification"}
+	}
+	if exists, err := drawerSpecExists(name); err != nil {
+		return nil, err
+	} else if exists {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("button already exists as a drawer: %s", name)}
 	}
 
 	// Validate sources: file, code, or url (--prompt is a modifier, not a source)
@@ -412,6 +422,21 @@ func (s *Service) Create(opts CreateOpts) (*Button, error) {
 	}
 
 	return btn, nil
+}
+
+func drawerSpecExists(name string) (bool, error) {
+	dir, err := config.DrawerDir(name)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(filepath.Join(dir, "drawer.json"))
+	if err == nil {
+		return !info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (s *Service) List() ([]Button, error) {

--- a/internal/button/service_test.go
+++ b/internal/button/service_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -165,6 +166,24 @@ func TestService_Create_Duplicate(t *testing.T) {
 	se, ok := err.(*ServiceError)
 	if !ok || se.Code != "VALIDATION_ERROR" {
 		t.Errorf("expected VALIDATION_ERROR, got %v", err)
+	}
+}
+
+func TestService_Create_RejectsExistingDrawerName(t *testing.T) {
+	home := setupTestEnv(t)
+	if err := os.MkdirAll(filepath.Join(home, "drawers", "deploy"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "drawers", "deploy", "drawer.json"), []byte(`{"schema_version":1,"name":"deploy","steps":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewService().Create(CreateOpts{Name: "deploy", Code: "echo deploy", TimeoutSeconds: 60})
+	if err == nil {
+		t.Fatal("expected create to reject a name already used by a drawer")
+	}
+	if !strings.Contains(err.Error(), "already exists as a drawer") {
+		t.Fatalf("error = %v, want drawer collision message", err)
 	}
 }
 

--- a/internal/drawer/entity.go
+++ b/internal/drawer/entity.go
@@ -24,6 +24,7 @@ type Drawer struct {
 	SchemaVersion int        `json:"schema_version" jsonschema:"const=1,description=Drawer spec version"`
 	Name          string     `json:"name" jsonschema:"description=Drawer name (kebab-case)"`
 	Description   string     `json:"description,omitempty" jsonschema:"description=Human-readable one-liner"`
+	Version       string     `json:"version,omitempty" jsonschema:"description=Drawer package content version"`
 	Inputs        []InputDef `json:"inputs,omitempty" jsonschema:"description=Top-level inputs supplied at press time"`
 	Steps         []Step     `json:"steps" jsonschema:"description=Ordered list of steps (depth-first execution)"`
 	// OnError points at another drawer that runs when any step in this
@@ -117,10 +118,10 @@ type TriggerAuth struct {
 // agents see a consistent shape across both, plus a Secret flag that
 // drives trace redaction.
 type InputDef struct {
-	Name        string   `json:"name" jsonschema:"description=Input name (referenced as ${inputs.<name>})"`
-	Type        string   `json:"type" jsonschema:"enum=string,enum=int,enum=bool,enum=enum"`
-	Required    bool     `json:"required,omitempty"`
-	Description string   `json:"description,omitempty"`
+	Name        string `json:"name" jsonschema:"description=Input name (referenced as ${inputs.<name>})"`
+	Type        string `json:"type" jsonschema:"enum=string,enum=int,enum=bool,enum=enum"`
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description,omitempty"`
 	// Values is the allowed value set for Type == "enum".
 	Values []string `json:"values,omitempty"`
 	// Secret-flagged inputs are redacted from execution traces and
@@ -269,11 +270,11 @@ type ErrorPolicy struct {
 // Backoff describes retry delay shape. Exponential with optional
 // jitter is the only strategy v1 supports; "fixed" reserved.
 type Backoff struct {
-	Strategy  string `json:"strategy" jsonschema:"enum=exponential,enum=fixed"`
-	InitialMs int    `json:"initial_ms,omitempty"`
+	Strategy  string  `json:"strategy" jsonschema:"enum=exponential,enum=fixed"`
+	InitialMs int     `json:"initial_ms,omitempty"`
 	Factor    float64 `json:"factor,omitempty"`
-	MaxMs     int    `json:"max_ms,omitempty"`
-	Jitter    bool   `json:"jitter,omitempty"`
+	MaxMs     int     `json:"max_ms,omitempty"`
+	Jitter    bool    `json:"jitter,omitempty"`
 }
 
 // ErrorHandler points at another drawer to invoke on failure. The

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -381,6 +381,10 @@
     "updated_at": {
       "format": "date-time",
       "type": "string"
+    },
+    "version": {
+      "description": "Drawer package content version",
+      "type": "string"
     }
   },
   "required": [

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -42,6 +42,11 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 	if slug == "" {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: "drawer name is empty after slugification"}
 	}
+	if exists, err := buttonSpecExists(slug); err != nil {
+		return nil, err
+	} else if exists {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("drawer already exists as a button: %s", slug)}
+	}
 
 	dir, err := config.DrawerDir(slug)
 	if err != nil {
@@ -75,6 +80,7 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 		SchemaVersion: SchemaVersion,
 		Name:          slug,
 		Description:   description,
+		Version:       button.InitialContentVersion,
 		Inputs:        inputs,
 		Steps:         []Step{},
 		CreatedAt:     now,
@@ -86,6 +92,21 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 		return nil, err
 	}
 	return d, nil
+}
+
+func buttonSpecExists(name string) (bool, error) {
+	dir, err := config.ButtonDir(name)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(filepath.Join(dir, "button.json"))
+	if err == nil {
+		return !info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 // Get returns the drawer by name. NOT_FOUND on missing.

--- a/internal/drawer/service_test.go
+++ b/internal/drawer/service_test.go
@@ -89,6 +89,25 @@ func TestService_DuplicateCreate_Errors(t *testing.T) {
 	}
 }
 
+func TestService_Create_RejectsExistingButtonName(t *testing.T) {
+	home := newTestHome(t)
+	btnDir := filepath.Join(home, "buttons", "deploy")
+	if err := os.MkdirAll(btnDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(btnDir, "button.json"), []byte(`{"schema_version":2,"name":"deploy","runtime":"shell","env":{},"timeout_seconds":60}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewService().Create("deploy", "", nil)
+	if err == nil {
+		t.Fatal("expected drawer create to reject a name already used by a button")
+	}
+	if !strings.Contains(err.Error(), "already exists as a button") {
+		t.Fatalf("error = %v, want button collision message", err)
+	}
+}
+
 func TestService_Remove(t *testing.T) {
 	newTestHome(t)
 	svc := NewService()

--- a/internal/store/http_publish.go
+++ b/internal/store/http_publish.go
@@ -49,7 +49,10 @@ func (p *HTTPPublisher) Publish(b *Bundle) error {
 	}
 	sum := sha256hex(tarball)
 
-	kind := p.Kind
+	kind := b.Kind
+	if kind == "" {
+		kind = p.Kind
+	}
 	if kind == "" {
 		kind = "button"
 	}

--- a/internal/store/http_source.go
+++ b/internal/store/http_source.go
@@ -171,10 +171,10 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 	defer func() { _ = resp.Body.Close() }()
 	tarball, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("button %q: download: %w", name, err)
+		return nil, fmt.Errorf("package %q: download: %w", name, err)
 	}
 	if int64(len(tarball)) > maxArtifactBytes {
-		return nil, fmt.Errorf("button %q: artifact exceeds %d bytes", name, int64(maxArtifactBytes))
+		return nil, fmt.Errorf("package %q: artifact exceeds %d bytes", name, int64(maxArtifactBytes))
 	}
 
 	// Integrity: the bytes must match the registry's advertised tarball hash —
@@ -185,12 +185,12 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 		want = wantHash
 	}
 	if want != "" && got != want {
-		return nil, fmt.Errorf("button %q@%s: content hash mismatch (registry %s, got %s)", name, version, want, got)
+		return nil, fmt.Errorf("package %q@%s: content hash mismatch (registry %s, got %s)", name, version, want, got)
 	}
 
 	files, err := untarGz(tarball)
 	if err != nil {
-		return nil, fmt.Errorf("button %q: %w", name, err)
+		return nil, fmt.Errorf("package %q: %w", name, err)
 	}
 	kind := "button"
 	if _, ok := files["button.json"]; !ok {

--- a/internal/store/http_source.go
+++ b/internal/store/http_source.go
@@ -139,7 +139,7 @@ func (s *HTTPSource) Index() ([]ButtonRef, error) {
 	return refs, nil
 }
 
-// Fetch downloads a button tarball, verifies it against the registry's advertised
+// Fetch downloads a package tarball, verifies it against the registry's advertised
 // content hash, and extracts it into a Bundle. version "" resolves to latest.
 func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 	// Resolve "" → latest. The Worker treats the last index entry for a name as
@@ -156,7 +156,7 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 			}
 		}
 		if version == "" {
-			return nil, fmt.Errorf("button %q not found in registry", name)
+			return nil, fmt.Errorf("package %q not found in registry", name)
 		}
 	}
 
@@ -192,12 +192,16 @@ func (s *HTTPSource) Fetch(name, version string) (*Bundle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("button %q: %w", name, err)
 	}
+	kind := "button"
 	if _, ok := files["button.json"]; !ok {
-		return nil, fmt.Errorf("button %q: bundle has no button.json", name)
+		if _, hasDrawer := files["drawer.json"]; !hasDrawer {
+			return nil, fmt.Errorf("package %q: bundle has no button.json or drawer.json", name)
+		}
+		kind = "drawer"
 	}
 	// Bundle.SHA256 is the file-content hash (what install stamps as content_hash),
 	// consistent with LocalSource — distinct from the tarball hash verified above.
-	return &Bundle{Name: name, Version: version, SHA256: hashFiles(files), Files: files}, nil
+	return &Bundle{Name: name, Kind: kind, Version: version, SHA256: hashFiles(files), Files: files}, nil
 }
 
 func sha256hex(b []byte) string {

--- a/internal/store/install.go
+++ b/internal/store/install.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/drawer"
 	"github.com/autonoco/buttons/internal/manifest"
 )
 
@@ -83,15 +84,23 @@ func installPackage(src Source, name, requested string, prior, next *manifest.Lo
 	if err != nil {
 		return err
 	}
-	bundle, spec, err := fetchInstallable(src, name, ref.Version)
-	if err != nil {
-		return err
-	}
 	if ref.Kind == "" {
 		ref.Kind = "button"
 	}
-	if ref.Kind != "button" {
-		return fmt.Errorf("installing %s kind %q is not implemented yet", name, ref.Kind)
+	switch ref.Kind {
+	case "button":
+		return installButtonPackage(src, name, requested, ref, prior, next, seen, installedNames, opts, out)
+	case "drawer":
+		return installDrawerPackage(src, name, requested, ref, prior, next, seen, installedNames, opts, out)
+	default:
+		return fmt.Errorf("installing %s kind %q is not implemented", name, ref.Kind)
+	}
+}
+
+func installButtonPackage(src Source, name, requested string, ref ButtonRef, prior, next *manifest.Lockfile, seen map[string]bool, installedNames map[string]string, opts InstallOptions, out *[]string) error {
+	bundle, spec, err := fetchButtonInstallable(src, name, ref.Version)
+	if err != nil {
+		return err
 	}
 	localName := button.Slugify(spec.Name)
 	if owner, exists := installedNames[localName]; exists && owner != name {
@@ -125,6 +134,42 @@ func installPackage(src Source, name, requested string, prior, next *manifest.Lo
 	return nil
 }
 
+func installDrawerPackage(src Source, name, requested string, ref ButtonRef, prior, next *manifest.Lockfile, seen map[string]bool, installedNames map[string]string, opts InstallOptions, out *[]string) error {
+	bundle, spec, err := fetchDrawerInstallable(src, name, ref.Version)
+	if err != nil {
+		return err
+	}
+	localName := button.Slugify(spec.Name)
+	if owner, exists := installedNames[localName]; exists && owner != name {
+		return fmt.Errorf("dependencies %s and %s both install as %q", owner, name, localName)
+	}
+	installedNames[localName] = name
+
+	if err := writeDrawerBundle(spec, bundle); err != nil {
+		return err
+	}
+	*out = append(*out, spec.Name)
+	next.Dependencies[name] = manifest.LockEntry{
+		Kind:          ref.Kind,
+		Requested:     requested,
+		Version:       bundle.Version,
+		ContentHash:   bundle.SHA256,
+		InstalledName: spec.Name,
+		ResolvedAt:    opts.Now().UTC().Format(time.RFC3339),
+	}
+
+	deps, err := drawerPackageDependencies(name, spec)
+	if err != nil {
+		return err
+	}
+	for _, dep := range deps {
+		if err := installPackage(src, dep, "latest", prior, next, seen, installedNames, opts, out); err != nil {
+			return fmt.Errorf("dependency of drawer %q: %w", spec.Name, err)
+		}
+	}
+	return nil
+}
+
 func Resolve(src Source, name, version string) (ButtonRef, error) {
 	refs, err := src.Index()
 	if err != nil {
@@ -147,18 +192,21 @@ func Resolve(src Source, name, version string) (ButtonRef, error) {
 		}
 	}
 	if version != "" {
-		return ButtonRef{}, fmt.Errorf("button %q@%s not found in registry", name, version)
+		return ButtonRef{}, fmt.Errorf("package %q@%s not found in registry", name, version)
 	}
 	if latest == nil {
-		return ButtonRef{}, fmt.Errorf("button %q not found in registry", name)
+		return ButtonRef{}, fmt.Errorf("package %q not found in registry", name)
 	}
 	return *latest, nil
 }
 
-func fetchInstallable(src Source, name, version string) (*Bundle, *button.Button, error) {
+func fetchButtonInstallable(src Source, name, version string) (*Bundle, *button.Button, error) {
 	bundle, err := src.Fetch(name, version)
 	if err != nil {
 		return nil, nil, err
+	}
+	if _, ok := bundle.Files["button.json"]; !ok {
+		return nil, nil, fmt.Errorf("button %q: bundle has no button.json", name)
 	}
 	var spec button.Button
 	if err := json.Unmarshal(bundle.Files["button.json"], &spec); err != nil {
@@ -170,6 +218,27 @@ func fetchInstallable(src Source, name, version string) (*Bundle, *button.Button
 		return nil, nil, err
 	}
 	bundle.Files["button.json"] = append(stamped, '\n')
+	return bundle, &spec, nil
+}
+
+func fetchDrawerInstallable(src Source, name, version string) (*Bundle, *drawer.Drawer, error) {
+	bundle, err := src.Fetch(name, version)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, ok := bundle.Files["drawer.json"]; !ok {
+		return nil, nil, fmt.Errorf("drawer %q: bundle has no drawer.json", name)
+	}
+	var spec drawer.Drawer
+	if err := json.Unmarshal(bundle.Files["drawer.json"], &spec); err != nil {
+		return nil, nil, fmt.Errorf("drawer %q: invalid drawer.json: %w", name, err)
+	}
+	spec.Version = bundle.Version
+	stamped, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		return nil, nil, err
+	}
+	bundle.Files["drawer.json"] = append(stamped, '\n')
 	return bundle, &spec, nil
 }
 
@@ -206,4 +275,112 @@ func writeBundle(spec *button.Button, bundle *Bundle) error {
 		return fmt.Errorf("write install state: %w", err)
 	}
 	return nil
+}
+
+func writeDrawerBundle(spec *drawer.Drawer, bundle *Bundle) error {
+	dir, err := config.DrawerDir(button.Slugify(spec.Name))
+	if err != nil {
+		return err
+	}
+	dsts := make(map[string]string, len(bundle.Files))
+	for rel := range bundle.Files {
+		dst, err := safeJoin(dir, rel)
+		if err != nil {
+			return err
+		}
+		dsts[rel] = dst
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "pressed"), 0o700); err != nil {
+		return fmt.Errorf("create drawer dir: %w", err)
+	}
+	for rel, data := range bundle.Files {
+		dst := dsts[rel]
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return fmt.Errorf("create parent for %s: %w", rel, err)
+		}
+		if err := os.WriteFile(dst, data, 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", rel, err)
+		}
+	}
+	if err := writeInstallState(dir, bundle.SHA256); err != nil {
+		return fmt.Errorf("write install state: %w", err)
+	}
+	return nil
+}
+
+func drawerPackageDependencies(packageName string, spec *drawer.Drawer) ([]string, error) {
+	desk, _, err := splitScoped(packageName)
+	if err != nil {
+		return nil, err
+	}
+	deps := map[string]bool{}
+	var walk func([]drawer.Step) error
+	walk = func(steps []drawer.Step) error {
+		for _, st := range steps {
+			kind := st.Kind
+			if kind == "" {
+				kind = "button"
+			}
+			switch kind {
+			case "button":
+				if st.Button != "" {
+					dep, err := scopedPackageForLocal(desk, st.Button)
+					if err != nil {
+						return err
+					}
+					deps[dep] = true
+				}
+			case "drawer":
+				if st.Drawer != "" {
+					dep, err := scopedPackageForLocal(desk, st.Drawer)
+					if err != nil {
+						return err
+					}
+					deps[dep] = true
+				}
+			}
+			if len(st.Steps) > 0 {
+				if err := walk(st.Steps); err != nil {
+					return err
+				}
+			}
+			for _, c := range st.Cases {
+				if err := walk(c.Steps); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := walk(spec.Steps); err != nil {
+		return nil, err
+	}
+	if spec.OnError != nil && spec.OnError.Drawer != "" {
+		dep, err := scopedPackageForLocal(desk, spec.OnError.Drawer)
+		if err != nil {
+			return nil, err
+		}
+		deps[dep] = true
+	}
+	out := make([]string, 0, len(deps))
+	for dep := range deps {
+		if dep == packageName {
+			continue
+		}
+		out = append(out, dep)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func scopedPackageForLocal(desk, name string) (string, error) {
+	local := button.Slugify(name)
+	if local == "" {
+		return "", fmt.Errorf("drawer step target %q is empty after slugification", name)
+	}
+	pkg := desk + "/" + local
+	if err := manifest.ValidatePackageName(pkg); err != nil {
+		return "", err
+	}
+	return pkg, nil
 }

--- a/internal/store/install.go
+++ b/internal/store/install.go
@@ -295,10 +295,14 @@ func writeDrawerBundle(spec *drawer.Drawer, bundle *Bundle) error {
 	}
 	for rel, data := range bundle.Files {
 		dst := dsts[rel]
+		mode := os.FileMode(0o700)
+		if filepath.Ext(rel) == ".json" {
+			mode = 0o600
+		}
 		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 			return fmt.Errorf("create parent for %s: %w", rel, err)
 		}
-		if err := os.WriteFile(dst, data, 0o600); err != nil {
+		if err := os.WriteFile(dst, data, mode); err != nil {
 			return fmt.Errorf("write %s: %w", rel, err)
 		}
 	}

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/drawer"
 )
 
 // Publisher accepts a button Bundle for distribution — the write-side mirror of
@@ -21,6 +22,7 @@ type Publisher interface {
 // PublishResult reports what a publish produced.
 type PublishResult struct {
 	Name    string `json:"name"`
+	Kind    string `json:"kind"`
 	Version string `json:"version,omitempty"`
 	SHA256  string `json:"sha256"`
 	Files   int    `json:"files"`
@@ -38,7 +40,7 @@ func Publish(dst Publisher, name string) (*PublishResult, error) {
 	if err := dst.Publish(bundle); err != nil {
 		return nil, err
 	}
-	return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+	return &PublishResult{Name: bundle.Name, Kind: bundle.Kind, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
 }
 
 // PublishToRegistry publishes a local button to the hosted registry under a
@@ -75,20 +77,42 @@ func PublishToRegistry(dst Publisher, ref string) (*PublishResult, error) {
 			version = next
 			continue
 		}
-		return &PublishResult{Name: bundle.Name, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+		return &PublishResult{Name: bundle.Name, Kind: bundle.Kind, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
 	}
 	return nil, fmt.Errorf("registry publish could not find an unused version after 1000 attempts")
 }
 
-// loadLocalBundle reads a local button folder into a Bundle. localName locates
-// the on-disk folder (slugified); identity, when non-empty, overrides the
-// stamped Bundle.Name with the registry id (@desk/name) — for a LocalSource it
-// stays empty so the button keeps its own name.
+// loadLocalBundle reads a local button or drawer folder into a Bundle. localName
+// locates the on-disk folder (slugified); identity, when non-empty, overrides
+// the stamped Bundle.Name with the registry id (@desk/name) — for a LocalSource
+// it stays empty so the package keeps its own local name.
 func loadLocalBundle(localName, identity string) (*Bundle, error) {
-	dir, err := config.ButtonDir(button.Slugify(localName))
+	slug := button.Slugify(localName)
+	btnDir, err := config.ButtonDir(slug)
 	if err != nil {
 		return nil, err
 	}
+	drawerDir, err := config.DrawerDir(slug)
+	if err != nil {
+		return nil, err
+	}
+	buttonSpec := filepath.Join(btnDir, "button.json")
+	drawerSpec := filepath.Join(drawerDir, "drawer.json")
+	buttonExists := fileExists(buttonSpec)
+	drawerExists := fileExists(drawerSpec)
+	switch {
+	case buttonExists && drawerExists:
+		return nil, fmt.Errorf("ambiguous package %q: found both button and drawer. Rename one.", slug)
+	case buttonExists:
+		return loadLocalButtonBundle(slug, identity, btnDir)
+	case drawerExists:
+		return loadLocalDrawerBundle(slug, identity, drawerDir)
+	default:
+		return nil, fmt.Errorf("package %q not found: expected button.json or drawer.json", localName)
+	}
+}
+
+func loadLocalButtonBundle(localName, identity, dir string) (*Bundle, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("button %q not found: %w", localName, err)
@@ -119,10 +143,54 @@ func loadLocalBundle(localName, identity string) (*Bundle, error) {
 	if identity != "" {
 		name = identity
 	}
-	return &Bundle{Name: name, Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
+	return &Bundle{Name: name, Kind: "button", Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
+}
+
+func loadLocalDrawerBundle(localName, identity, dir string) (*Bundle, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("drawer %q not found: %w", localName, err)
+	}
+
+	files := map[string][]byte{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue // skip pressed/ — run history isn't part of the artifact
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name())) // #nosec G304 -- dir is config.DrawerDir + enumerated entry.
+		if err != nil {
+			return nil, err
+		}
+		files[e.Name()] = data
+	}
+	specData, ok := files["drawer.json"]
+	if !ok {
+		return nil, fmt.Errorf("drawer %q has no drawer.json", localName)
+	}
+	var spec drawer.Drawer
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return nil, fmt.Errorf("drawer %q: invalid drawer.json: %w", localName, err)
+	}
+
+	name := spec.Name
+	if identity != "" {
+		name = identity
+	}
+	return &Bundle{Name: name, Kind: "drawer", Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
 }
 
 func stampLocalBundleVersion(localName string, bundle *Bundle, version string) error {
+	switch bundle.Kind {
+	case "", "button":
+		return stampLocalButtonBundleVersion(localName, bundle, version)
+	case "drawer":
+		return stampLocalDrawerBundleVersion(localName, bundle, version)
+	default:
+		return fmt.Errorf("unsupported package kind %q", bundle.Kind)
+	}
+}
+
+func stampLocalButtonBundleVersion(localName string, bundle *Bundle, version string) error {
 	specData, ok := bundle.Files["button.json"]
 	if !ok {
 		return fmt.Errorf("button %q has no button.json", localName)
@@ -150,6 +218,40 @@ func stampLocalBundleVersion(localName string, bundle *Bundle, version string) e
 		return fmt.Errorf("write %q button.json: %w", localName, err)
 	}
 	return nil
+}
+
+func stampLocalDrawerBundleVersion(localName string, bundle *Bundle, version string) error {
+	specData, ok := bundle.Files["drawer.json"]
+	if !ok {
+		return fmt.Errorf("drawer %q has no drawer.json", localName)
+	}
+	var spec drawer.Drawer
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		return fmt.Errorf("drawer %q: invalid drawer.json: %w", localName, err)
+	}
+	spec.Version = version
+	data, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %q drawer.json: %w", localName, err)
+	}
+
+	bundle.Version = version
+	bundle.Files["drawer.json"] = data
+	bundle.SHA256 = hashFiles(bundle.Files)
+
+	dir, err := config.DrawerDir(button.Slugify(localName))
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "drawer.json"), data, 0o600); err != nil {
+		return fmt.Errorf("write %q drawer.json: %w", localName, err)
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // splitScoped parses a registry identity @desk/name into its parts, rejecting

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -157,6 +157,9 @@ func loadLocalDrawerBundle(localName, identity, dir string) (*Bundle, error) {
 		if e.IsDir() {
 			continue // skip pressed/ — run history isn't part of the artifact
 		}
+		if e.Type()&os.ModeSymlink != 0 {
+			continue // don't follow symlinks; they can point outside the drawer root
+		}
 		data, err := os.ReadFile(filepath.Join(dir, e.Name())) // #nosec G304 -- dir is config.DrawerDir + enumerated entry.
 		if err != nil {
 			return nil, err

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -102,7 +102,7 @@ func loadLocalBundle(localName, identity string) (*Bundle, error) {
 	drawerExists := fileExists(drawerSpec)
 	switch {
 	case buttonExists && drawerExists:
-		return nil, fmt.Errorf("ambiguous package %q: found both button and drawer. Rename one.", slug)
+		return nil, fmt.Errorf("ambiguous package %q: found both button and drawer; rename one", slug)
 	case buttonExists:
 		return loadLocalButtonBundle(slug, identity, btnDir)
 	case drawerExists:

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -55,17 +55,17 @@ func writeInstalledButton(t *testing.T, home string, b button.Button, body strin
 func writeInstalledDrawer(t *testing.T, home string, d drawer.Drawer) {
 	t.Helper()
 	dir := filepath.Join(home, "drawers", d.Name)
-	if err := os.MkdirAll(filepath.Join(dir, "pressed"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "pressed"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := json.MarshalIndent(&d, "", "  ")
-	if err := os.WriteFile(filepath.Join(dir, "drawer.json"), data, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "drawer.json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# "+d.Name+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "pressed", "run1.json"), []byte("{}"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "pressed", "run1.json"), []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/drawer"
 )
 
 type capturePublisher struct {
@@ -45,6 +47,24 @@ func writeInstalledButton(t *testing.T, home string, b button.Button, body strin
 		t.Fatal(err)
 	}
 	// A run-history file that must NOT be published.
+	if err := os.WriteFile(filepath.Join(dir, "pressed", "run1.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeInstalledDrawer(t *testing.T, home string, d drawer.Drawer) {
+	t.Helper()
+	dir := filepath.Join(home, "drawers", d.Name)
+	if err := os.MkdirAll(filepath.Join(dir, "pressed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.MarshalIndent(&d, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "drawer.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# "+d.Name+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "pressed", "run1.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -131,6 +151,61 @@ func TestPublishToRegistryStampsAutomaticVersion(t *testing.T) {
 	}
 	if local.Version != res.Version {
 		t.Fatalf("local button.json version = %q, want %q", local.Version, res.Version)
+	}
+}
+
+func TestPublishToRegistryAutoDetectsDrawerPackage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledDrawer(t, home, drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "deploy-pack",
+		Steps:         []drawer.Step{{ID: "build", Button: "build"}},
+	})
+
+	pub := &capturePublisher{}
+	res, err := PublishToRegistry(pub, "@autono/deploy-pack")
+	if err != nil {
+		t.Fatalf("publish drawer to registry: %v", err)
+	}
+	if res.Name != "@autono/deploy-pack" || res.Kind != "drawer" || res.Version != "1" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if pub.bundle == nil || pub.bundle.Kind != "drawer" {
+		t.Fatalf("publisher bundle = %+v, want drawer kind", pub.bundle)
+	}
+	if _, ok := pub.bundle.Files["drawer.json"]; !ok {
+		t.Fatal("published drawer bundle missing drawer.json")
+	}
+	if _, ok := pub.bundle.Files["pressed/run1.json"]; ok {
+		t.Fatal("drawer pressed history must not be published")
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, "drawers", "deploy-pack", "drawer.json"))
+	if err != nil {
+		t.Fatalf("read local drawer.json: %v", err)
+	}
+	var local drawer.Drawer
+	if err := json.Unmarshal(data, &local); err != nil {
+		t.Fatalf("local drawer.json: %v", err)
+	}
+	if local.Version != "1" {
+		t.Fatalf("local drawer version = %q, want 1", local.Version)
+	}
+}
+
+func TestPublishToRegistryRejectsLocalButtonDrawerCollision(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledButton(t, home, button.Button{SchemaVersion: 1, Name: "deploy", Runtime: "shell", Version: "1"}, "#!/bin/sh\necho deploy\n")
+	writeInstalledDrawer(t, home, drawer.Drawer{SchemaVersion: drawer.SchemaVersion, Name: "deploy", Version: "1"})
+
+	_, err := PublishToRegistry(&capturePublisher{}, "@autono/deploy")
+	if err == nil {
+		t.Fatal("publishing a colliding button/drawer name should error")
+	}
+	if !strings.Contains(err.Error(), "found both button and drawer") {
+		t.Fatalf("error = %v, want collision message", err)
 	}
 }
 

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -194,6 +194,34 @@ func TestPublishToRegistryAutoDetectsDrawerPackage(t *testing.T) {
 	}
 }
 
+func TestPublishToRegistrySkipsDrawerSymlinks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledDrawer(t, home, drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "deploy-pack",
+		Steps:         []drawer.Step{{ID: "build", Button: "build"}},
+	})
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(home, "drawers", "deploy-pack", "leak.txt")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	pub := &capturePublisher{}
+	if _, err := PublishToRegistry(pub, "@autono/deploy-pack"); err != nil {
+		t.Fatalf("publish drawer to registry: %v", err)
+	}
+	if pub.bundle == nil {
+		t.Fatal("publisher did not receive bundle")
+	}
+	if _, leaked := pub.bundle.Files["leak.txt"]; leaked {
+		t.Fatal("drawer publish followed a symlink and leaked an out-of-root file")
+	}
+}
+
 func TestPublishToRegistryRejectsLocalButtonDrawerCollision(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("BUTTONS_HOME", home)

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/drawer"
 )
 
 // ButtonRef is a catalog entry — what a Source advertises in its index.
@@ -26,12 +27,13 @@ type ButtonRef struct {
 	SHA256  string   `json:"sha256,omitempty"`
 }
 
-// Bundle is a fetched button's content, ready to write to disk.
+// Bundle is a fetched package's content, ready to write to disk.
 type Bundle struct {
 	Name    string
+	Kind    string
 	Version string
 	SHA256  string            // content hash of Files (provenance pin)
-	Files   map[string][]byte // relative filename -> bytes (button.json, main.*, AGENTS.md)
+	Files   map[string][]byte // relative filename -> bytes (button.json/drawer.json, code, AGENTS.md)
 }
 
 // Source is where buttons are installed/updated from. HTTPSource (the registry,
@@ -85,8 +87,8 @@ func safeJoin(dir, rel string) (string, error) {
 	return dst, nil
 }
 
-// LocalSource installs from a directory laid out like a buttons dir:
-// <Root>/<name>/{button.json, main.*, AGENTS.md}. For dev/testing without a
+// LocalSource installs from a directory laid out like a package dir:
+// <Root>/<name>/{button.json|drawer.json, main.*, AGENTS.md}. For dev/testing without a
 // registry server, and the reference for what an HTTPSource must reproduce.
 type LocalSource struct {
 	Root string
@@ -102,16 +104,27 @@ func (s *LocalSource) Index() ([]ButtonRef, error) {
 		if !e.IsDir() {
 			continue
 		}
+		dir := filepath.Join(s.Root, e.Name())
 		// #nosec G304 -- path is rooted in s.Root + a DirEntry name we just enumerated.
-		data, err := os.ReadFile(filepath.Join(s.Root, e.Name(), "button.json"))
-		if err != nil {
-			continue // not a button folder
-		}
-		var b button.Button
-		if json.Unmarshal(data, &b) != nil {
+		data, err := os.ReadFile(filepath.Join(dir, "button.json"))
+		if err == nil {
+			var b button.Button
+			if json.Unmarshal(data, &b) != nil {
+				continue
+			}
+			refs = append(refs, ButtonRef{Name: b.Name, Kind: "button", Version: b.Version, Tags: b.Tags})
 			continue
 		}
-		refs = append(refs, ButtonRef{Name: b.Name, Kind: "button", Version: b.Version, Tags: b.Tags})
+		// #nosec G304 -- path is rooted in s.Root + a DirEntry name we just enumerated.
+		data, err = os.ReadFile(filepath.Join(dir, "drawer.json"))
+		if err != nil {
+			continue
+		}
+		var d drawer.Drawer
+		if json.Unmarshal(data, &d) != nil {
+			continue
+		}
+		refs = append(refs, ButtonRef{Name: d.Name, Kind: "drawer", Version: d.Version})
 	}
 	return refs, nil
 }
@@ -140,17 +153,27 @@ func (s *LocalSource) Fetch(name, version string) (*Bundle, error) {
 		}
 		files[e.Name()] = data
 	}
-	if _, ok := files["button.json"]; !ok {
-		return nil, fmt.Errorf("button %q has no button.json", name)
+	if data, ok := files["button.json"]; ok {
+		var b button.Button
+		if err := json.Unmarshal(data, &b); err != nil {
+			return nil, fmt.Errorf("button %q: invalid button.json: %w", name, err)
+		}
+		// A LocalSource holds one version per package on disk; honor an explicit pin
+		// by validating it matches rather than silently returning whatever is there.
+		if version != "" && b.Version != version {
+			return nil, fmt.Errorf("button %q version mismatch: requested %q, found %q", name, version, b.Version)
+		}
+		return &Bundle{Name: b.Name, Kind: "button", Version: b.Version, SHA256: hashFiles(files), Files: files}, nil
 	}
-	var b button.Button
-	if err := json.Unmarshal(files["button.json"], &b); err != nil {
-		return nil, fmt.Errorf("button %q: invalid button.json: %w", name, err)
+	if data, ok := files["drawer.json"]; ok {
+		var d drawer.Drawer
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, fmt.Errorf("drawer %q: invalid drawer.json: %w", name, err)
+		}
+		if version != "" && d.Version != version {
+			return nil, fmt.Errorf("drawer %q version mismatch: requested %q, found %q", name, version, d.Version)
+		}
+		return &Bundle{Name: d.Name, Kind: "drawer", Version: d.Version, SHA256: hashFiles(files), Files: files}, nil
 	}
-	// A LocalSource holds one version per button on disk; honor an explicit pin
-	// by validating it matches rather than silently returning whatever is there.
-	if version != "" && b.Version != version {
-		return nil, fmt.Errorf("button %q version mismatch: requested %q, found %q", name, version, b.Version)
-	}
-	return &Bundle{Name: b.Name, Version: b.Version, SHA256: hashFiles(files), Files: files}, nil
+	return nil, fmt.Errorf("package %q has no button.json or drawer.json", name)
 }

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -106,22 +106,25 @@ func (s *LocalSource) Index() ([]ButtonRef, error) {
 		}
 		dir := filepath.Join(s.Root, e.Name())
 		// #nosec G304 -- path is rooted in s.Root + a DirEntry name we just enumerated.
-		data, err := os.ReadFile(filepath.Join(dir, "button.json"))
-		if err == nil {
+		buttonData, buttonErr := os.ReadFile(filepath.Join(dir, "button.json"))
+		// #nosec G304 -- path is rooted in s.Root + a DirEntry name we just enumerated.
+		drawerData, drawerErr := os.ReadFile(filepath.Join(dir, "drawer.json"))
+		if buttonErr == nil && drawerErr == nil {
+			return nil, fmt.Errorf("ambiguous package %q: found both button.json and drawer.json", e.Name())
+		}
+		if buttonErr == nil {
 			var b button.Button
-			if json.Unmarshal(data, &b) != nil {
+			if json.Unmarshal(buttonData, &b) != nil {
 				continue
 			}
 			refs = append(refs, ButtonRef{Name: b.Name, Kind: "button", Version: b.Version, Tags: b.Tags})
 			continue
 		}
-		// #nosec G304 -- path is rooted in s.Root + a DirEntry name we just enumerated.
-		data, err = os.ReadFile(filepath.Join(dir, "drawer.json"))
-		if err != nil {
+		if drawerErr != nil {
 			continue
 		}
 		var d drawer.Drawer
-		if json.Unmarshal(data, &d) != nil {
+		if json.Unmarshal(drawerData, &d) != nil {
 			continue
 		}
 		refs = append(refs, ButtonRef{Name: d.Name, Kind: "drawer", Version: d.Version})
@@ -136,7 +139,7 @@ func (s *LocalSource) Fetch(name, version string) (*Bundle, error) {
 	dir := filepath.Join(s.Root, name)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("button %q not found in source: %w", name, err)
+		return nil, fmt.Errorf("package %q not found in source: %w", name, err)
 	}
 	files := map[string][]byte{}
 	for _, e := range entries {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/drawer"
 	"github.com/autonoco/buttons/internal/manifest"
 )
 
@@ -23,6 +24,17 @@ func sourceBundle(t *testing.T, ref string, b button.Button, body string) *Bundl
 	files["button.json"] = data
 	files["main.sh"] = []byte(body)
 	return &Bundle{Name: ref, Version: b.Version, SHA256: hashFiles(files), Files: files}
+}
+
+func drawerBundle(t *testing.T, ref string, d drawer.Drawer) *Bundle {
+	t.Helper()
+	files := map[string][]byte{}
+	data, err := json.MarshalIndent(&d, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files["drawer.json"] = data
+	return &Bundle{Name: ref, Kind: "drawer", Version: d.Version, SHA256: hashFiles(files), Files: files}
 }
 
 type memorySource struct {
@@ -60,6 +72,19 @@ func installedSpec(t *testing.T, home, name string) button.Button {
 		t.Fatal(err)
 	}
 	return b
+}
+
+func installedDrawer(t *testing.T, home, name string) drawer.Drawer {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "drawers", name, "drawer.json"))
+	if err != nil {
+		t.Fatalf("drawer %q not installed: %v", name, err)
+	}
+	var d drawer.Drawer
+	if err := json.Unmarshal(data, &d); err != nil {
+		t.Fatal(err)
+	}
+	return d
 }
 
 func TestInstallManifestWithDepsWritesLock(t *testing.T) {
@@ -124,6 +149,96 @@ func TestInstallManifestWithDepsWritesLock(t *testing.T) {
 	}
 	if info.Mode().Perm()&0o100 == 0 {
 		t.Fatalf("main.sh not executable: %v", info.Mode())
+	}
+}
+
+func TestInstallManifestInstallsDrawerPackageAndMemberButtons(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	pack := drawerBundle(t, "@autono/deploy-pack", drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "deploy-pack",
+		Version:       "1",
+		Steps: []drawer.Step{
+			{ID: "build", Kind: "button", Button: "build"},
+			{ID: "ship", Button: "ship"},
+		},
+	})
+	build := sourceBundle(t, "@autono/build", button.Button{
+		SchemaVersion: 1,
+		Name:          "build",
+		Runtime:       "shell",
+		Version:       "4",
+	}, "#!/bin/sh\necho build\n")
+	ship := sourceBundle(t, "@autono/ship", button.Button{
+		SchemaVersion: 1,
+		Name:          "ship",
+		Runtime:       "shell",
+		Version:       "2",
+		Requires:      map[string]string{"@autono/base": "latest"},
+	}, "#!/bin/sh\necho ship\n")
+	base := sourceBundle(t, "@autono/base", button.Button{
+		SchemaVersion: 1,
+		Name:          "base",
+		Runtime:       "shell",
+		Version:       "3",
+	}, "#!/bin/sh\necho base\n")
+	src := memorySource{
+		refs: []ButtonRef{
+			{Name: "@autono/deploy-pack", Kind: "drawer", Version: "1"},
+			{Name: "@autono/build", Kind: "button", Version: "4"},
+			{Name: "@autono/ship", Kind: "button", Version: "2"},
+			{Name: "@autono/base", Kind: "button", Version: "3"},
+		},
+		bundles: map[string]*Bundle{
+			"@autono/deploy-pack@1": pack,
+			"@autono/build@4":       build,
+			"@autono/ship@2":        ship,
+			"@autono/base@3":        base,
+		},
+	}
+
+	res, lock, err := InstallManifest(src, &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{"@autono/deploy-pack": "latest"}}, nil, InstallOptions{RefreshFloating: true, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("install drawer package: %v", err)
+	}
+	got := append([]string{}, res.Installed...)
+	sort.Strings(got)
+	want := []string{"base", "build", "deploy-pack", "ship"}
+	if len(got) != len(want) {
+		t.Fatalf("installed = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("installed = %v, want %v", got, want)
+		}
+	}
+
+	if d := installedDrawer(t, home, "deploy-pack"); d.Version != "1" || len(d.Steps) != 2 {
+		t.Fatalf("installed drawer = %+v", d)
+	}
+	if installedSpec(t, home, "build").Version != "4" {
+		t.Fatal("build button was not installed at version 4")
+	}
+	if installedSpec(t, home, "ship").Version != "2" {
+		t.Fatal("ship button was not installed at version 2")
+	}
+	if installedSpec(t, home, "base").Version != "3" {
+		t.Fatal("transitive base button was not installed at version 3")
+	}
+
+	for name, wantKind := range map[string]string{
+		"@autono/deploy-pack": "drawer",
+		"@autono/build":       "button",
+		"@autono/ship":        "button",
+		"@autono/base":        "button",
+	} {
+		entry := lock.Dependencies[name]
+		if entry.Kind != wantKind || entry.Version == "" || entry.ContentHash == "" || entry.ResolvedAt != now.Format(time.RFC3339) {
+			t.Fatalf("bad lock entry for %s: %+v", name, entry)
+		}
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -166,6 +166,8 @@ func TestInstallManifestInstallsDrawerPackageAndMemberButtons(t *testing.T) {
 			{ID: "ship", Button: "ship"},
 		},
 	})
+	pack.Files["helper.sh"] = []byte("#!/bin/sh\necho helper\n")
+	pack.SHA256 = hashFiles(pack.Files)
 	build := sourceBundle(t, "@autono/build", button.Button{
 		SchemaVersion: 1,
 		Name:          "build",
@@ -218,6 +220,20 @@ func TestInstallManifestInstallsDrawerPackageAndMemberButtons(t *testing.T) {
 
 	if d := installedDrawer(t, home, "deploy-pack"); d.Version != "1" || len(d.Steps) != 2 {
 		t.Fatalf("installed drawer = %+v", d)
+	}
+	drawerInfo, err := os.Stat(filepath.Join(home, "drawers", "deploy-pack", "drawer.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drawerInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("drawer.json mode = %v, want 0600", drawerInfo.Mode().Perm())
+	}
+	helperInfo, err := os.Stat(filepath.Join(home, "drawers", "deploy-pack", "helper.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if helperInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("helper.sh mode = %v, want 0700", helperInfo.Mode().Perm())
 	}
 	if installedSpec(t, home, "build").Version != "4" {
 		t.Fatal("build button was not installed at version 4")
@@ -366,6 +382,20 @@ func TestFetchVersionMismatch(t *testing.T) {
 	}
 	if _, err := ls.Fetch("pin", ""); err != nil {
 		t.Errorf("Fetch with empty version (latest) should succeed: %v", err)
+	}
+}
+
+func TestIndexRejectsAmbiguousPackageSpec(t *testing.T) {
+	src := t.TempDir()
+	writeSourceButton(t, src, button.Button{SchemaVersion: 1, Name: "ambiguous", Runtime: "shell", Version: "1"})
+	data, _ := json.MarshalIndent(&drawer.Drawer{SchemaVersion: drawer.SchemaVersion, Name: "ambiguous", Version: "1"}, "", "  ")
+	if err := os.WriteFile(filepath.Join(src, "ambiguous", "drawer.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (&LocalSource{Root: src}).Index()
+	if err == nil || !strings.Contains(err.Error(), "ambiguous package") {
+		t.Fatalf("Index error = %v, want ambiguous package", err)
 	}
 }
 

--- a/internal/updater/content.go
+++ b/internal/updater/content.go
@@ -147,16 +147,9 @@ func reportsWithSourceError(m *manifest.Manifest, lock *manifest.Lockfile, err e
 	reports := make([]ButtonReport, 0, len(deps))
 	for _, dep := range deps {
 		entry := lock.Dependencies[dep.name]
-		kind := entry.Kind
-		if kind == "" {
-			kind = "button"
-		}
-		name := entry.InstalledName
-		if name == "" {
-			name = localNameFromPackage(dep.name)
-		}
+		kind, installedName := effectiveDependencyIdentity(dep.name, entry)
 		reports = append(reports, ButtonReport{
-			Name:           name,
+			Name:           installedName,
 			Kind:           kind,
 			PackageName:    dep.name,
 			Requested:      dep.requested,
@@ -171,20 +164,15 @@ func reportsWithSourceError(m *manifest.Manifest, lock *manifest.Lockfile, err e
 
 func checkOneDependency(ctx context.Context, src store.Source, name, requested string, lock *manifest.Lockfile) ButtonReport {
 	entry, locked := lock.Dependencies[name]
+	kind, installedName := effectiveDependencyIdentity(name, entry)
 	rep := ButtonReport{
-		Name:           entry.InstalledName,
-		Kind:           entry.Kind,
+		Name:           installedName,
+		Kind:           kind,
 		PackageName:    name,
 		Requested:      requested,
 		CurrentVersion: entry.Version,
 		CurrentHash:    entry.ContentHash,
 		Pinned:         !manifest.IsFloating(requested),
-	}
-	if rep.Name == "" {
-		rep.Name = localNameFromPackage(name)
-	}
-	if rep.Kind == "" {
-		rep.Kind = "button"
 	}
 	if !locked {
 		rep.UpdateAvailable = true
@@ -221,6 +209,18 @@ func checkOneDependency(ctx context.Context, src store.Source, name, requested s
 		rep.UpdateAvailable = !locked || contentUpdateAvailable(rep)
 	}
 	return rep
+}
+
+func effectiveDependencyIdentity(packageName string, entry manifest.LockEntry) (kind, installedName string) {
+	kind = entry.Kind
+	if kind == "" {
+		kind = "button"
+	}
+	installedName = entry.InstalledName
+	if installedName == "" {
+		installedName = localNameFromPackage(packageName)
+	}
+	return kind, installedName
 }
 
 func contentUpdateAvailable(rep ButtonReport) bool {

--- a/internal/updater/content.go
+++ b/internal/updater/content.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/autonoco/buttons/internal/button"
@@ -102,26 +103,67 @@ func CheckContent(ctx context.Context, opts Options) ([]ButtonReport, error) {
 	}
 	src, err := sourceForManifest(ctx, opts)
 	if err != nil {
-		return reportsWithSourceError(m, err), nil
+		return reportsWithSourceError(m, lock, err), nil
 	}
 
-	reports := make([]ButtonReport, 0, len(m.Dependencies))
-	for name, requested := range m.Dependencies {
-		rep := checkOneDependency(ctx, src, name, requested, lock)
-		reports = append(reports, rep)
+	deps := contentDependencies(m, lock)
+	reports := make([]ButtonReport, 0, len(deps))
+	for _, dep := range deps {
+		reports = append(reports, checkOneDependency(ctx, src, dep.name, dep.requested, lock))
 	}
 	return reports, nil
 }
 
-func reportsWithSourceError(m *manifest.Manifest, err error) []ButtonReport {
-	reports := make([]ButtonReport, 0, len(m.Dependencies))
+type contentDependency struct {
+	name      string
+	requested string
+}
+
+func contentDependencies(m *manifest.Manifest, lock *manifest.Lockfile) []contentDependency {
+	deps := make(map[string]string, len(m.Dependencies)+len(lock.Dependencies))
 	for name, requested := range m.Dependencies {
+		deps[name] = requested
+	}
+	for name, entry := range lock.Dependencies {
+		if _, ok := deps[name]; ok {
+			continue
+		}
+		deps[name] = entry.Requested
+	}
+	names := make([]string, 0, len(deps))
+	for name := range deps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]contentDependency, 0, len(names))
+	for _, name := range names {
+		out = append(out, contentDependency{name: name, requested: deps[name]})
+	}
+	return out
+}
+
+func reportsWithSourceError(m *manifest.Manifest, lock *manifest.Lockfile, err error) []ButtonReport {
+	deps := contentDependencies(m, lock)
+	reports := make([]ButtonReport, 0, len(deps))
+	for _, dep := range deps {
+		entry := lock.Dependencies[dep.name]
+		kind := entry.Kind
+		if kind == "" {
+			kind = "button"
+		}
+		name := entry.InstalledName
+		if name == "" {
+			name = localNameFromPackage(dep.name)
+		}
 		reports = append(reports, ButtonReport{
-			Name:        localNameFromPackage(name),
-			PackageName: name,
-			Requested:   requested,
-			Pinned:      !manifest.IsFloating(requested),
-			Error:       err.Error(),
+			Name:           name,
+			Kind:           kind,
+			PackageName:    dep.name,
+			Requested:      dep.requested,
+			CurrentVersion: entry.Version,
+			CurrentHash:    entry.ContentHash,
+			Pinned:         !manifest.IsFloating(dep.requested),
+			Error:          err.Error(),
 		})
 	}
 	return reports
@@ -131,6 +173,7 @@ func checkOneDependency(ctx context.Context, src store.Source, name, requested s
 	entry, locked := lock.Dependencies[name]
 	rep := ButtonReport{
 		Name:           entry.InstalledName,
+		Kind:           entry.Kind,
 		PackageName:    name,
 		Requested:      requested,
 		CurrentVersion: entry.Version,
@@ -139,6 +182,9 @@ func checkOneDependency(ctx context.Context, src store.Source, name, requested s
 	}
 	if rep.Name == "" {
 		rep.Name = localNameFromPackage(name)
+	}
+	if rep.Kind == "" {
+		rep.Kind = "button"
 	}
 	if !locked {
 		rep.UpdateAvailable = true
@@ -165,6 +211,9 @@ func checkOneDependency(ctx context.Context, src store.Source, name, requested s
 	if err != nil {
 		rep.Error = err.Error()
 		return rep
+	}
+	if ref.Kind != "" {
+		rep.Kind = ref.Kind
 	}
 	rep.LatestVersion = ref.Version
 	rep.LatestHash = ref.SHA256
@@ -216,7 +265,14 @@ func locallyModified(entry manifest.LockEntry) (bool, error) {
 	if entry.InstalledName == "" {
 		return false, nil
 	}
-	dir, err := config.ButtonDir(button.Slugify(entry.InstalledName))
+	var dir string
+	var err error
+	switch entry.Kind {
+	case "drawer":
+		dir, err = config.DrawerDir(button.Slugify(entry.InstalledName))
+	default:
+		dir, err = config.ButtonDir(button.Slugify(entry.InstalledName))
+	}
 	if err != nil {
 		return false, err
 	}

--- a/internal/updater/content_test.go
+++ b/internal/updater/content_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/drawer"
 	"github.com/autonoco/buttons/internal/manifest"
 	"github.com/autonoco/buttons/internal/store"
 )
@@ -64,6 +65,24 @@ func (r *testRegistry) addButton(t *testing.T, pkg, localName, version, body str
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.entries = append(r.entries, registryEntry{Name: pkg, Kind: "button", Version: version, SHA256: sum})
+	r.blobs[pkg+"@"+version] = tb
+}
+
+func (r *testRegistry) addDrawer(t *testing.T, pkg, localName, version string, steps []drawer.Step) {
+	t.Helper()
+	spec := drawer.Drawer{SchemaVersion: drawer.SchemaVersion, Name: localName, Version: version, Steps: steps}
+	data, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{
+		"drawer.json": append(data, '\n'),
+	}
+	tb := makeRegistryTarball(t, localName, files)
+	sum := sha(tb)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, registryEntry{Name: pkg, Kind: "drawer", Version: version, SHA256: sum})
 	r.blobs[pkg+"@"+version] = tb
 }
 
@@ -144,6 +163,19 @@ func readInstalledButton(t *testing.T, home, name string) button.Button {
 	return b
 }
 
+func readInstalledDrawer(t *testing.T, home, name string) drawer.Drawer {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "drawers", name, "drawer.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d drawer.Drawer
+	if err := json.Unmarshal(data, &d); err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
 func installFromRegistry(t *testing.T, home, url, key string, deps map[string]string) {
 	t.Helper()
 	t.Setenv("BUTTONS_HOME", home)
@@ -198,6 +230,89 @@ func TestApplyContentUpdateFromManifest(t *testing.T) {
 	}
 	if got := lock.Dependencies["@autono/hello"].Version; got != "2" {
 		t.Fatalf("lock version = %q, want 2", got)
+	}
+}
+
+func TestApplyContentUpdateFromDrawerManifest(t *testing.T) {
+	home := t.TempDir()
+	reg := newTestRegistry("rk")
+	reg.addButton(t, "@autono/build", "build", "1", "#!/bin/sh\necho build\n")
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "1", []drawer.Step{{ID: "build", Button: "build"}})
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/deploy-pack": "latest"})
+
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "2", []drawer.Step{{ID: "build", Button: "build"}})
+	report, err := Check(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	var drawerReport *ButtonReport
+	for i := range report.Buttons {
+		if report.Buttons[i].PackageName == "@autono/deploy-pack" {
+			drawerReport = &report.Buttons[i]
+			break
+		}
+	}
+	if drawerReport == nil || drawerReport.Kind != "drawer" || !drawerReport.UpdateAvailable {
+		t.Fatalf("expected one drawer content update, got %+v", report.Buttons)
+	}
+
+	result, err := Apply(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(result.UpdatedButtons) != 1 || result.UpdatedButtons[0] != "deploy-pack" {
+		t.Fatalf("updated packages = %v, want [deploy-pack]", result.UpdatedButtons)
+	}
+	if got := readInstalledDrawer(t, home, "deploy-pack"); got.Version != "2" {
+		t.Fatalf("installed drawer version = %q, want 2", got.Version)
+	}
+}
+
+func TestApplyContentUpdateFromDrawerMemberLockEntry(t *testing.T) {
+	home := t.TempDir()
+	reg := newTestRegistry("rk")
+	reg.addButton(t, "@autono/build", "build", "1", "#!/bin/sh\necho build v1\n")
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "1", []drawer.Step{{ID: "build", Button: "build"}})
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/deploy-pack": "latest"})
+
+	reg.addButton(t, "@autono/build", "build", "2", "#!/bin/sh\necho build v2\n")
+	reports, err := CheckContent(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("check content: %v", err)
+	}
+	var buildReport *ButtonReport
+	for i := range reports {
+		if reports[i].PackageName == "@autono/build" {
+			buildReport = &reports[i]
+			break
+		}
+	}
+	if buildReport == nil || buildReport.Kind != "button" || !buildReport.UpdateAvailable {
+		t.Fatalf("expected drawer member button update report, got %+v", reports)
+	}
+
+	result, err := Apply(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(result.UpdatedButtons) != 1 || result.UpdatedButtons[0] != "build" {
+		t.Fatalf("updated packages = %v, want [build]", result.UpdatedButtons)
+	}
+	if got := readInstalledButton(t, home, "build"); got.Version != "2" {
+		t.Fatalf("installed member button version = %q, want 2", got.Version)
+	}
+	lock, err := manifest.LoadLockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lock.Dependencies["@autono/build"].Version; got != "2" {
+		t.Fatalf("member button lock version = %q, want 2", got)
 	}
 }
 
@@ -259,6 +374,41 @@ func TestApplyContentUpdateSkipsLocalEdits(t *testing.T) {
 	}
 	if string(got) != "#!/bin/sh\necho local\n" {
 		t.Fatalf("local edit was overwritten: %q", string(got))
+	}
+}
+
+func TestApplyContentUpdateSkipsLocalDrawerEdits(t *testing.T) {
+	home := t.TempDir()
+	reg := newTestRegistry("rk")
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "1", nil)
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	installFromRegistry(t, home, srv.URL, "rk", map[string]string{"@autono/deploy-pack": "latest"})
+	path := filepath.Join(home, "drawers", "deploy-pack", "drawer.json")
+	local := readInstalledDrawer(t, home, "deploy-pack")
+	local.Description = "local edit"
+	data, err := json.MarshalIndent(&local, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reg.addDrawer(t, "@autono/deploy-pack", "deploy-pack", "2", nil)
+
+	result, err := Apply(contextWithTestDeadline(t), Options{SkipBinary: true, RegistryURL: srv.URL, RegistryKey: "rk", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(result.UpdatedButtons) != 0 {
+		t.Fatalf("updated drawer packages = %v, want none", result.UpdatedButtons)
+	}
+	if len(result.Buttons) != 1 || !result.Buttons[0].Skipped || result.Buttons[0].Kind != "drawer" {
+		t.Fatalf("expected local drawer edit skip, got %+v", result.Buttons)
+	}
+	if got := readInstalledDrawer(t, home, "deploy-pack"); got.Version != "1" || got.Description != "local edit" {
+		t.Fatalf("local drawer was overwritten: %+v", got)
 	}
 }
 

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -36,6 +36,7 @@ type BinaryReport struct {
 
 type ButtonReport struct {
 	Name            string `json:"name"`
+	Kind            string `json:"kind,omitempty"`
 	PackageName     string `json:"package_name"`
 	Requested       string `json:"requested,omitempty"`
 	Pinned          bool   `json:"pinned,omitempty"`

--- a/test/integration/ota_update_test.go
+++ b/test/integration/ota_update_test.go
@@ -125,10 +125,13 @@ func writeOTAPublishButton(t *testing.T, home, name, version, body string) {
 		t.Fatal(err)
 	}
 	spec := map[string]any{
-		"schema_version": 1,
-		"name":           name,
-		"runtime":        "shell",
-		"version":        version,
+		"schema_version":  1,
+		"name":            name,
+		"runtime":         "shell",
+		"version":         version,
+		"timeout_seconds": 300,
+		"mcp_enabled":     false,
+		"env":             map[string]string{},
 	}
 	data, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
@@ -142,9 +145,45 @@ func writeOTAPublishButton(t *testing.T, home, name, version, body string) {
 	}
 }
 
+func writeOTAPublishDrawer(t *testing.T, home, name, version string, steps []map[string]any) {
+	t.Helper()
+	dir := filepath.Join(home, "drawers", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	spec := map[string]any{
+		"schema_version": 1,
+		"name":           name,
+		"version":        version,
+		"steps":          steps,
+	}
+	data, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "drawer.json"), append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func readInstalledVersion(t *testing.T, home, name string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(home, "buttons", name, "button.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spec struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatal(err)
+	}
+	return spec.Version
+}
+
+func readInstalledDrawerVersion(t *testing.T, home, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "drawers", name, "drawer.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,6 +228,23 @@ func readLockVersion(t *testing.T, home, name string) string {
 	return lock.Dependencies[name].Version
 }
 
+func readLockKind(t *testing.T, home, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "buttons-lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lock struct {
+		Dependencies map[string]struct {
+			Kind string `json:"kind"`
+		} `json:"dependencies"`
+	}
+	if err := json.Unmarshal(data, &lock); err != nil {
+		t.Fatal(err)
+	}
+	return lock.Dependencies[name].Kind
+}
+
 func readLifecycleEvents(t *testing.T, home string) []struct {
 	Action      string `json:"action"`
 	PackageName string `json:"package_name,omitempty"`
@@ -225,6 +281,106 @@ func publishEnv(url string) []string {
 		"BUTTONS_REGISTRY_URL=" + url,
 		"BUTTONS_BAT_REGISTRY_WRITE_KEY=write-key",
 		"BUTTONS_NO_UPDATE=1",
+	}
+}
+
+func TestAddDrawerPackageInstallsAndUpdatesMemberButtons(t *testing.T) {
+	reg := newOTARegistry("read-key", "write-key")
+	srv := httptest.NewServer(reg.handler())
+	defer srv.Close()
+
+	publisher := newTestEnv(t)
+	agent := newTestEnv(t)
+
+	writeOTAPublishButton(t, publisher.home, "build", "1", "#!/bin/sh\necho build-v1\n")
+	res := publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/build", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("publish build v1 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
+	}
+	writeOTAPublishButton(t, publisher.home, "ship", "1", "#!/bin/sh\necho ship-v1\n")
+	res = publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/ship", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("publish ship v1 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
+	}
+
+	writeOTAPublishDrawer(t, publisher.home, "deploy-pack", "1", []map[string]any{
+		{"id": "build", "button": "build"},
+		{"id": "ship", "button": "ship"},
+	})
+	res = publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/deploy-pack", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("publish drawer failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
+	}
+
+	res = agent.runWithEnv(registryEnv(srv.URL), "add", "@autono/deploy-pack", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("add drawer package failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
+	}
+	if got := readManifestDependency(t, agent.home, "@autono/deploy-pack"); got != "latest" {
+		t.Fatalf("manifest drawer dependency = %q, want latest", got)
+	}
+	if got := readInstalledDrawerVersion(t, agent.home, "deploy-pack"); got != "1" {
+		t.Fatalf("installed drawer version = %q, want 1", got)
+	}
+	if got := readInstalledVersion(t, agent.home, "build"); got != "1" {
+		t.Fatalf("installed member button version = %q, want 1", got)
+	}
+	if got := readInstalledVersion(t, agent.home, "ship"); got != "1" {
+		t.Fatalf("installed second member button version = %q, want 1", got)
+	}
+	if got := readLockKind(t, agent.home, "@autono/deploy-pack"); got != "drawer" {
+		t.Fatalf("drawer lock kind = %q, want drawer", got)
+	}
+	if got := readLockKind(t, agent.home, "@autono/build"); got != "button" {
+		t.Fatalf("member lock kind = %q, want button", got)
+	}
+	if got := readLockKind(t, agent.home, "@autono/ship"); got != "button" {
+		t.Fatalf("second member lock kind = %q, want button", got)
+	}
+
+	press := agent.runWithEnv(registryEnv(srv.URL), "drawer", "deploy-pack", "press", "--json")
+	if press.ExitCode != 0 {
+		t.Fatalf("drawer press failed: stdout=%s stderr=%s", press.Stdout, press.Stderr)
+	}
+	pressJSON := parseJSON(t, press.Stdout)
+	if !pressJSON.OK || !jsonContains(t, pressJSON.Data, `"status": "ok"`) {
+		t.Fatalf("drawer press did not succeed: stdout=%s stderr=%s", press.Stdout, press.Stderr)
+	}
+
+	writeOTAPublishButton(t, publisher.home, "build", "2", "#!/bin/sh\necho build-v2\n")
+	res = publisher.runWithEnv(publishEnv(srv.URL), "publish", "@autono/build", "--json")
+	if res.ExitCode != 0 {
+		t.Fatalf("publish build v2 failed: stdout=%s stderr=%s", res.Stdout, res.Stderr)
+	}
+
+	status := agent.runWithEnv(registryEnv(srv.URL), "status", "--json")
+	if status.ExitCode != 0 {
+		t.Fatalf("status failed: stdout=%s stderr=%s", status.Stdout, status.Stderr)
+	}
+	statusJSON := parseJSON(t, status.Stdout)
+	if !statusJSON.OK {
+		t.Fatalf("status returned error: %+v", statusJSON.Error)
+	}
+	if !jsonContains(t, statusJSON.Data, `"package_name": "@autono/build"`) || !jsonContains(t, statusJSON.Data, `"update_available": true`) {
+		t.Fatalf("status did not report the member button update: %s", statusJSON.Data)
+	}
+
+	update := agent.runWithEnv(registryEnv(srv.URL), "update", "--json")
+	if update.ExitCode != 0 {
+		t.Fatalf("update failed: stdout=%s stderr=%s", update.Stdout, update.Stderr)
+	}
+	if got := readInstalledVersion(t, agent.home, "build"); got != "2" {
+		t.Fatalf("updated member button version = %q, want 2", got)
+	}
+	if got := readLockVersion(t, agent.home, "@autono/build"); got != "2" {
+		t.Fatalf("updated member lock version = %q, want 2", got)
+	}
+	body, err := os.ReadFile(filepath.Join(agent.home, "buttons", "build", "main.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "#!/bin/sh\necho build-v2\n" {
+		t.Fatalf("installed member content was not refreshed: %q", string(body))
 	}
 }
 


### PR DESCRIPTION
## Summary
- publish and install drawers as registry packages using the same @desk/name identity as buttons
- install drawer member buttons and transitive button requires into the lockfile
- include drawer/member package updates in status, update, and passive update paths
- update CLI docs and add integration coverage for drawer package add/press/status/update

## Validation
- go test ./...
- git diff --check

## Notes
- Companion registry PR: https://github.com/autonoco/buttons-registry/pull/16
- The live desk.buttons.sh smoke should run after the registry PR is merged/deployed and registry read/write keys are available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands and documentation now consistently describe installable “packages,” supporting both buttons and drawers.
  * Publishing and registry install now autodetect and handle drawer packages, including drawer version stamping and drawer package metadata.
  * Status/update now display drawer vs button labels appropriately for pinned, skipped, error, and update-available items.
* **Bug Fixes**
  * Creation and publishing now prevent name collisions across button and drawer slugs.
  * Passive and content updates now correctly apply drawer updates (including member dependencies) while respecting local drawer edits.
* **Tests**
  * Added coverage for passive updates, registry drawer installs, and drawer-related content update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->