### PR TITLE
refactor: collapse buttons agent to setup + status

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -105,12 +105,15 @@ re-run — it re-points to the current tunnel.
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
 		}
 
-		res, err := (&agent.Client{BaseURL: reg}).Setup(cmd.Context(), id, enrollToken(), runtime.GOOS+"/"+runtime.GOARCH, agent.RegisterParams{
+		token := enrollToken()
+		res, err := (&agent.Client{BaseURL: reg}).Setup(cmd.Context(), id, token, runtime.GOOS+"/"+runtime.GOARCH, agent.RegisterParams{
 			Slug:      slug,
 			TunnelID:  tunnel,
 			Principal: agentSetupPrincipal,
 		})
-		if agent.IsNotEnrolled(err) {
+		if agent.IsNotEnrolled(err) && token == "" {
+			// Only the no-token case gets the setup hint; a not-enrolled error DESPITE a
+			// supplied token is a real failure → fall through to SETUP_ERROR.
 			return agentConfigError("device not enrolled and no ENROLL_TOKEN set: run `buttons batteries set ENROLL_TOKEN <token>` (or set $BUTTONS_BAT_ENROLL_TOKEN)")
 		}
 		if err != nil {

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -17,24 +17,22 @@ import (
 var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 
 var (
-	agentRegisterSlug      string
-	agentRegisterTunnel    string
-	agentRegisterAgentID   string
-	agentRegisterPrincipal string
+	agentSetupTunnel    string
+	agentSetupPrincipal string
 )
 
 var agentCmd = &cobra.Command{
 	Use:   "agent",
-	Short: "Register this workspace's device identity with the registry",
-	Long: `Manage this agent workspace's device identity.
+	Short: "Set up this agent's identity and public URL",
+	Long: `Set up and inspect this agent workspace's identity and public URL.
 
 The device holds an Ed25519 keypair generated on first use and stored 0600 in the
 data dir (agent.json); the private key never leaves the machine. Identity is
 proven by signature, not asserted.
 
-All subcommands use $BUTTONS_REGISTRY_URL as the registry base URL — this repo
-ships no default host. Enrollment consumes a one-time token supplied as the
-ENROLL_TOKEN battery (or $BUTTONS_BAT_ENROLL_TOKEN).`,
+Uses $BUTTONS_REGISTRY_URL as the registry base URL (this repo ships no default
+host). First-time setup consumes a one-time token from the ENROLL_TOKEN battery
+(or $BUTTONS_BAT_ENROLL_TOKEN).`,
 	RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
@@ -69,18 +67,34 @@ func agentRuntimeError(code string, err error) error {
 	return err
 }
 
-var agentEnrollCmd = &cobra.Command{
-	Use:   "enroll",
-	Short: "Generate this device's key and bind it to its owner with a one-time token",
-	Args:  exactArgs(0),
-	RunE: func(cmd *cobra.Command, _ []string) error {
+var agentSetupCmd = &cobra.Command{
+	Use:   "setup <slug>",
+	Short: "Register this agent under a slug and print its URLs (enrolls on first run)",
+	Long: `Set up this agent's identity and public URL. One idempotent command:
+generates the device key on first use, enrolls with the ENROLL_TOKEN battery if
+the device isn't bound yet, then registers the slug and prints its URLs. Safe to
+re-run — it re-points to the current tunnel.
+
+--tunnel defaults to the tunnel id from a configured named webhook tunnel
+(buttons webhook setup) when present.`,
+	Args: exactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
 		reg := registryURL()
 		if reg == "" {
 			return agentConfigError("no registry target: set $BUTTONS_REGISTRY_URL")
 		}
-		token := enrollToken()
-		if token == "" {
-			return agentConfigError("no enroll token: run `buttons batteries set ENROLL_TOKEN <token>` (or set $BUTTONS_BAT_ENROLL_TOKEN)")
+		if !slugRe.MatchString(slug) {
+			return agentConfigError("slug must be one DNS label: lowercase letters, digits and hyphens, starting alphanumeric (max 63 chars)")
+		}
+		tunnel := agentSetupTunnel
+		if tunnel == "" {
+			if wc, err := webhook.LoadConfig(); err == nil && wc != nil {
+				tunnel = wc.TunnelID
+			}
+		}
+		if tunnel == "" {
+			return agentConfigError("no tunnel id: pass --tunnel <id> (or configure a named tunnel with `buttons webhook setup`)")
 		}
 		c, err := agent.LoadOrCreate()
 		if err != nil {
@@ -90,72 +104,20 @@ var agentEnrollCmd = &cobra.Command{
 		if err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
 		}
-		res, err := (&agent.Client{BaseURL: reg}).Enroll(cmd.Context(), token, runtime.GOOS+"/"+runtime.GOARCH, id)
-		if err != nil {
-			return agentRuntimeError("ENROLL_ERROR", err)
-		}
-		if jsonOutput {
-			return config.WriteJSON(res)
-		}
-		fmt.Fprintf(os.Stderr, "Enrolled device %s (owner %s)\n", res.DeviceID, res.OwnerID)
-		printNextHint("buttons agent register --slug <name> --tunnel <tunnel-id>")
-		return nil
-	},
-}
 
-var agentRegisterCmd = &cobra.Command{
-	Use:   "register",
-	Short: "Register this workspace under a slug and print its URLs",
-	Long: `Register this workspace: claim a slug, and receive its URL set from the
-registry. Requires an enrolled device (run "buttons agent enroll" first).
-
---tunnel defaults to the tunnel id from a configured named webhook tunnel
-(buttons webhook setup) when present.`,
-	Args: exactArgs(0),
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		reg := registryURL()
-		if reg == "" {
-			return agentConfigError("no registry target: set $BUTTONS_REGISTRY_URL")
-		}
-		if agentRegisterSlug == "" {
-			return agentConfigError("--slug is required")
-		}
-		if !slugRe.MatchString(agentRegisterSlug) {
-			return agentConfigError("--slug must be one DNS label: lowercase letters, digits and hyphens, starting alphanumeric (max 63 chars)")
-		}
-		c, err := agent.LoadConfig()
-		if err != nil {
-			return agentRuntimeError("AGENT_KEY_ERROR", err)
-		}
-		if c == nil || c.DeviceSeed == "" {
-			return agentConfigError("device not enrolled: run `buttons agent enroll` first")
-		}
-		id, err := c.Identity()
-		if err != nil {
-			return agentRuntimeError("AGENT_KEY_ERROR", err)
-		}
-
-		tunnel := agentRegisterTunnel
-		if tunnel == "" {
-			if wc, err := webhook.LoadConfig(); err == nil && wc != nil {
-				tunnel = wc.TunnelID
-			}
-		}
-		if tunnel == "" {
-			return agentConfigError("no tunnel id: pass --tunnel <id> (or configure a named tunnel with `buttons webhook setup`)")
-		}
-
-		res, err := (&agent.Client{BaseURL: reg}).Register(cmd.Context(), id, agent.RegisterParams{
-			Slug:      agentRegisterSlug,
+		res, err := (&agent.Client{BaseURL: reg}).Setup(cmd.Context(), id, enrollToken(), runtime.GOOS+"/"+runtime.GOARCH, agent.RegisterParams{
+			Slug:      slug,
 			TunnelID:  tunnel,
-			AgentID:   agentRegisterAgentID,
-			Principal: agentRegisterPrincipal,
+			Principal: agentSetupPrincipal,
 		})
+		if agent.IsNotEnrolled(err) {
+			return agentConfigError("device not enrolled and no ENROLL_TOKEN set: run `buttons batteries set ENROLL_TOKEN <token>` (or set $BUTTONS_BAT_ENROLL_TOKEN)")
+		}
 		if err != nil {
-			return agentRuntimeError("REGISTER_ERROR", err)
+			return agentRuntimeError("SETUP_ERROR", err)
 		}
 
-		// Persist the slug locally so `status` and re-registers know it.
+		// Persist the slug locally so `status` and re-runs know it.
 		c.Slug = res.Slug
 		if err := agent.SaveConfig(c); err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
@@ -164,7 +126,7 @@ registry. Requires an enrolled device (run "buttons agent enroll" first).
 		if jsonOutput {
 			return config.WriteJSON(res)
 		}
-		fmt.Fprintf(os.Stderr, "Registered %s (%s)\n", res.Slug, res.Status)
+		fmt.Fprintf(os.Stderr, "Agent %s is set up (%s)\n", res.Slug, res.Status)
 		fmt.Fprintf(os.Stderr, "  webhook: %s\n", res.URLs.Webhook)
 		fmt.Fprintf(os.Stderr, "  tunnel:  %s\n", res.URLs.Tunnel)
 		fmt.Fprintf(os.Stderr, "  wake:    %s\n", res.URLs.Wake)
@@ -188,7 +150,7 @@ var agentStatusCmd = &cobra.Command{
 			if jsonOutput {
 				return config.WriteJSON(map[string]any{"enrolled": false})
 			}
-			fmt.Fprintln(os.Stderr, "not enrolled — run `buttons agent enroll`")
+			fmt.Fprintln(os.Stderr, "not set up — run `buttons agent setup <slug>`")
 			return nil
 		}
 		id, err := c.Identity()
@@ -207,10 +169,8 @@ var agentStatusCmd = &cobra.Command{
 }
 
 func init() {
-	agentRegisterCmd.Flags().StringVar(&agentRegisterSlug, "slug", "", "the workspace slug to claim (one DNS label)")
-	agentRegisterCmd.Flags().StringVar(&agentRegisterTunnel, "tunnel", "", "tunnel id backing this workspace (defaults to the named webhook tunnel)")
-	agentRegisterCmd.Flags().StringVar(&agentRegisterAgentID, "agent-id", "", "optional persona id")
-	agentRegisterCmd.Flags().StringVar(&agentRegisterPrincipal, "principal", "", "optional principal this workspace serves")
-	agentCmd.AddCommand(agentEnrollCmd, agentRegisterCmd, agentStatusCmd)
+	agentSetupCmd.Flags().StringVar(&agentSetupTunnel, "tunnel", "", "tunnel id backing this agent (defaults to the named webhook tunnel)")
+	agentSetupCmd.Flags().StringVar(&agentSetupPrincipal, "principal", "", "optional principal this agent serves")
+	agentCmd.AddCommand(agentSetupCmd, agentStatusCmd)
 	rootCmd.AddCommand(agentCmd)
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -201,10 +201,14 @@ type BrokerError struct {
 }
 
 func (e *BrokerError) Error() string {
-	if e.Code != "" {
+	switch {
+	case e.Code != "":
 		return fmt.Sprintf("%s: %d %s (%s)", e.What, e.Status, e.Message, e.Code)
+	case e.Message != "": // non-JSON body kept as raw detail
+		return fmt.Sprintf("%s: %d %s", e.What, e.Status, e.Message)
+	default:
+		return fmt.Sprintf("%s: %d", e.What, e.Status)
 	}
-	return fmt.Sprintf("%s: %d", e.What, e.Status)
 }
 
 // IsNotEnrolled reports whether err is the broker's UNKNOWN_DEVICE response.
@@ -223,7 +227,11 @@ func brokerError(what string, resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	_ = json.Unmarshal(data, &env)
+	if json.Unmarshal(data, &env) != nil || env.Error.Message == "" {
+		// Not our JSON envelope (e.g. a proxy / load-balancer error page): keep the raw
+		// body so the error still carries useful detail instead of just a status code.
+		return &BrokerError{What: what, Status: resp.StatusCode, Message: strings.TrimSpace(string(data))}
+	}
 	return &BrokerError{What: what, Status: resp.StatusCode, Code: env.Error.Code, Message: env.Error.Message}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -190,7 +191,29 @@ func (c *Client) do(ctx context.Context, method, p, bearer string, body any) (*h
 	return resp, nil
 }
 
-// brokerError decodes the {"error":{code,message}} envelope into a useful error.
+// BrokerError is a decoded {"error":{code,message}} response — carries the code
+// so callers can branch (e.g. "device not enrolled").
+type BrokerError struct {
+	What    string
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *BrokerError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("%s: %d %s (%s)", e.What, e.Status, e.Message, e.Code)
+	}
+	return fmt.Sprintf("%s: %d", e.What, e.Status)
+}
+
+// IsNotEnrolled reports whether err is the broker's UNKNOWN_DEVICE response.
+func IsNotEnrolled(err error) bool {
+	var be *BrokerError
+	return errors.As(err, &be) && be.Code == "UNKNOWN_DEVICE"
+}
+
+// brokerError decodes the {"error":{code,message}} envelope into a *BrokerError.
 func brokerError(what string, resp *http.Response) error {
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
@@ -200,10 +223,8 @@ func brokerError(what string, resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if json.Unmarshal(data, &env) == nil && env.Error.Message != "" {
-		return fmt.Errorf("%s: %d %s (%s)", what, resp.StatusCode, env.Error.Message, env.Error.Code)
-	}
-	return fmt.Errorf("%s: %d", what, resp.StatusCode)
+	_ = json.Unmarshal(data, &env)
+	return &BrokerError{What: what, Status: resp.StatusCode, Code: env.Error.Code, Message: env.Error.Message}
 }
 
 // EnrollResult is the device→owner binding the broker returns.
@@ -315,4 +336,22 @@ func (c *Client) Register(ctx context.Context, id *Identity, p RegisterParams) (
 		return nil, fmt.Errorf("register: decode: %w", err)
 	}
 	return &out, nil
+}
+
+// Setup is the one idempotent call behind `buttons agent setup`: register, and if
+// the device isn't bound yet, enroll with the one-time token and register again.
+// An already-registered device just re-points. Returns the not-enrolled BrokerError
+// (IsNotEnrolled) when the device is unbound and no enroll token was supplied.
+func (c *Client) Setup(ctx context.Context, id *Identity, enrollToken, hostKind string, p RegisterParams) (*RegisterResult, error) {
+	res, err := c.Register(ctx, id, p)
+	if !IsNotEnrolled(err) {
+		return res, err // registered, or a non-enrollment failure
+	}
+	if enrollToken == "" {
+		return nil, err // unbound + no token — let the caller surface a helpful message
+	}
+	if _, eerr := c.Enroll(ctx, enrollToken, hostKind, id); eerr != nil {
+		return nil, eerr
+	}
+	return c.Register(ctx, id, p)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -45,6 +45,10 @@ func fakeBroker(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/v1/agents/register", func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]string
 		_ = json.NewDecoder(r.Body).Decode(&body)
+		if enrolledPub == nil { // device not bound yet — the signal Setup auto-enrolls on
+			http.Error(w, `{"error":{"code":"UNKNOWN_DEVICE","message":"device not enrolled"}}`, http.StatusUnauthorized)
+			return
+		}
 		msg := "buttons-agent-register\n" + body["slug"] + "\n" + body["tunnel_id"] + "\n" + body["nonce"]
 		sig, err := base64.StdEncoding.DecodeString(body["signature"])
 		if err != nil || !ed25519.Verify(enrolledPub, []byte(msg), sig) {
@@ -111,4 +115,39 @@ func TestEnrollRejectsBadToken(t *testing.T) {
 
 func agentClientFor(srv *httptest.Server) *Client {
 	return &Client{BaseURL: srv.URL, HTTP: srv.Client()}
+}
+
+func TestSetupAutoEnrollsThenReRegisters(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeBroker(t)
+	defer srv.Close()
+	c, _ := LoadOrCreate()
+	id, _ := c.Identity()
+	client := agentClientFor(srv)
+
+	// First run: device unbound → Setup auto-enrolls with the token, then registers.
+	res, err := client.Setup(context.Background(), id, "test-enroll-token", "test/arch", RegisterParams{Slug: "cindy", TunnelID: "t1"})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if res.Slug != "cindy" || res.Status != "created" {
+		t.Fatalf("unexpected: %+v", res)
+	}
+
+	// Re-run: already enrolled → registers again with NO token needed.
+	if _, err := client.Setup(context.Background(), id, "", "test/arch", RegisterParams{Slug: "cindy", TunnelID: "t2"}); err != nil {
+		t.Fatalf("Setup re-run: %v", err)
+	}
+}
+
+func TestSetupWithoutTokenWhenUnboundIsNotEnrolled(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeBroker(t)
+	defer srv.Close()
+	c, _ := LoadOrCreate()
+	id, _ := c.Identity()
+	_, err := agentClientFor(srv).Setup(context.Background(), id, "", "test/arch", RegisterParams{Slug: "x", TunnelID: "t"})
+	if !IsNotEnrolled(err) {
+		t.Fatalf("expected IsNotEnrolled, got %v", err)
+	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +117,14 @@ func TestEnrollRejectsBadToken(t *testing.T) {
 
 func agentClientFor(srv *httptest.Server) *Client {
 	return &Client{BaseURL: srv.URL, HTTP: srv.Client()}
+}
+
+func TestBrokerErrorKeepsRawNonJSONBody(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusBadGateway, Body: io.NopCloser(strings.NewReader("502 Bad Gateway (nginx)"))}
+	err := brokerError("register", resp)
+	if !strings.Contains(err.Error(), "502 Bad Gateway (nginx)") {
+		t.Fatalf("raw body dropped from non-JSON error: %q", err.Error())
+	}
 }
 
 func TestSetupAutoEnrollsThenReRegisters(t *testing.T) {


### PR DESCRIPTION
Collapses the `buttons agent` surface to **two** commands:

- **`buttons agent setup <slug>`** — one idempotent command: generates the device key on first use, enrolls with the `ENROLL_TOKEN` battery if the device isn't bound yet, registers the slug, and prints its URLs. Re-running re-points to the current tunnel. `--tunnel` defaults to the named webhook tunnel.
- **`buttons agent status`** — unchanged.

The separate `enroll` and `register` commands are gone — they're now internal steps of `setup` (orchestrated by `agent.Client.Setup`, which registers and auto-enrolls on `UNKNOWN_DEVICE`). Verified end-to-end against the live registry (setup → created → re-run → updated → deregister). `go build`/`vet` clean; `internal/agent` + `cmd` tests green (incl. auto-enroll flow).

Follow-up to #232 — lands before the `agent` command ships in a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a single agent setup command that combines onboarding steps into one flow.
  * Agent setup now supports optional tunnel and principal settings.
  * Status messaging now uses clearer “set up” language when no local setup exists.

* **Bug Fixes**
  * Improved handling for devices that are not yet enrolled, with clearer validation errors.
  * Made agent registration more resilient by automatically retrying after enrollment when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->