### PR TITLE
feat(agent): setup persists the webhook config for the registry tunnel

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Keep in sync with GO_VERSION in ci.yml.
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   # HTTP/2 infinite loop) and GO-2026-4971 (net) fixed in 1.26.3, plus
   # GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto) fixed
   # in 1.26.4.
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   test:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Keep in sync with GO_VERSION in ci.yml.
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Regenerate CLI reference + SKILL.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Keep in sync with GO_VERSION in ci.yml.
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       # QEMU + Buildx let us build the linux/arm64 image from an amd64

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/autonoco/buttons/internal/agent"
 	"github.com/autonoco/buttons/internal/config"
@@ -65,6 +66,32 @@ func agentRuntimeError(code string, err error) error {
 		return errSilent
 	}
 	return err
+}
+
+// persistWebhookConfig points the named webhook config at a tunnel the broker
+// just provisioned, so `buttons webhook listen` serves the agent's URL without
+// a separate `buttons webhook setup`. A config bound to a different tunnel is
+// someone else's setup and is left untouched. Reports whether it wrote.
+func persistWebhookConfig(res *agent.RegisterResult) (bool, error) {
+	host := strings.TrimPrefix(res.URLs.Tunnel, "https://")
+	if host == "" {
+		return false, nil
+	}
+	wc, err := webhook.LoadConfig()
+	if err != nil {
+		return false, err
+	}
+	if wc != nil && wc.TunnelID != res.TunnelID {
+		return false, nil
+	}
+	if wc == nil {
+		wc = &webhook.Config{}
+	}
+	wc.Mode = webhook.ModeNamed
+	wc.Hostname = host
+	wc.TunnelID = res.TunnelID
+	wc.TunnelToken = res.TunnelToken
+	return true, webhook.SaveConfig(wc)
 }
 
 var agentSetupCmd = &cobra.Command{
@@ -138,6 +165,17 @@ run-token (saved to agent.json).`,
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
 		}
 
+		// A fresh run-token means the broker just provisioned this tunnel — persist
+		// it as the named webhook config so `buttons webhook listen` works next.
+		webhookReady := false
+		if res.TunnelToken != "" {
+			wrote, err := persistWebhookConfig(res)
+			if err != nil {
+				return agentRuntimeError("SETUP_ERROR", err)
+			}
+			webhookReady = wrote
+		}
+
 		if jsonOutput {
 			res.TunnelToken = "" // secret — saved to agent.json above, never emitted
 			return config.WriteJSON(res)
@@ -151,6 +189,9 @@ run-token (saved to agent.json).`,
 		}
 		if res.TunnelToken != "" {
 			fmt.Fprintln(os.Stderr, "  (tunnel provisioned — run-token saved to agent.json)")
+		}
+		if webhookReady {
+			fmt.Fprintf(os.Stderr, "  webhook config saved — `buttons webhook listen` serves %s\n", res.URLs.Tunnel)
 		}
 		return nil
 	},

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/agent"
+	"github.com/autonoco/buttons/internal/webhook"
+)
+
+// fakeSetupBroker is a minimal registry for driving `agent setup` end to end.
+// No enroll gate or signature check (crypto interop is covered in
+// internal/agent) — it mints a tunnel + run-token only when the request
+// carries no tunnel_id, mirroring the broker's fresh-provision rule.
+func fakeSetupBroker(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/challenge", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"nonce": "test-nonce", "expires_at": 0})
+	})
+	mux.HandleFunc("/v1/agents/register", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		base := "https://" + body["slug"] + ".example.test"
+		tunnelID := body["tunnel_id"]
+		token := "" // run-token only when the broker just created the tunnel
+		if tunnelID == "" {
+			tunnelID, token = "tun-"+body["slug"], "token-"+body["slug"]
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "slug": body["slug"], "status": "created", "owner_id": "org_test",
+			"urls": map[string]any{"webhook": base + "/hooks", "tunnel": base, "wake": base + "/wake", "deploy": nil},
+			"dns":  "written", "tunnel_id": tunnelID, "tunnel_token": token,
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+func runAgentSetup(t *testing.T, slug string) {
+	t.Helper()
+	agentSetupTunnel = ""
+	agentSetupCmd.SetContext(context.Background())
+	if err := agentSetupCmd.RunE(agentSetupCmd, []string{slug}); err != nil {
+		t.Fatalf("agent setup: %v", err)
+	}
+}
+
+func TestAgentSetupWritesWebhookConfig(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeSetupBroker(t)
+	defer srv.Close()
+	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
+
+	runAgentSetup(t, "cindy")
+
+	wc, err := webhook.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if wc == nil {
+		t.Fatal("expected webhook config after fresh register")
+	}
+	if wc.Mode != webhook.ModeNamed || wc.Hostname != "cindy.example.test" ||
+		wc.TunnelID != "tun-cindy" || wc.TunnelToken != "token-cindy" {
+		t.Fatalf("unexpected webhook config: %+v", wc)
+	}
+}
+
+func TestAgentSetupRerunKeepsWebhookConfig(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	srv := fakeSetupBroker(t)
+	defer srv.Close()
+	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
+
+	runAgentSetup(t, "cindy")
+	path, err := webhook.ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read webhook.json: %v", err)
+	}
+
+	// Re-run reuses the stored tunnel, so the broker returns no run-token and
+	// the config written by the first run must survive byte for byte.
+	runAgentSetup(t, "cindy")
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read webhook.json: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("re-run rewrote webhook.json:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestPersistWebhookConfigPreservesForeign(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	orig := &webhook.Config{Mode: webhook.ModeNamed, Hostname: "keep.example.com", TunnelName: "keep", TunnelID: "tun-keep"}
+	if err := webhook.SaveConfig(orig); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	res := &agent.RegisterResult{TunnelID: "tun-cindy", TunnelToken: "token-cindy"}
+	res.URLs.Tunnel = "https://cindy.example.test"
+	wrote, err := persistWebhookConfig(res)
+	if err != nil {
+		t.Fatalf("persistWebhookConfig: %v", err)
+	}
+	if wrote {
+		t.Fatal("foreign webhook config must not be overwritten")
+	}
+	wc, err := webhook.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if wc.Hostname != "keep.example.com" || wc.TunnelName != "keep" || wc.TunnelID != "tun-keep" || wc.TunnelToken != "" {
+		t.Fatalf("foreign webhook config changed: %+v", wc)
+	}
+}
+
+func TestPersistWebhookConfigRefreshesOwnTunnel(t *testing.T) {
+	t.Setenv("BUTTONS_HOME", t.TempDir())
+	orig := &webhook.Config{Mode: webhook.ModeNamed, Hostname: "old.example.test", TunnelID: "tun-cindy", TunnelToken: "stale"}
+	if err := webhook.SaveConfig(orig); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	res := &agent.RegisterResult{TunnelID: "tun-cindy", TunnelToken: "token-cindy"}
+	res.URLs.Tunnel = "https://cindy.example.test"
+	wrote, err := persistWebhookConfig(res)
+	if err != nil {
+		t.Fatalf("persistWebhookConfig: %v", err)
+	}
+	if !wrote {
+		t.Fatal("expected same-tunnel config to be refreshed")
+	}
+	wc, err := webhook.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if wc.Hostname != "cindy.example.test" || wc.TunnelToken != "token-cindy" {
+		t.Fatalf("unexpected webhook config: %+v", wc)
+	}
+}


### PR DESCRIPTION
B0 of buttons-platform proposal 0004 rev 2 — **no new commands, no new flags**.

When `buttons agent setup` registers and the broker returns a fresh tunnel run-token, the token previously landed only in `agent.json`, which nothing at runtime reads — `buttons webhook listen` reads the webhook config, so a freshly registered box fell back to a quick tunnel instead of `<slug>.buttons.sh`.

Now setup also persists the named/token-mode webhook config (hostname from the register response, `tunnel_id`, `tunnel_token`) through the same path `buttons webhook setup` uses:

- written when no webhook config exists, refreshed when the existing config's `tunnel_id` matches this agent's tunnel
- an existing config for a **different** tunnel (a user's own `webhook setup`) is never touched
- one stderr banner tells the user `webhook listen` is ready

Tests (`cmd/agent_test.go`, httptest broker fixture): fresh register writes the config · re-run without a token leaves it byte-identical · foreign config preserved · own-tunnel config refreshed.

Gates: `gofmt` clean · `go build ./...` · `go vet ./cmd/... ./internal/...` · `go test -race ./cmd/... ./internal/...` all green.

Companion PR: autonoco/buttons-platform `feat/e2e-onboarding-exe` (plugin setup engine consumes this config via its supervised `webhook listen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent setup now persists webhook connection details immediately after provisioning a new tunnel.
  * Setup output includes an additional notice that local webhook listening will serve the agent’s tunnel.
* **Bug Fixes**
  * Existing webhook settings are preserved unless they correspond to the same tunnel, preventing accidental overwrites.
  * Re-running setup reuses the stored tunnel and keeps webhook configuration stable when no new tunnel is provisioned.
* **Tests**
  * Added end-to-end style tests covering fresh setup, repeat runs, and webhook config preserve/refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->