### PR TITLE
feat: agent setup works with no tunnel (broker-provisioned)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -87,15 +87,6 @@ re-run — it re-points to the current tunnel.
 		if !slugRe.MatchString(slug) {
 			return agentConfigError("slug must be one DNS label: lowercase letters, digits and hyphens, starting alphanumeric (max 63 chars)")
 		}
-		tunnel := agentSetupTunnel
-		if tunnel == "" {
-			if wc, err := webhook.LoadConfig(); err == nil && wc != nil {
-				tunnel = wc.TunnelID
-			}
-		}
-		if tunnel == "" {
-			return agentConfigError("no tunnel id: pass --tunnel <id> (or configure a named tunnel with `buttons webhook setup`)")
-		}
 		c, err := agent.LoadOrCreate()
 		if err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
@@ -103,6 +94,18 @@ re-run — it re-points to the current tunnel.
 		id, err := c.Identity()
 		if err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+
+		// Tunnel: --tunnel > the named webhook tunnel > this agent's stored tunnel > empty.
+		// Empty is fine — the broker creates one and hands back a run-token.
+		tunnel := agentSetupTunnel
+		if tunnel == "" {
+			if wc, err := webhook.LoadConfig(); err == nil && wc != nil {
+				tunnel = wc.TunnelID
+			}
+		}
+		if tunnel == "" {
+			tunnel = c.TunnelID
 		}
 
 		token := enrollToken()
@@ -120,8 +123,15 @@ re-run — it re-points to the current tunnel.
 			return agentRuntimeError("SETUP_ERROR", err)
 		}
 
-		// Persist the slug locally so `status` and re-runs know it.
+		// Persist slug + tunnel so `status` and re-runs reuse them. The run-token is
+		// kept only when the broker just created the tunnel.
 		c.Slug = res.Slug
+		if res.TunnelID != "" {
+			c.TunnelID = res.TunnelID
+		}
+		if res.TunnelToken != "" {
+			c.TunnelToken = res.TunnelToken
+		}
 		if err := agent.SaveConfig(c); err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
 		}
@@ -135,6 +145,9 @@ re-run — it re-points to the current tunnel.
 		fmt.Fprintf(os.Stderr, "  wake:    %s\n", res.URLs.Wake)
 		if res.URLs.Deploy != nil {
 			fmt.Fprintf(os.Stderr, "  deploy:  %s\n", *res.URLs.Deploy)
+		}
+		if res.TunnelToken != "" {
+			fmt.Fprintln(os.Stderr, "  (tunnel provisioned — run-token saved to agent.json)")
 		}
 		return nil
 	},

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -75,8 +75,10 @@ generates the device key on first use, enrolls with the ENROLL_TOKEN battery if
 the device isn't bound yet, then registers the slug and prints its URLs. Safe to
 re-run — it re-points to the current tunnel.
 
---tunnel defaults to the tunnel id from a configured named webhook tunnel
-(buttons webhook setup) when present.`,
+--tunnel is optional. When omitted, the tunnel is taken from a configured named
+webhook tunnel (buttons webhook setup), then this agent's previously provisioned
+tunnel; if there's still none, the broker provisions one and returns its
+run-token (saved to agent.json).`,
 	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		slug := args[0]
@@ -137,6 +139,7 @@ re-run — it re-points to the current tunnel.
 		}
 
 		if jsonOutput {
+			res.TunnelToken = "" // secret — saved to agent.json above, never emitted
 			return config.WriteJSON(res)
 		}
 		fmt.Fprintf(os.Stderr, "Agent %s is set up (%s)\n", res.Slug, res.Status)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -38,8 +38,10 @@ const ConfigSchemaVersion = 1
 // in once the workspace has registered.
 type Config struct {
 	SchemaVersion int    `json:"schema_version"`
-	DeviceSeed    string `json:"device_seed"`    // base64 Ed25519 seed (32 bytes)
-	Slug          string `json:"slug,omitempty"` // set once registered
+	DeviceSeed    string `json:"device_seed"`            // base64 Ed25519 seed (32 bytes)
+	Slug          string `json:"slug,omitempty"`         // set once registered
+	TunnelID      string `json:"tunnel_id,omitempty"`    // the agent's tunnel (broker-created or supplied)
+	TunnelToken   string `json:"tunnel_token,omitempty"` // run-token when the broker created the tunnel
 }
 
 // Identity is the key material derived from a Config's seed.
@@ -302,12 +304,14 @@ type URLs struct {
 
 // RegisterResult is the broker's response — the slug's URLs come from here.
 type RegisterResult struct {
-	OK      bool   `json:"ok"`
-	Slug    string `json:"slug"`
-	Status  string `json:"status"`
-	OwnerID string `json:"owner_id"`
-	URLs    URLs   `json:"urls"`
-	DNS     string `json:"dns"`
+	OK          bool   `json:"ok"`
+	Slug        string `json:"slug"`
+	Status      string `json:"status"`
+	OwnerID     string `json:"owner_id"`
+	URLs        URLs   `json:"urls"`
+	DNS         string `json:"dns"`
+	TunnelID    string `json:"tunnel_id"`    // the resolved tunnel (broker-created when none supplied)
+	TunnelToken string `json:"tunnel_token"` // run-token, present only when the broker just created it
 }
 
 // Register fetches a fresh nonce, signs it into the registration message, and

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -58,11 +58,16 @@ func fakeBroker(t *testing.T) *httptest.Server {
 			return
 		}
 		base := "https://" + body["slug"] + ".example.test"
+		tunnelID := body["tunnel_id"]
+		token := "" // broker returns a run-token only when it created the tunnel (empty request)
+		if tunnelID == "" {
+			tunnelID, token = "tun-"+body["slug"], "token-"+body["slug"]
+		}
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok": true, "slug": body["slug"], "status": "created", "owner_id": "org_test",
 			"urls": map[string]any{"webhook": base + "/hooks", "tunnel": base, "wake": base + "/wake", "deploy": nil},
-			"dns":  "written",
+			"dns":  "written", "tunnel_id": tunnelID, "tunnel_token": token,
 		})
 	})
 
@@ -159,5 +164,21 @@ func TestSetupWithoutTokenWhenUnboundIsNotEnrolled(t *testing.T) {
 	_, err := agentClientFor(srv).Setup(context.Background(), id, "", "test/arch", RegisterParams{Slug: "x", TunnelID: "t"})
 	if !IsNotEnrolled(err) {
 		t.Fatalf("expected IsNotEnrolled, got %v", err)
+	}
+}
+
+func TestSetupWithNoTunnelGetsBrokerCreatedTunnel(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeBroker(t)
+	defer srv.Close()
+	c, _ := LoadOrCreate()
+	id, _ := c.Identity()
+	// empty TunnelID → broker creates one and hands back the id + run-token
+	res, err := agentClientFor(srv).Setup(context.Background(), id, "test-enroll-token", "test/arch", RegisterParams{Slug: "cindy", TunnelID: ""})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if res.TunnelID != "tun-cindy" || res.TunnelToken != "token-cindy" {
+		t.Fatalf("broker-created tunnel not returned: %+v", res)
 	}
 }


### PR DESCRIPTION
Pairs with buttons-registry #19 so `buttons agent setup <slug>` needs **no tunnel**.

- `setup` resolves the tunnel as `--tunnel` > the named webhook tunnel > the agent's stored tunnel > **empty**, and empty is now fine — it registers with no tunnel id and the broker provisions one.
- The broker-returned `tunnel_id` + `tunnel_token` are persisted to `agent.json` (0600); re-runs pass the stored id so the broker reuses the same tunnel.
- The run-token is stored, never printed (secret). `RegisterResult`/`Config` gain the two fields.

No new command — still just `buttons agent setup <slug>`. `go build`/`vet`/tests green (incl. a no-tunnel Setup case that asserts the broker-created id/token round-trip).

Note: the auto-create end-to-end only lights up once buttons-registry #19 is deployed with `CF_ACCOUNT_ID` + the Tunnel-scoped token; until then pass `--tunnel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup now supports a broader tunnel selection fallback, using an existing saved tunnel when one isn’t provided directly.
  * Successful setup can now save additional tunnel details for future use.

* **Bug Fixes**
  * Setup no longer fails when tunnel settings are missing if a previously stored tunnel is available.
  * The app now shows a note when a tunnel token has been saved locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->