### PR TITLE
feat: buttons agent enroll/register client

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/autonoco/buttons/internal/agent"
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/webhook"
+	"github.com/spf13/cobra"
+)
+
+var (
+	agentRegisterSlug      string
+	agentRegisterTunnel    string
+	agentRegisterAgentID   string
+	agentRegisterPrincipal string
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Register this workspace's device identity with the registry",
+	Long: `Manage this agent workspace's device identity.
+
+The device holds an Ed25519 keypair generated on first use and stored 0600 in the
+data dir (agent.json); the private key never leaves the machine. Identity is
+proven by signature, not asserted.
+
+All subcommands use $BUTTONS_REGISTRY_URL as the registry base URL — this repo
+ships no default host. Enrollment consumes a one-time token supplied as the
+ENROLL_TOKEN battery (or $BUTTONS_BAT_ENROLL_TOKEN).`,
+	RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+}
+
+// enrollToken resolves the one-time enrollment token — the injected
+// BUTTONS_BAT_ENROLL_TOKEN env wins, else the ENROLL_TOKEN battery.
+func enrollToken() string {
+	if t := os.Getenv("BUTTONS_BAT_ENROLL_TOKEN"); t != "" {
+		return t
+	}
+	if svc, err := newBatteryService(); err == nil {
+		if v, _, err := svc.Get("ENROLL_TOKEN"); err == nil {
+			return v
+		}
+	}
+	return ""
+}
+
+// agentConfigError renders a pre-flight validation error in the active format.
+func agentConfigError(msg string) error {
+	if jsonOutput {
+		_ = config.WriteJSONError("VALIDATION_ERROR", msg)
+		return errSilent
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func agentRuntimeError(code string, err error) error {
+	if jsonOutput {
+		_ = config.WriteJSONError(code, err.Error())
+		return errSilent
+	}
+	return err
+}
+
+var agentEnrollCmd = &cobra.Command{
+	Use:   "enroll",
+	Short: "Generate this device's key and bind it to its owner with a one-time token",
+	Args:  exactArgs(0),
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		reg := registryURL()
+		if reg == "" {
+			return agentConfigError("no registry target: set $BUTTONS_REGISTRY_URL")
+		}
+		token := enrollToken()
+		if token == "" {
+			return agentConfigError("no enroll token: run `buttons batteries set ENROLL_TOKEN <token>` (or set $BUTTONS_BAT_ENROLL_TOKEN)")
+		}
+		c, err := agent.LoadOrCreate()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		id, err := c.Identity()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		res, err := (&agent.Client{BaseURL: reg}).Enroll(cmd.Context(), token, runtime.GOOS+"/"+runtime.GOARCH, id)
+		if err != nil {
+			return agentRuntimeError("ENROLL_ERROR", err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(res)
+		}
+		fmt.Fprintf(os.Stderr, "Enrolled device %s (owner %s)\n", res.DeviceID, res.OwnerID)
+		printNextHint("buttons agent register --slug <name> --tunnel <tunnel-id>")
+		return nil
+	},
+}
+
+var agentRegisterCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register this workspace under a slug and print its URLs",
+	Long: `Register this workspace: claim a slug, and receive its URL set from the
+registry. Requires an enrolled device (run "buttons agent enroll" first).
+
+--tunnel defaults to the tunnel id from a configured named webhook tunnel
+(buttons webhook setup) when present.`,
+	Args: exactArgs(0),
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		reg := registryURL()
+		if reg == "" {
+			return agentConfigError("no registry target: set $BUTTONS_REGISTRY_URL")
+		}
+		if agentRegisterSlug == "" {
+			return agentConfigError("--slug is required")
+		}
+		c, err := agent.LoadConfig()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		if c == nil || c.DeviceSeed == "" {
+			return agentConfigError("device not enrolled: run `buttons agent enroll` first")
+		}
+		id, err := c.Identity()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+
+		tunnel := agentRegisterTunnel
+		if tunnel == "" {
+			if wc, err := webhook.LoadConfig(); err == nil && wc != nil {
+				tunnel = wc.TunnelID
+			}
+		}
+		if tunnel == "" {
+			return agentConfigError("no tunnel id: pass --tunnel <id> (or configure a named tunnel with `buttons webhook setup`)")
+		}
+
+		res, err := (&agent.Client{BaseURL: reg}).Register(cmd.Context(), id, agent.RegisterParams{
+			Slug:      agentRegisterSlug,
+			TunnelID:  tunnel,
+			AgentID:   agentRegisterAgentID,
+			Principal: agentRegisterPrincipal,
+		})
+		if err != nil {
+			return agentRuntimeError("REGISTER_ERROR", err)
+		}
+
+		// Persist the slug locally so `status` and re-registers know it.
+		c.Slug = res.Slug
+		if err := agent.SaveConfig(c); err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+
+		if jsonOutput {
+			return config.WriteJSON(res)
+		}
+		fmt.Fprintf(os.Stderr, "Registered %s (%s)\n", res.Slug, res.Status)
+		fmt.Fprintf(os.Stderr, "  webhook: %s\n", res.URLs.Webhook)
+		fmt.Fprintf(os.Stderr, "  tunnel:  %s\n", res.URLs.Tunnel)
+		fmt.Fprintf(os.Stderr, "  wake:    %s\n", res.URLs.Wake)
+		if res.URLs.Deploy != nil {
+			fmt.Fprintf(os.Stderr, "  deploy:  %s\n", *res.URLs.Deploy)
+		}
+		return nil
+	},
+}
+
+var agentStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show this device's identity (no secrets)",
+	Args:  exactArgs(0),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := agent.LoadConfig()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		if c == nil || c.DeviceSeed == "" {
+			if jsonOutput {
+				return config.WriteJSON(map[string]any{"enrolled": false})
+			}
+			fmt.Fprintln(os.Stderr, "not enrolled — run `buttons agent enroll`")
+			return nil
+		}
+		id, err := c.Identity()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		if jsonOutput {
+			return config.WriteJSON(map[string]any{"enrolled": true, "device_id": id.DeviceID, "slug": c.Slug})
+		}
+		fmt.Fprintf(os.Stderr, "device %s\n", id.DeviceID)
+		if c.Slug != "" {
+			fmt.Fprintf(os.Stderr, "slug   %s\n", c.Slug)
+		}
+		return nil
+	},
+}
+
+func init() {
+	agentRegisterCmd.Flags().StringVar(&agentRegisterSlug, "slug", "", "the workspace slug to claim (one DNS label)")
+	agentRegisterCmd.Flags().StringVar(&agentRegisterTunnel, "tunnel", "", "tunnel id backing this workspace (defaults to the named webhook tunnel)")
+	agentRegisterCmd.Flags().StringVar(&agentRegisterAgentID, "agent-id", "", "optional persona id")
+	agentRegisterCmd.Flags().StringVar(&agentRegisterPrincipal, "principal", "", "optional principal this workspace serves")
+	agentCmd.AddCommand(agentEnrollCmd, agentRegisterCmd, agentStatusCmd)
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 
 	"github.com/autonoco/buttons/internal/agent"
@@ -10,6 +11,10 @@ import (
 	"github.com/autonoco/buttons/internal/webhook"
 	"github.com/spf13/cobra"
 )
+
+// slugRe mirrors the broker's hostname-label rule: one DNS label, so an invalid
+// slug is rejected locally with a clear message instead of a round-trip + 400.
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 
 var (
 	agentRegisterSlug      string
@@ -114,6 +119,9 @@ registry. Requires an enrolled device (run "buttons agent enroll" first).
 		}
 		if agentRegisterSlug == "" {
 			return agentConfigError("--slug is required")
+		}
+		if !slugRe.MatchString(agentRegisterSlug) {
+			return agentConfigError("--slug must be one DNS label: lowercase letters, digits and hyphens, starting alphanumeric (max 63 chars)")
 		}
 		c, err := agent.LoadConfig()
 		if err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,311 @@
+// Package agent is the device-identity + registration client for an agent
+// workspace. Identity is an Ed25519 keypair generated on-device: the private
+// key never leaves this machine, and the device id is the hash of the public
+// key, so the identity is provable by signature rather than asserted.
+//
+// The registry base URL is NEVER hardcoded here — every call takes a BaseURL
+// the caller sources from $BUTTONS_REGISTRY_URL. The one-time enrollment token
+// is a battery (never committed), and the returned URLs come from the server,
+// so this client carries no knowledge of any specific host.
+package agent
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/autonoco/buttons/internal/config"
+)
+
+// ConfigSchemaVersion pins the shape of agent.json. Bump on breaks.
+const ConfigSchemaVersion = 1
+
+// Config is the on-disk device identity, stored 0600 in the data dir. DeviceSeed
+// is the Ed25519 seed (the private key) — the durable credential; Slug is filled
+// in once the workspace has registered.
+type Config struct {
+	SchemaVersion int    `json:"schema_version"`
+	DeviceSeed    string `json:"device_seed"`    // base64 Ed25519 seed (32 bytes)
+	Slug          string `json:"slug,omitempty"` // set once registered
+}
+
+// Identity is the key material derived from a Config's seed.
+type Identity struct {
+	priv     ed25519.PrivateKey
+	PubB64   string // base64 of the 32-byte raw public key
+	DeviceID string // hex(sha256(raw public key))
+}
+
+// ConfigPath resolves agent.json under the standard data directory (project-local
+// .buttons/ beats global ~/.buttons/), so co-located agents each get their own.
+func ConfigPath() (string, error) {
+	base, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "agent.json"), nil
+}
+
+// LoadConfig returns the persisted identity, or (nil, nil) if none exists yet.
+func LoadConfig() (*Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed path under DataDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// SaveConfig writes the identity at 0600 (it holds the private key).
+func SaveConfig(c *Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	c.SchemaVersion = ConfigSchemaVersion
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal agent config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// LoadOrCreate returns the existing identity, generating and persisting a fresh
+// keypair on first use. The generated seed is the durable device credential.
+func LoadOrCreate() (*Config, error) {
+	c, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	if c != nil && c.DeviceSeed != "" {
+		return c, nil
+	}
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		return nil, fmt.Errorf("generate device key: %w", err)
+	}
+	c = &Config{SchemaVersion: ConfigSchemaVersion, DeviceSeed: base64.StdEncoding.EncodeToString(seed)}
+	if err := SaveConfig(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Identity derives the key material from the stored seed. device_id and the
+// public-key encoding match what the registry computes server-side.
+func (c *Config) Identity() (*Identity, error) {
+	if c.DeviceSeed == "" {
+		return nil, fmt.Errorf("no device key: run `buttons agent enroll` first")
+	}
+	seed, err := base64.StdEncoding.DecodeString(c.DeviceSeed)
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("corrupt device key in agent.json")
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	sum := sha256.Sum256(pub)
+	return &Identity{priv: priv, PubB64: base64.StdEncoding.EncodeToString(pub), DeviceID: hex.EncodeToString(sum[:])}, nil
+}
+
+func (id *Identity) sign(msg string) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(id.priv, []byte(msg)))
+}
+
+// --- broker client ---
+
+// Client talks to the registration broker. BaseURL is the caller-supplied
+// $BUTTONS_REGISTRY_URL; nothing here embeds a host.
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func (c *Client) do(ctx context.Context, method, p, bearer string, body any) (*http.Response, error) {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.BaseURL, "/")+p, rdr)
+	if err != nil {
+		return nil, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		// Deliberately does not echo the URL — keep transport errors host-quiet.
+		return nil, fmt.Errorf("registry request failed: %w", err)
+	}
+	return resp, nil
+}
+
+// brokerError decodes the {"error":{code,message}} envelope into a useful error.
+func brokerError(what string, resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(data, &env) == nil && env.Error.Message != "" {
+		return fmt.Errorf("%s: %d %s (%s)", what, resp.StatusCode, env.Error.Message, env.Error.Code)
+	}
+	return fmt.Errorf("%s: %d", what, resp.StatusCode)
+}
+
+// EnrollResult is the device→owner binding the broker returns.
+type EnrollResult struct {
+	DeviceID  string  `json:"device_id"`
+	OwnerID   string  `json:"owner_id"`
+	Namespace *string `json:"namespace"`
+}
+
+// Enroll trades a one-time enroll token for a device→owner binding. Idempotent
+// server-side for the same key + owner.
+func (c *Client) Enroll(ctx context.Context, enrollToken, hostKind string, id *Identity) (*EnrollResult, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/v1/devices/enroll", enrollToken, map[string]string{
+		"pubkey":    id.PubB64,
+		"host_kind": hostKind,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, brokerError("enroll", resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out EnrollResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("enroll: decode: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) challenge(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/v1/challenge", "", nil)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", brokerError("challenge", resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out struct {
+		Nonce string `json:"nonce"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("challenge: decode: %w", err)
+	}
+	if out.Nonce == "" {
+		return "", fmt.Errorf("challenge: empty nonce")
+	}
+	return out.Nonce, nil
+}
+
+// RegisterParams are the caller-chosen fields for a registration.
+type RegisterParams struct {
+	Slug      string
+	TunnelID  string
+	AgentID   string // optional
+	Principal string // optional
+}
+
+// URLs is the derived URL set the broker returns (never constructed client-side).
+type URLs struct {
+	Webhook string  `json:"webhook"`
+	Tunnel  string  `json:"tunnel"`
+	Wake    string  `json:"wake"`
+	Deploy  *string `json:"deploy"`
+}
+
+// RegisterResult is the broker's response — the slug's URLs come from here.
+type RegisterResult struct {
+	OK      bool   `json:"ok"`
+	Slug    string `json:"slug"`
+	Status  string `json:"status"`
+	OwnerID string `json:"owner_id"`
+	URLs    URLs   `json:"urls"`
+	DNS     string `json:"dns"`
+}
+
+// Register fetches a fresh nonce, signs it into the registration message, and
+// registers the workspace. The signature proves possession of the device key.
+func (c *Client) Register(ctx context.Context, id *Identity, p RegisterParams) (*RegisterResult, error) {
+	nonce, err := c.challenge(ctx)
+	if err != nil {
+		return nil, err
+	}
+	msg := "buttons-agent-register\n" + p.Slug + "\n" + p.TunnelID + "\n" + nonce
+	body := map[string]string{
+		"device_id": id.DeviceID,
+		"slug":      p.Slug,
+		"tunnel_id": p.TunnelID,
+		"nonce":     nonce,
+		"signature": id.sign(msg),
+	}
+	if p.AgentID != "" {
+		body["agent_id"] = p.AgentID
+	}
+	if p.Principal != "" {
+		body["principal"] = p.Principal
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/v1/agents/register", "", body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, brokerError("register", resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out RegisterResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("register: decode: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -92,7 +92,14 @@ func SaveConfig(c *Config) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	// Write to a temp file then atomically rename, so an interrupted write never
+	// leaves a truncated device credential in place.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeBroker stands in for the registry — entirely local (httptest), so no real
+// host is involved. It reproduces the server's device_id formula and verifies the
+// register signature exactly as the Worker does, so this also checks crypto interop.
+func fakeBroker(t *testing.T) *httptest.Server {
+	t.Helper()
+	var enrolledPub []byte // captured at enroll, used to verify the register signature
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/devices/enroll", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-enroll-token" {
+			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"bad token"}}`, 401)
+			return
+		}
+		var body struct{ Pubkey string }
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		pub, err := base64.StdEncoding.DecodeString(body.Pubkey)
+		if err != nil || len(pub) != ed25519.PublicKeySize {
+			http.Error(w, `{"error":{"code":"INVALID","message":"pubkey"}}`, 400)
+			return
+		}
+		enrolledPub = pub
+		sum := sha256.Sum256(pub)
+		w.WriteHeader(201)
+		_ = json.NewEncoder(w).Encode(map[string]any{"device_id": hex.EncodeToString(sum[:]), "owner_id": "org_test"})
+	})
+
+	mux.HandleFunc("/v1/challenge", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"nonce": "test-nonce", "expires_at": 0})
+	})
+
+	mux.HandleFunc("/v1/agents/register", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		msg := "buttons-agent-register\n" + body["slug"] + "\n" + body["tunnel_id"] + "\n" + body["nonce"]
+		sig, err := base64.StdEncoding.DecodeString(body["signature"])
+		if err != nil || !ed25519.Verify(enrolledPub, []byte(msg), sig) {
+			http.Error(w, `{"error":{"code":"BAD_SIGNATURE","message":"bad sig"}}`, 401)
+			return
+		}
+		base := "https://" + body["slug"] + ".example.test"
+		w.WriteHeader(201)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "slug": body["slug"], "status": "created", "owner_id": "org_test",
+			"urls": map[string]any{"webhook": base + "/hooks", "tunnel": base, "wake": base + "/wake", "deploy": nil},
+			"dns":  "written",
+		})
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestEnrollThenRegister(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir()) // agent.json lands here, not the real data dir
+	srv := fakeBroker(t)
+	defer srv.Close()
+
+	c, err := LoadOrCreate()
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	id, err := c.Identity()
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	client := agentClientFor(srv)
+
+	enr, err := client.Enroll(context.Background(), "test-enroll-token", "test/arch", id)
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if enr.DeviceID != id.DeviceID {
+		t.Fatalf("device_id mismatch: server %s, client %s", enr.DeviceID, id.DeviceID)
+	}
+
+	res, err := client.Register(context.Background(), id, RegisterParams{Slug: "cindy", TunnelID: "tun_1", Principal: "bobak"})
+	if err != nil {
+		t.Fatalf("Register: %v", err) // fails if the signature didn't verify server-side
+	}
+	if res.Slug != "cindy" || res.Status != "created" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.URLs.Tunnel != "https://cindy.example.test" {
+		t.Fatalf("urls come from the server; got %q", res.URLs.Tunnel)
+	}
+}
+
+func TestEnrollRejectsBadToken(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeBroker(t)
+	defer srv.Close()
+	c, _ := LoadOrCreate()
+	id, _ := c.Identity()
+	if _, err := agentClientFor(srv).Enroll(context.Background(), "wrong", "test/arch", id); err == nil {
+		t.Fatal("expected enroll to reject a bad token")
+	}
+}
+
+func agentClientFor(srv *httptest.Server) *Client {
+	return &Client{BaseURL: srv.URL, HTTP: srv.Client()}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -22,19 +22,19 @@ func fakeBroker(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("/v1/devices/enroll", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-enroll-token" {
-			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"bad token"}}`, 401)
+			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"bad token"}}`, http.StatusUnauthorized)
 			return
 		}
 		var body struct{ Pubkey string }
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		pub, err := base64.StdEncoding.DecodeString(body.Pubkey)
 		if err != nil || len(pub) != ed25519.PublicKeySize {
-			http.Error(w, `{"error":{"code":"INVALID","message":"pubkey"}}`, 400)
+			http.Error(w, `{"error":{"code":"INVALID","message":"pubkey"}}`, http.StatusBadRequest)
 			return
 		}
 		enrolledPub = pub
 		sum := sha256.Sum256(pub)
-		w.WriteHeader(201)
+		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"device_id": hex.EncodeToString(sum[:]), "owner_id": "org_test"})
 	})
 
@@ -48,11 +48,11 @@ func fakeBroker(t *testing.T) *httptest.Server {
 		msg := "buttons-agent-register\n" + body["slug"] + "\n" + body["tunnel_id"] + "\n" + body["nonce"]
 		sig, err := base64.StdEncoding.DecodeString(body["signature"])
 		if err != nil || !ed25519.Verify(enrolledPub, []byte(msg), sig) {
-			http.Error(w, `{"error":{"code":"BAD_SIGNATURE","message":"bad sig"}}`, 401)
+			http.Error(w, `{"error":{"code":"BAD_SIGNATURE","message":"bad sig"}}`, http.StatusUnauthorized)
 			return
 		}
 		base := "https://" + body["slug"] + ".example.test"
-		w.WriteHeader(201)
+		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true, "slug": body["slug"], "status": "created", "owner_id": "org_test",
 			"urls": map[string]any{"webhook": base + "/hooks", "tunnel": base, "wake": base + "/wake", "deploy": nil},


### PR DESCRIPTION
## `buttons agent` — device identity + registration

Adds the client that lets an agent workspace register itself.

- **`buttons agent enroll`** — generates an on-device Ed25519 keypair (stored `0600` in the data dir as `agent.json`; the private key never leaves the machine) and trades a one-time token for a device→owner binding.
- **`buttons agent register`** — signs a server challenge to claim a slug and receive its URL set from the registry.
- **`buttons agent status`** — shows the device id + slug (no secrets).

### Conventions (host-agnostic, per this repo)
- Registry base URL comes from `$BUTTONS_REGISTRY_URL` — **no default host is hardcoded**.
- The enroll token is the `ENROLL_TOKEN` battery (`$BUTTONS_BAT_ENROLL_TOKEN`), env-first then battery store — the same shape as `REGISTRY_WRITE_KEY`.
- Returned URLs come **from the server response**, never constructed client-side.
- Tests use a local `httptest` server (fake `.example.test`); the fake broker verifies the client's Ed25519 signature, so this also checks crypto interop with the Worker's WebCrypto.

`go build` / `go vet` clean; `internal/agent` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `buttons agent` command group with `enroll`, `register`, and `status` subcommands.
  * You can now enroll a device, register a workspace, and check enrollment status from the CLI.
  * Registration now prints the relevant connection URLs and supports JSON output for automation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->