### PR TITLE
feat(drawer): add proactive flow definitions

### DIFF
--- a/cmd/drawer.go
+++ b/cmd/drawer.go
@@ -20,7 +20,7 @@ import (
 
 // drawer uses NAME-before-verb syntax for per-drawer operations:
 //
-//	buttons drawer create NAME                         (verb-first: creates a new drawer)
+//	buttons drawer create NAME [--kind action|flow]    (verb-first: creates a new drawer)
 //	buttons drawer list                                (verb-first: lists all drawers)
 //	buttons drawer NAME add BUTTON [BUTTON...]         (name-first: append buttons)
 //	buttons drawer NAME connect BUTTON to BUTTON       (auto-match output→args)
@@ -44,12 +44,13 @@ var drawerCmd = &cobra.Command{
 ${ref} references between steps.
 
 Usage:
-  buttons drawer create NAME
+  buttons drawer create NAME [--kind action|flow]
   buttons drawer list
   buttons drawer NAME add BUTTON [BUTTON ...]         append button step(s)
   buttons drawer NAME add drawer/OTHER                append a sub-drawer step
   buttons drawer NAME add for_each:BUTTON             append a per-item loop wrapping BUTTON
   buttons drawer NAME add wait:DURATION               append a time-based pause (e.g. wait:30s)
+  buttons drawer NAME stage add ID --title TITLE      append a stage to a flow drawer
   buttons drawer NAME connect A to B                  auto-match output → args by name+type
   buttons drawer NAME connect A.output.x to B.args.y  explicit field path
   buttons drawer NAME set STEP.args.FIELD=value       literal or ${ref} into a step arg
@@ -125,6 +126,8 @@ Typical authoring flow:
 		switch verb {
 		case "add":
 			return drawerAdd(name, vargs)
+		case "stage":
+			return drawerStage(name, vargs)
 		case "connect":
 			return drawerConnect(name, vargs)
 		case "set":
@@ -156,11 +159,27 @@ func init() {
 
 func drawerCreate(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: buttons drawer create NAME")
+		return fmt.Errorf("usage: buttons drawer create NAME [--kind action|flow]")
 	}
 	name := args[0]
+	kind := drawer.DrawerKindAction
+	for i := 1; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--kind":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--kind needs a value")
+			}
+			kind = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--kind="):
+			kind = strings.TrimPrefix(a, "--kind=")
+		default:
+			return fmt.Errorf("unknown drawer create argument %q", a)
+		}
+	}
 	svc := drawer.NewService()
-	d, err := svc.Create(name, "", nil)
+	d, err := svc.CreateWithKind(name, "", nil, kind)
 	if err != nil {
 		return handleDrawerError(err)
 	}
@@ -168,7 +187,55 @@ func drawerCreate(args []string) error {
 		return config.WriteJSON(d)
 	}
 	fmt.Fprintf(os.Stderr, "Created drawer: %s\n", d.Name)
-	printNextHint("buttons drawer %s add BUTTON [BUTTON...]", d.Name)
+	if d.DrawerKind == drawer.DrawerKindFlow {
+		printNextHint("buttons drawer %s stage add STAGE --title TITLE", d.Name)
+	} else {
+		printNextHint("buttons drawer %s add BUTTON [BUTTON...]", d.Name)
+	}
+	return nil
+}
+
+func drawerStage(name string, args []string) error {
+	if len(args) < 2 || args[0] != "add" {
+		return fmt.Errorf("usage: buttons drawer %s stage add ID [--title TITLE] [--system-prompt PROMPT]", name)
+	}
+	stageID := args[1]
+	title := ""
+	systemPrompt := ""
+	for i := 2; i < len(args); i++ {
+		a := args[i]
+		var value string
+		switch {
+		case a == "--title" || a == "--system-prompt":
+			if i+1 >= len(args) {
+				return fmt.Errorf("%s needs a value", a)
+			}
+			value = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--title="):
+			title = strings.TrimPrefix(a, "--title=")
+			continue
+		case strings.HasPrefix(a, "--system-prompt="):
+			systemPrompt = strings.TrimPrefix(a, "--system-prompt=")
+			continue
+		default:
+			return fmt.Errorf("unknown stage add argument %q", a)
+		}
+		if a == "--title" {
+			title = value
+		} else {
+			systemPrompt = value
+		}
+	}
+	d, err := drawer.NewService().AddFlowStage(name, stageID, title, systemPrompt)
+	if err != nil {
+		return handleDrawerError(err)
+	}
+	if jsonOutput {
+		return config.WriteJSON(d)
+	}
+	fmt.Fprintf(os.Stderr, "Added stage %s to flow drawer %s\n", stageID, name)
+	printNextHint("buttons drawer %s set flow.initial_stage=%s", name, stageID)
 	return nil
 }
 
@@ -405,6 +472,12 @@ func drawerPress(name string, args []string) error {
 	if err != nil {
 		return handleDrawerError(err)
 	}
+	if d.DrawerKind == drawer.DrawerKindFlow {
+		return handleDrawerError(&drawer.ServiceError{
+			Code:    "FLOW_RUNTIME_REQUIRED",
+			Message: fmt.Sprintf("flow drawer %q is activated and run by a Buttons Flow runtime; it cannot be pressed as an action drawer", name),
+		})
+	}
 
 	// Split --webhook-body <value> out of args before parseKV sees it.
 	// Accepts three forms so agents can pick what's ergonomic:
@@ -512,6 +585,18 @@ func drawerSet(name string, vargs []string) error {
 		var value any
 		if err := json.Unmarshal([]byte(rawValue), &value); err != nil {
 			value = rawValue
+		}
+
+		if strings.HasPrefix(target, "flow.") {
+			path := strings.TrimPrefix(target, "flow.")
+			if path == "" {
+				return fmt.Errorf("empty flow path in %q", target)
+			}
+			if _, err := svc.SetFlowField(name, path, value); err != nil {
+				return handleDrawerError(err)
+			}
+			applied = append(applied, target)
+			continue
 		}
 
 		parts := strings.SplitN(target, ".", 2)
@@ -1050,6 +1135,12 @@ func drawerShowSummary(name string) error {
 	for _, s := range d.Steps {
 		topology = append(topology, s.ID)
 	}
+	if d.DrawerKind == drawer.DrawerKindFlow && d.Flow != nil {
+		topology = make([]string, 0, len(d.Flow.Stages))
+		for _, stage := range d.Flow.Stages {
+			topology = append(topology, stage.ID)
+		}
+	}
 
 	// Webhook trigger surfacing: if this drawer has one, compute the
 	// full public URL so agents see exactly what to paste into the
@@ -1057,14 +1148,18 @@ func drawerShowSummary(name string) error {
 	triggersOut := summarizeDrawerTriggers(d)
 
 	snapshot := map[string]any{
-		"name":        d.Name,
-		"description": d.Description,
-		"inputs":      d.Inputs,
-		"steps":       d.Steps,
-		"topology":    strings.Join(topology, " → "),
-		"validation":  report,
-		"recent_runs": summarizeDrawerRuns(runs),
-		"triggers":    triggersOut,
+		"schema_version": d.SchemaVersion,
+		"name":           d.Name,
+		"version":        d.Version,
+		"drawer_kind":    d.DrawerKind,
+		"description":    d.Description,
+		"inputs":         d.Inputs,
+		"steps":          d.Steps,
+		"flow":           d.Flow,
+		"topology":       strings.Join(topology, " → "),
+		"validation":     report,
+		"recent_runs":    summarizeDrawerRuns(runs),
+		"triggers":       triggersOut,
 	}
 
 	if jsonOutput {

--- a/docs/concepts/drawer-json.mdx
+++ b/docs/concepts/drawer-json.mdx
@@ -1,9 +1,12 @@
 ---
 title: "drawer.json"
-description: "The workflow spec for drawers."
+description: "The action or proactive-flow spec for drawers."
 ---
 
-A drawer is a workflow made of steps. Its source of truth is `drawer.json`.
+A Drawer is a reusable package. Schema v2 distinguishes an `action` Drawer,
+which is pressed as a graph of steps, from a `flow` Drawer, which defines a
+proactive board that a platform runtime activates and supervises. Its source of
+truth is `drawer.json`.
 
 ```text
 ~/.buttons/drawers/<name>/
@@ -13,12 +16,13 @@ A drawer is a workflow made of steps. Its source of truth is `drawer.json`.
 
 Project-local drawers use the same shape under `.buttons/drawers/<name>/`.
 
-## Example
+## Action Drawer example
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "release-flow",
+  "drawer_kind": "action",
   "version": "1",
   "inputs": [
     { "name": "env", "type": "enum", "required": true, "values": ["staging", "prod"] }
@@ -42,16 +46,72 @@ Project-local drawers use the same shape under `.buttons/drawers/<name>/`.
 }
 ```
 
+Schema-v1 action Drawers remain readable, installable, and pressable. New
+Drawers are written as schema v2.
+
+## Flow Drawer example
+
+Flow Drawers describe arbitrary board stages and policy. They do not contain
+`steps` and cannot be pressed locally as action Drawers.
+
+```json
+{
+  "schema_version": 2,
+  "name": "software-delivery",
+  "drawer_kind": "flow",
+  "version": "1",
+  "flow": {
+    "initial_stage": "intake",
+    "manager": {
+      "agent": "activation.manager",
+      "system_prompt": "Supervise this flow and return one valid decision.",
+      "heartbeat_seconds": 300
+    },
+    "stages": [
+      {
+        "id": "intake",
+        "title": "Intake",
+        "worker": { "agent": "activation.worker" },
+        "transitions": ["research"]
+      },
+      {
+        "id": "research",
+        "title": "Research",
+        "transitions": ["done"]
+      },
+      { "id": "done", "title": "Done" }
+    ]
+  }
+}
+```
+
+Create and edit the definition through the CLI:
+
+```bash
+buttons drawer create software-delivery --kind flow
+buttons drawer software-delivery stage add intake --title "Intake"
+buttons drawer software-delivery stage add research --title "Research"
+buttons drawer software-delivery set flow.initial_stage=intake
+buttons drawer software-delivery set flow.manager.agent=activation.manager
+buttons drawer software-delivery set 'flow.stages.intake.transitions=["research"]'
+```
+
+Publishing a valid flow Drawer adds a normalized `flow-definition.json` to the
+immutable artifact and sends its SHA-256 as registry metadata. Installation
+rejects the package if that definition does not exactly match `drawer.json`.
+
 ## Top-level fields
 
 | Field | Meaning |
 | --- | --- |
-| `schema_version` | Drawer spec version. Current version is `1`. |
+| `schema_version` | Drawer spec version. Current version is `2`; version `1` remains supported for legacy action Drawers. |
 | `name` | Drawer name. |
+| `drawer_kind` | Required in schema v2: `action` or `flow`. |
 | `description` | Human-readable one-liner. |
 | `version` | Drawer package content version. New drawers start at `1`; registry publish auto-bumps to the next number when the current immutable version already exists. |
-| `inputs` | Values supplied at drawer press time. |
-| `steps` | Ordered workflow steps. |
+| `inputs` | Values supplied at action Drawer press time. |
+| `steps` | Ordered action steps; required only for action Drawers. |
+| `flow` | Manager, limits, stages, transitions, triggers, sessions, retry, timeout, and concurrency policy; required only for flow Drawers. |
 | `output_schema` | Optional JSON Schema for values exposed when called as a sub-drawer. |
 | `return` | Map of output fields to `${...}` expressions. |
 | `triggers` | Automatic invocation sources. Webhook triggers are live today. |

--- a/docs/concepts/drawers.mdx
+++ b/docs/concepts/drawers.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Drawers"
-description: "Typed workflows that chain buttons together."
+description: "Reusable action graphs and proactive flows."
 ---
 
-A drawer is a workflow made of buttons and workflow steps. Use a drawer when an action has multiple steps, needs output from an earlier step, or should be triggered as a unit.
+A Drawer is a reusable package. An action Drawer chains buttons and steps; a
+flow Drawer defines a proactive board whose stages are supervised by a bound
+manager and runtime.
 
 ```bash
 buttons drawer create release-flow
@@ -12,12 +14,21 @@ buttons drawer release-flow connect build to publish
 buttons drawer release-flow press env=prod
 ```
 
+```bash
+buttons drawer create software-delivery --kind flow
+buttons drawer software-delivery stage add intake --title "Intake"
+buttons drawer software-delivery set flow.initial_stage=intake
+buttons drawer software-delivery set flow.manager.agent=activation.manager
+```
+
 ## Mental model
 
 | Concept | Meaning |
 | --- | --- |
-| Drawer | A reusable workflow. |
+| Drawer | A reusable action or flow package. |
+| Kind | `action` for pressable step graphs; `flow` for activated proactive boards. |
 | Step | A button, sub-drawer, loop, switch, aggregate, or wait. |
+| Stage | A column and policy boundary in a flow Drawer. |
 | Input | A value supplied when the drawer is pressed. |
 | Output | JSON produced by a step and made available to later steps. |
 | Ref | A `${...}` expression that reads inputs, step outputs, env, or webhook URLs. |
@@ -29,8 +40,9 @@ Drawers live under `.buttons/drawers/<name>/` and record their own run history u
 Buttons are the units of work. Drawers compose them.
 
 ```text
-button -> one action
-drawer -> many actions wired together
+button        -> one action
+action drawer -> many actions wired together
+flow drawer   -> stages and supervision policy
 ```
 
 ## Related

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -72,12 +72,14 @@ See [button.json](/concepts/button-json) for every field, including HTTP host lo
 
 ## drawer.json
 
-The workflow spec for a drawer. It stores inputs, steps, refs, triggers, return values, and error handling.
+The reusable spec for a Drawer. Schema v2 discriminates pressable action
+Drawers from proactive flow Drawers.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "release-flow",
+  "drawer_kind": "action",
   "steps": [
     { "id": "build", "kind": "button", "button": "build" },
     { "id": "publish", "kind": "button", "button": "publish" }

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -663,8 +663,8 @@
     "schema_version": {
       "description": "Drawer spec version",
       "enum": [
-        "1",
-        "2"
+        1,
+        2
       ],
       "type": "integer"
     },

--- a/docs/schemas/drawer.schema.json
+++ b/docs/schemas/drawer.schema.json
@@ -98,6 +98,222 @@
       ],
       "type": "object"
     },
+    "FlowCompletion": {
+      "additionalProperties": false,
+      "properties": {
+        "requires_proof": {
+          "type": "boolean"
+        },
+        "requires_summary": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "FlowDefinition": {
+      "additionalProperties": false,
+      "properties": {
+        "initial_stage": {
+          "description": "Stage id assigned to new tasks",
+          "type": "string"
+        },
+        "limits": {
+          "$ref": "#/$defs/FlowLimits",
+          "description": "Definition-wide execution limits"
+        },
+        "manager": {
+          "$ref": "#/$defs/FlowManager",
+          "description": "Default manager binding and supervision prompt"
+        },
+        "stages": {
+          "description": "Ordered board stages",
+          "items": {
+            "$ref": "#/$defs/FlowStage"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "initial_stage",
+        "manager",
+        "stages"
+      ],
+      "type": "object"
+    },
+    "FlowLimits": {
+      "additionalProperties": false,
+      "properties": {
+        "max_active_tasks": {
+          "type": "integer"
+        },
+        "max_attempts_per_stage": {
+          "type": "integer"
+        },
+        "max_runtime_seconds": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FlowManager": {
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "description": "Logical activation.manager/activation.worker or pinned agent:tenant:name reference",
+          "type": "string"
+        },
+        "heartbeat_seconds": {
+          "description": "Manager supervision heartbeat in seconds",
+          "type": "integer"
+        },
+        "system_prompt": {
+          "description": "Manager system prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent"
+      ],
+      "type": "object"
+    },
+    "FlowRetry": {
+      "additionalProperties": false,
+      "properties": {
+        "backoff": {
+          "enum": [
+            "fixed",
+            "exponential"
+          ],
+          "type": "string"
+        },
+        "initial_seconds": {
+          "type": "integer"
+        },
+        "limit": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FlowSessionPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "manager": {
+          "enum": [
+            "new_attempt",
+            "continue_stage",
+            "continue_task"
+          ],
+          "type": "string"
+        },
+        "worker": {
+          "enum": [
+            "new_attempt",
+            "continue_stage",
+            "continue_task"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FlowStage": {
+      "additionalProperties": false,
+      "properties": {
+        "completion": {
+          "$ref": "#/$defs/FlowCompletion"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "id": {
+          "description": "Stable stage id",
+          "type": "string"
+        },
+        "manager": {
+          "$ref": "#/$defs/FlowManager"
+        },
+        "retry": {
+          "$ref": "#/$defs/FlowRetry"
+        },
+        "session_policy": {
+          "$ref": "#/$defs/FlowSessionPolicy"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "timeout_seconds": {
+          "type": "integer"
+        },
+        "title": {
+          "description": "Human-readable stage title",
+          "type": "string"
+        },
+        "transitions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "triggers": {
+          "items": {
+            "$ref": "#/$defs/FlowStageTrigger"
+          },
+          "type": "array"
+        },
+        "worker": {
+          "$ref": "#/$defs/FlowWorker"
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ],
+      "type": "object"
+    },
+    "FlowStageTrigger": {
+      "additionalProperties": false,
+      "properties": {
+        "cron": {
+          "type": "string"
+        },
+        "event_type": {
+          "type": "string"
+        },
+        "every_seconds": {
+          "type": "integer"
+        },
+        "hook_id": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "heartbeat",
+            "cron",
+            "event",
+            "webhook"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "FlowWorker": {
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "description": "Logical activation.worker or pinned agent:tenant:name reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent"
+      ],
+      "type": "object"
+    },
     "InputDef": {
       "additionalProperties": false,
       "properties": {
@@ -324,6 +540,79 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "description": "Buttons drawer: a typed workflow chaining buttons with ${ref} references between steps.",
+  "oneOf": [
+    {
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "drawer_kind"
+            ]
+          },
+          {
+            "required": [
+              "flow"
+            ]
+          }
+        ]
+      },
+      "properties": {
+        "schema_version": {
+          "const": 1
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "steps"
+      ],
+      "title": "Legacy action drawer (schema v1)"
+    },
+    {
+      "not": {
+        "required": [
+          "flow"
+        ]
+      },
+      "properties": {
+        "drawer_kind": {
+          "const": "action"
+        },
+        "schema_version": {
+          "const": 2
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "drawer_kind",
+        "steps"
+      ],
+      "title": "Action drawer (schema v2)"
+    },
+    {
+      "not": {
+        "required": [
+          "steps"
+        ]
+      },
+      "properties": {
+        "drawer_kind": {
+          "const": "flow"
+        },
+        "schema_version": {
+          "const": 2
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "drawer_kind",
+        "flow"
+      ],
+      "title": "Flow drawer (schema v2)"
+    }
+  ],
   "properties": {
     "created_at": {
       "format": "date-time",
@@ -332,6 +621,18 @@
     "description": {
       "description": "Human-readable one-liner",
       "type": "string"
+    },
+    "drawer_kind": {
+      "description": "Execution model (required for schema v2)",
+      "enum": [
+        "action",
+        "flow"
+      ],
+      "type": "string"
+    },
+    "flow": {
+      "$ref": "#/$defs/FlowDefinition",
+      "description": "Proactive board definition (flow drawers only)"
     },
     "inputs": {
       "description": "Top-level inputs supplied at press time",
@@ -360,12 +661,15 @@
       "type": "object"
     },
     "schema_version": {
-      "const": 1,
       "description": "Drawer spec version",
+      "enum": [
+        "1",
+        "2"
+      ],
       "type": "integer"
     },
     "steps": {
-      "description": "Ordered list of steps (depth-first execution)",
+      "description": "Ordered action steps (action drawers only)",
       "items": {
         "$ref": "#/$defs/Step"
       },
@@ -390,7 +694,6 @@
   "required": [
     "schema_version",
     "name",
-    "steps",
     "created_at",
     "updated_at"
   ],

--- a/internal/drawer/entity.go
+++ b/internal/drawer/entity.go
@@ -13,20 +13,27 @@ import (
 	"time"
 )
 
-// SchemaVersion is the current drawer.json schema version. Bump when
-// making breaking changes; additive changes (new optional fields)
-// don't require a bump.
-const SchemaVersion = 1
+// SchemaVersion is the current drawer.json schema version. Version 2
+// introduces a discriminated action/flow union while readers continue
+// to accept schema-v1 action drawers unchanged.
+const SchemaVersion = 2
+
+const (
+	DrawerKindAction = "action"
+	DrawerKindFlow   = "flow"
+)
 
 // Drawer is the top-level spec stored at
 // ~/.buttons/drawers/<name>/drawer.json.
 type Drawer struct {
-	SchemaVersion int        `json:"schema_version" jsonschema:"const=1,description=Drawer spec version"`
-	Name          string     `json:"name" jsonschema:"description=Drawer name (kebab-case)"`
-	Description   string     `json:"description,omitempty" jsonschema:"description=Human-readable one-liner"`
-	Version       string     `json:"version,omitempty" jsonschema:"description=Drawer package content version"`
-	Inputs        []InputDef `json:"inputs,omitempty" jsonschema:"description=Top-level inputs supplied at press time"`
-	Steps         []Step     `json:"steps" jsonschema:"description=Ordered list of steps (depth-first execution)"`
+	SchemaVersion int             `json:"schema_version" jsonschema:"enum=1,enum=2,description=Drawer spec version"`
+	Name          string          `json:"name" jsonschema:"description=Drawer name (kebab-case)"`
+	DrawerKind    string          `json:"drawer_kind,omitempty" jsonschema:"enum=action,enum=flow,description=Execution model (required for schema v2)"`
+	Description   string          `json:"description,omitempty" jsonschema:"description=Human-readable one-liner"`
+	Version       string          `json:"version,omitempty" jsonschema:"description=Drawer package content version"`
+	Inputs        []InputDef      `json:"inputs,omitempty" jsonschema:"description=Top-level inputs supplied at press time"`
+	Steps         []Step          `json:"steps,omitempty" jsonschema:"description=Ordered action steps (action drawers only)"`
+	Flow          *FlowDefinition `json:"flow,omitempty" jsonschema:"description=Proactive board definition (flow drawers only)"`
 	// OnError points at another drawer that runs when any step in this
 	// drawer fails. Reserved in the schema now so adding it later
 	// doesn't require a schema bump; the v1 executor ignores it.
@@ -57,6 +64,92 @@ type Drawer struct {
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// MarshalJSON keeps the discriminated variants exact on disk: action drawers
+// always carry a steps array (including an empty one), while flow drawers never
+// serialize the action-only field.
+func (d Drawer) MarshalJSON() ([]byte, error) {
+	type rawDrawer Drawer
+	raw, err := json.Marshal(rawDrawer(d))
+	if err != nil {
+		return nil, err
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	if d.DrawerKind == DrawerKindFlow {
+		delete(object, "steps")
+	} else if _, exists := object["steps"]; !exists {
+		object["steps"] = []Step{}
+	}
+	return json.Marshal(object)
+}
+
+// FlowDefinition is the runtime-neutral, immutable board policy carried by a
+// flow-type Drawer. Runtime and tenant bindings are deliberately resolved at
+// activation time by the platform rather than embedded in the package.
+type FlowDefinition struct {
+	InitialStage string      `json:"initial_stage" jsonschema:"description=Stage id assigned to new tasks"`
+	Manager      FlowManager `json:"manager" jsonschema:"description=Default manager binding and supervision prompt"`
+	Limits       *FlowLimits `json:"limits,omitempty" jsonschema:"description=Definition-wide execution limits"`
+	Stages       []FlowStage `json:"stages" jsonschema:"description=Ordered board stages"`
+}
+
+type FlowManager struct {
+	Agent            string `json:"agent" jsonschema:"description=Logical activation.manager/activation.worker or pinned agent:tenant:name reference"`
+	SystemPrompt     string `json:"system_prompt,omitempty" jsonschema:"description=Manager system prompt"`
+	HeartbeatSeconds int    `json:"heartbeat_seconds,omitempty" jsonschema:"description=Manager supervision heartbeat in seconds"`
+}
+
+type FlowWorker struct {
+	Agent string `json:"agent" jsonschema:"description=Logical activation.worker or pinned agent:tenant:name reference"`
+}
+
+type FlowLimits struct {
+	MaxActiveTasks      int `json:"max_active_tasks,omitempty"`
+	MaxRuntimeSeconds   int `json:"max_runtime_seconds,omitempty"`
+	MaxAttemptsPerStage int `json:"max_attempts_per_stage,omitempty"`
+}
+
+type FlowStage struct {
+	ID             string             `json:"id" jsonschema:"description=Stable stage id"`
+	Title          string             `json:"title" jsonschema:"description=Human-readable stage title"`
+	SystemPrompt   string             `json:"system_prompt,omitempty"`
+	Manager        *FlowManager       `json:"manager,omitempty"`
+	Worker         *FlowWorker        `json:"worker,omitempty"`
+	SessionPolicy  *FlowSessionPolicy `json:"session_policy,omitempty"`
+	Triggers       []FlowStageTrigger `json:"triggers,omitempty"`
+	Transitions    []string           `json:"transitions,omitempty"`
+	Completion     *FlowCompletion    `json:"completion,omitempty"`
+	Retry          *FlowRetry         `json:"retry,omitempty"`
+	TimeoutSeconds int                `json:"timeout_seconds,omitempty"`
+	Concurrency    int                `json:"concurrency,omitempty"`
+}
+
+type FlowSessionPolicy struct {
+	Manager string `json:"manager,omitempty" jsonschema:"enum=new_attempt,enum=continue_stage,enum=continue_task"`
+	Worker  string `json:"worker,omitempty" jsonschema:"enum=new_attempt,enum=continue_stage,enum=continue_task"`
+}
+
+type FlowStageTrigger struct {
+	Kind         string `json:"kind" jsonschema:"enum=heartbeat,enum=cron,enum=event,enum=webhook"`
+	EverySeconds int    `json:"every_seconds,omitempty"`
+	Cron         string `json:"cron,omitempty"`
+	EventType    string `json:"event_type,omitempty"`
+	HookID       string `json:"hook_id,omitempty"`
+}
+
+type FlowCompletion struct {
+	RequiresSummary bool `json:"requires_summary,omitempty"`
+	RequiresProof   bool `json:"requires_proof,omitempty"`
+}
+
+type FlowRetry struct {
+	Limit          int    `json:"limit,omitempty"`
+	Backoff        string `json:"backoff,omitempty" jsonschema:"enum=fixed,enum=exponential"`
+	InitialSeconds int    `json:"initial_seconds,omitempty"`
 }
 
 // Trigger is one automatic invocation source for a drawer. The only

--- a/internal/drawer/flow_normalize.go
+++ b/internal/drawer/flow_normalize.go
@@ -1,0 +1,36 @@
+package drawer
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// NormalizedFlowDefinition is the immutable execution definition emitted next
+// to a published flow Drawer artifact. Authoring timestamps and action-only
+// fields are excluded so consumers can hash and register the actual policy.
+type NormalizedFlowDefinition struct {
+	SchemaVersion int             `json:"schema_version"`
+	Name          string          `json:"name"`
+	DrawerKind    string          `json:"drawer_kind"`
+	Description   string          `json:"description,omitempty"`
+	Version       string          `json:"version"`
+	Flow          *FlowDefinition `json:"flow"`
+}
+
+func NormalizeFlowDefinition(d *Drawer) ([]byte, error) {
+	if d == nil || d.DrawerKind != DrawerKindFlow || d.Flow == nil {
+		return nil, fmt.Errorf("normalized flow definition requires a flow drawer")
+	}
+	report := Validate(d, nil)
+	if !report.OK {
+		return nil, fmt.Errorf("flow drawer is invalid: %s", report.Errors[0].Message)
+	}
+	return json.Marshal(NormalizedFlowDefinition{
+		SchemaVersion: d.SchemaVersion,
+		Name:          d.Name,
+		DrawerKind:    d.DrawerKind,
+		Description:   d.Description,
+		Version:       d.Version,
+		Flow:          d.Flow,
+	})
+}

--- a/internal/drawer/flow_validation_test.go
+++ b/internal/drawer/flow_validation_test.go
@@ -1,0 +1,249 @@
+package drawer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+)
+
+func validFlowDrawerJSON() string {
+	return `{
+		"schema_version": 2,
+		"name": "software-delivery",
+		"drawer_kind": "flow",
+		"description": "Move a ticket through delivery.",
+		"version": "1",
+		"flow": {
+			"initial_stage": "intake",
+			"manager": {
+				"agent": "activation.manager",
+				"system_prompt": "Supervise this flow.",
+				"heartbeat_seconds": 300
+			},
+			"limits": {
+				"max_active_tasks": 50,
+				"max_runtime_seconds": 86400,
+				"max_attempts_per_stage": 3
+			},
+			"stages": [
+				{
+					"id": "intake",
+					"title": "Intake",
+					"system_prompt": "Clarify the request.",
+					"manager": {
+						"agent": "agent:tenant-a:intake-manager",
+						"system_prompt": "Review intake quality.",
+						"heartbeat_seconds": 180
+					},
+					"worker": {"agent": "activation.worker"},
+					"session_policy": {
+						"manager": "continue_stage",
+						"worker": "new_attempt"
+					},
+					"triggers": [
+						{"kind": "heartbeat", "every_seconds": 180},
+						{"kind": "event", "event_type": "comment.added"}
+					],
+					"transitions": ["research", "blocked"],
+					"completion": {"requires_summary": true},
+					"retry": {
+						"limit": 2,
+						"backoff": "exponential",
+						"initial_seconds": 30
+					},
+					"timeout_seconds": 1800,
+					"concurrency": 5
+				},
+				{
+					"id": "research",
+					"title": "Research",
+					"transitions": ["done"]
+				},
+				{
+					"id": "blocked",
+					"title": "Blocked",
+					"transitions": ["intake"]
+				},
+				{
+					"id": "done",
+					"title": "Done"
+				}
+			]
+		},
+		"created_at": "2026-07-12T00:00:00Z",
+		"updated_at": "2026-07-12T00:00:00Z"
+	}`
+}
+
+func decodeDrawerJSON(t *testing.T, raw string) *Drawer {
+	t.Helper()
+	var got Drawer
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("decode drawer: %v", err)
+	}
+	return &got
+}
+
+func mutateFlowDrawerJSON(t *testing.T, mutate func(map[string]any)) string {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal([]byte(validFlowDrawerJSON()), &value); err != nil {
+		t.Fatal(err)
+	}
+	mutate(value)
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func requireFlowValidationError(t *testing.T, raw, contains string) {
+	t.Helper()
+	report := Validate(decodeDrawerJSON(t, raw), button.NewService())
+	if report.OK {
+		t.Fatalf("Validate() unexpectedly succeeded; want error containing %q", contains)
+	}
+	for _, issue := range report.Errors {
+		if strings.Contains(issue.Message, contains) {
+			return
+		}
+	}
+	t.Fatalf("errors = %#v; want one containing %q", report.Errors, contains)
+}
+
+func TestValidateFlowDrawerAcceptsValidDefinition(t *testing.T) {
+	report := Validate(decodeDrawerJSON(t, validFlowDrawerJSON()), button.NewService())
+	if !report.OK {
+		t.Fatalf("valid flow rejected: %#v", report.Errors)
+	}
+}
+
+func TestValidateFlowDrawerStructuralInvariants(t *testing.T) {
+	t.Run("non-empty stages", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			value["flow"].(map[string]any)["stages"] = []any{}
+		})
+		requireFlowValidationError(t, raw, "at least one stage")
+	})
+
+	t.Run("unique stage ids", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[1].(map[string]any)["id"] = "intake"
+		})
+		requireFlowValidationError(t, raw, "duplicate stage id")
+	})
+
+	t.Run("initial stage exists", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			value["flow"].(map[string]any)["initial_stage"] = "missing"
+		})
+		requireFlowValidationError(t, raw, "initial stage")
+	})
+
+	t.Run("transition target exists", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["transitions"] = []any{"missing"}
+		})
+		requireFlowValidationError(t, raw, "unknown transition target")
+	})
+
+	t.Run("manager reference syntax", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			value["flow"].(map[string]any)["manager"].(map[string]any)["agent"] = "../../manager"
+		})
+		requireFlowValidationError(t, raw, "invalid manager agent reference")
+	})
+
+	t.Run("worker reference syntax", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["worker"].(map[string]any)["agent"] = "not a ref"
+		})
+		requireFlowValidationError(t, raw, "invalid worker agent reference")
+	})
+}
+
+func TestValidateFlowDrawerPolicyInvariants(t *testing.T) {
+	t.Run("session policy", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["session_policy"].(map[string]any)["manager"] = "forever"
+		})
+		requireFlowValidationError(t, raw, "invalid manager session policy")
+	})
+
+	t.Run("trigger kind", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["triggers"] = []any{map[string]any{"kind": "magic"}}
+		})
+		requireFlowValidationError(t, raw, "invalid stage trigger kind")
+	})
+
+	t.Run("heartbeat duration", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["triggers"] = []any{map[string]any{"kind": "heartbeat", "every_seconds": 0}}
+		})
+		requireFlowValidationError(t, raw, "positive every_seconds")
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["timeout_seconds"] = -1
+		})
+		requireFlowValidationError(t, raw, "timeout_seconds must be positive")
+	})
+
+	t.Run("concurrency", func(t *testing.T) {
+		raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+			stages := value["flow"].(map[string]any)["stages"].([]any)
+			stages[0].(map[string]any)["concurrency"] = -1
+		})
+		requireFlowValidationError(t, raw, "concurrency must be positive")
+	})
+}
+
+func TestValidateFlowDrawerRejectsMixedActionFields(t *testing.T) {
+	raw := mutateFlowDrawerJSON(t, func(value map[string]any) {
+		value["steps"] = []any{map[string]any{"id": "build", "button": "build"}}
+	})
+	requireFlowValidationError(t, raw, "flow drawer cannot define steps")
+}
+
+func TestValidateLegacyV1ActionDrawerRemainsValid(t *testing.T) {
+	d := decodeDrawerJSON(t, `{
+		"schema_version": 1,
+		"name": "legacy",
+		"steps": [],
+		"created_at": "2026-07-12T00:00:00Z",
+		"updated_at": "2026-07-12T00:00:00Z"
+	}`)
+	report := Validate(d, button.NewService())
+	if !report.OK {
+		t.Fatalf("legacy v1 action drawer rejected: %#v", report.Errors)
+	}
+}
+
+func TestDrawerSchemaDescribesLegacyActionAndFlowVariants(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal(SchemaJSON, &schema); err != nil {
+		t.Fatalf("embedded schema is invalid JSON: %v", err)
+	}
+	variants, ok := schema["oneOf"].([]any)
+	if !ok || len(variants) != 3 {
+		t.Fatalf("schema oneOf = %#v; want legacy, action, and flow variants", schema["oneOf"])
+	}
+	encoded := string(SchemaJSON)
+	for _, want := range []string{`"drawer_kind"`, `"action"`, `"flow"`, `"FlowDefinition"`, `"FlowStage"`} {
+		if !strings.Contains(encoded, want) {
+			t.Errorf("schema missing %s", want)
+		}
+	}
+}

--- a/internal/drawer/flow_validation_test.go
+++ b/internal/drawer/flow_validation_test.go
@@ -246,4 +246,19 @@ func TestDrawerSchemaDescribesLegacyActionAndFlowVariants(t *testing.T) {
 			t.Errorf("schema missing %s", want)
 		}
 	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v", schema["properties"])
+	}
+	versionSchema, ok := properties["schema_version"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema_version = %#v", properties["schema_version"])
+	}
+	if got := versionSchema["type"]; got != "integer" {
+		t.Fatalf("schema_version type = %#v, want integer", got)
+	}
+	versions, ok := versionSchema["enum"].([]any)
+	if !ok || len(versions) != 2 || versions[0] != float64(1) || versions[1] != float64(2) {
+		t.Fatalf("schema_version enum = %#v, want numeric [1, 2]", versionSchema["enum"])
+	}
 }

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -663,8 +663,8 @@
     "schema_version": {
       "description": "Drawer spec version",
       "enum": [
-        "1",
-        "2"
+        1,
+        2
       ],
       "type": "integer"
     },

--- a/internal/drawer/schema_embedded.json
+++ b/internal/drawer/schema_embedded.json
@@ -98,6 +98,222 @@
       ],
       "type": "object"
     },
+    "FlowCompletion": {
+      "additionalProperties": false,
+      "properties": {
+        "requires_proof": {
+          "type": "boolean"
+        },
+        "requires_summary": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "FlowDefinition": {
+      "additionalProperties": false,
+      "properties": {
+        "initial_stage": {
+          "description": "Stage id assigned to new tasks",
+          "type": "string"
+        },
+        "limits": {
+          "$ref": "#/$defs/FlowLimits",
+          "description": "Definition-wide execution limits"
+        },
+        "manager": {
+          "$ref": "#/$defs/FlowManager",
+          "description": "Default manager binding and supervision prompt"
+        },
+        "stages": {
+          "description": "Ordered board stages",
+          "items": {
+            "$ref": "#/$defs/FlowStage"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "initial_stage",
+        "manager",
+        "stages"
+      ],
+      "type": "object"
+    },
+    "FlowLimits": {
+      "additionalProperties": false,
+      "properties": {
+        "max_active_tasks": {
+          "type": "integer"
+        },
+        "max_attempts_per_stage": {
+          "type": "integer"
+        },
+        "max_runtime_seconds": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FlowManager": {
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "description": "Logical activation.manager/activation.worker or pinned agent:tenant:name reference",
+          "type": "string"
+        },
+        "heartbeat_seconds": {
+          "description": "Manager supervision heartbeat in seconds",
+          "type": "integer"
+        },
+        "system_prompt": {
+          "description": "Manager system prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent"
+      ],
+      "type": "object"
+    },
+    "FlowRetry": {
+      "additionalProperties": false,
+      "properties": {
+        "backoff": {
+          "enum": [
+            "fixed",
+            "exponential"
+          ],
+          "type": "string"
+        },
+        "initial_seconds": {
+          "type": "integer"
+        },
+        "limit": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FlowSessionPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "manager": {
+          "enum": [
+            "new_attempt",
+            "continue_stage",
+            "continue_task"
+          ],
+          "type": "string"
+        },
+        "worker": {
+          "enum": [
+            "new_attempt",
+            "continue_stage",
+            "continue_task"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FlowStage": {
+      "additionalProperties": false,
+      "properties": {
+        "completion": {
+          "$ref": "#/$defs/FlowCompletion"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "id": {
+          "description": "Stable stage id",
+          "type": "string"
+        },
+        "manager": {
+          "$ref": "#/$defs/FlowManager"
+        },
+        "retry": {
+          "$ref": "#/$defs/FlowRetry"
+        },
+        "session_policy": {
+          "$ref": "#/$defs/FlowSessionPolicy"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "timeout_seconds": {
+          "type": "integer"
+        },
+        "title": {
+          "description": "Human-readable stage title",
+          "type": "string"
+        },
+        "transitions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "triggers": {
+          "items": {
+            "$ref": "#/$defs/FlowStageTrigger"
+          },
+          "type": "array"
+        },
+        "worker": {
+          "$ref": "#/$defs/FlowWorker"
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ],
+      "type": "object"
+    },
+    "FlowStageTrigger": {
+      "additionalProperties": false,
+      "properties": {
+        "cron": {
+          "type": "string"
+        },
+        "event_type": {
+          "type": "string"
+        },
+        "every_seconds": {
+          "type": "integer"
+        },
+        "hook_id": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "heartbeat",
+            "cron",
+            "event",
+            "webhook"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "FlowWorker": {
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "description": "Logical activation.worker or pinned agent:tenant:name reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent"
+      ],
+      "type": "object"
+    },
     "InputDef": {
       "additionalProperties": false,
       "properties": {
@@ -324,6 +540,79 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "description": "Buttons drawer: a typed workflow chaining buttons with ${ref} references between steps.",
+  "oneOf": [
+    {
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "drawer_kind"
+            ]
+          },
+          {
+            "required": [
+              "flow"
+            ]
+          }
+        ]
+      },
+      "properties": {
+        "schema_version": {
+          "const": 1
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "steps"
+      ],
+      "title": "Legacy action drawer (schema v1)"
+    },
+    {
+      "not": {
+        "required": [
+          "flow"
+        ]
+      },
+      "properties": {
+        "drawer_kind": {
+          "const": "action"
+        },
+        "schema_version": {
+          "const": 2
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "drawer_kind",
+        "steps"
+      ],
+      "title": "Action drawer (schema v2)"
+    },
+    {
+      "not": {
+        "required": [
+          "steps"
+        ]
+      },
+      "properties": {
+        "drawer_kind": {
+          "const": "flow"
+        },
+        "schema_version": {
+          "const": 2
+        }
+      },
+      "required": [
+        "schema_version",
+        "name",
+        "drawer_kind",
+        "flow"
+      ],
+      "title": "Flow drawer (schema v2)"
+    }
+  ],
   "properties": {
     "created_at": {
       "format": "date-time",
@@ -332,6 +621,18 @@
     "description": {
       "description": "Human-readable one-liner",
       "type": "string"
+    },
+    "drawer_kind": {
+      "description": "Execution model (required for schema v2)",
+      "enum": [
+        "action",
+        "flow"
+      ],
+      "type": "string"
+    },
+    "flow": {
+      "$ref": "#/$defs/FlowDefinition",
+      "description": "Proactive board definition (flow drawers only)"
     },
     "inputs": {
       "description": "Top-level inputs supplied at press time",
@@ -360,12 +661,15 @@
       "type": "object"
     },
     "schema_version": {
-      "const": 1,
       "description": "Drawer spec version",
+      "enum": [
+        "1",
+        "2"
+      ],
       "type": "integer"
     },
     "steps": {
-      "description": "Ordered list of steps (depth-first execution)",
+      "description": "Ordered action steps (action drawers only)",
       "items": {
         "$ref": "#/$defs/Step"
       },
@@ -390,7 +694,6 @@
   "required": [
     "schema_version",
     "name",
-    "steps",
     "created_at",
     "updated_at"
   ],

--- a/internal/drawer/service.go
+++ b/internal/drawer/service.go
@@ -35,6 +35,18 @@ func NewService() *Service { return &Service{} }
 // reserved) so an agent can't create `buttons drawer list` and
 // collide with the subcommand.
 func (s *Service) Create(name string, description string, inputs []InputDef) (*Drawer, error) {
+	return s.CreateWithKind(name, description, inputs, DrawerKindAction)
+}
+
+// CreateWithKind scaffolds one of the schema-v2 Drawer variants. Keeping
+// Create as the action-default entrypoint preserves existing callers.
+func (s *Service) CreateWithKind(name string, description string, inputs []InputDef, kind string) (*Drawer, error) {
+	if kind == "" {
+		kind = DrawerKindAction
+	}
+	if kind != DrawerKindAction && kind != DrawerKindFlow {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("drawer kind must be %q or %q", DrawerKindAction, DrawerKindFlow)}
+	}
 	if err := button.ValidateName(name); err != nil {
 		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: err.Error()}
 	}
@@ -79,12 +91,18 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 	d := &Drawer{
 		SchemaVersion: SchemaVersion,
 		Name:          slug,
+		DrawerKind:    kind,
 		Description:   description,
 		Version:       button.InitialContentVersion,
 		Inputs:        inputs,
-		Steps:         []Step{},
 		CreatedAt:     now,
 		UpdatedAt:     now,
+	}
+	if kind == DrawerKindFlow {
+		d.Inputs = nil
+		d.Flow = &FlowDefinition{Stages: []FlowStage{}}
+	} else {
+		d.Steps = []Step{}
 	}
 
 	if err := s.save(d); err != nil {
@@ -92,6 +110,213 @@ func (s *Service) Create(name string, description string, inputs []InputDef) (*D
 		return nil, err
 	}
 	return d, nil
+}
+
+// AddFlowStage appends a stage to a flow-type Drawer in board order.
+func (s *Service) AddFlowStage(drawerName, stageID, title, systemPrompt string) (*Drawer, error) {
+	d, err := s.Get(drawerName)
+	if err != nil {
+		return nil, err
+	}
+	if d.DrawerKind != DrawerKindFlow || d.Flow == nil {
+		return nil, &ServiceError{Code: "DRAWER_KIND_MISMATCH", Message: fmt.Sprintf("drawer %q is not a flow drawer", drawerName)}
+	}
+	if !flowStageIDPattern.MatchString(stageID) {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("stage id %q must be kebab-case", stageID)}
+	}
+	for _, stage := range d.Flow.Stages {
+		if stage.ID == stageID {
+			return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("stage %q already exists", stageID)}
+		}
+	}
+	if title == "" {
+		title = strings.ToTitle(strings.ReplaceAll(stageID, "-", " "))
+	}
+	d.Flow.Stages = append(d.Flow.Stages, FlowStage{
+		ID:           stageID,
+		Title:        title,
+		SystemPrompt: systemPrompt,
+	})
+	d.UpdatedAt = time.Now().UTC()
+	if err := s.save(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// SetFlowField applies a bounded typed path to a flow definition. It avoids a
+// generic reflection/JSON patch surface so typos and unsupported policy fields
+// fail loudly instead of being persisted as inert metadata.
+func (s *Service) SetFlowField(drawerName, path string, value any) (*Drawer, error) {
+	d, err := s.Get(drawerName)
+	if err != nil {
+		return nil, err
+	}
+	if d.DrawerKind != DrawerKindFlow || d.Flow == nil {
+		return nil, &ServiceError{Code: "DRAWER_KIND_MISMATCH", Message: fmt.Sprintf("drawer %q is not a flow drawer", drawerName)}
+	}
+
+	setString := func(dst *string) error {
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("must be a string")
+		}
+		*dst = v
+		return nil
+	}
+	setInt := func(dst *int) error {
+		v, ok := numberAsInt(value)
+		if !ok {
+			return fmt.Errorf("must be an integer")
+		}
+		*dst = v
+		return nil
+	}
+	setBool := func(dst *bool) error {
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("must be a boolean")
+		}
+		*dst = v
+		return nil
+	}
+
+	var setErr error
+	switch path {
+	case "initial_stage":
+		setErr = setString(&d.Flow.InitialStage)
+	case "manager.agent":
+		setErr = setString(&d.Flow.Manager.Agent)
+	case "manager.system_prompt":
+		setErr = setString(&d.Flow.Manager.SystemPrompt)
+	case "manager.heartbeat_seconds":
+		setErr = setInt(&d.Flow.Manager.HeartbeatSeconds)
+	case "limits.max_active_tasks", "limits.max_runtime_seconds", "limits.max_attempts_per_stage":
+		if d.Flow.Limits == nil {
+			d.Flow.Limits = &FlowLimits{}
+		}
+		switch path {
+		case "limits.max_active_tasks":
+			setErr = setInt(&d.Flow.Limits.MaxActiveTasks)
+		case "limits.max_runtime_seconds":
+			setErr = setInt(&d.Flow.Limits.MaxRuntimeSeconds)
+		case "limits.max_attempts_per_stage":
+			setErr = setInt(&d.Flow.Limits.MaxAttemptsPerStage)
+		}
+	default:
+		parts := strings.Split(path, ".")
+		if len(parts) < 3 || parts[0] != "stages" {
+			return nil, &ServiceError{Code: "FLOW_FIELD_UNKNOWN", Message: fmt.Sprintf("unknown flow field %q", path)}
+		}
+		stage := findFlowStage(d.Flow.Stages, parts[1])
+		if stage == nil {
+			return nil, &ServiceError{Code: "STAGE_NOT_FOUND", Message: fmt.Sprintf("stage %q not found in drawer %q", parts[1], drawerName)}
+		}
+		field := strings.Join(parts[2:], ".")
+		switch field {
+		case "title":
+			setErr = setString(&stage.Title)
+		case "system_prompt":
+			setErr = setString(&stage.SystemPrompt)
+		case "transitions":
+			setErr = decodeFlowValue(value, &stage.Transitions)
+		case "timeout_seconds":
+			setErr = setInt(&stage.TimeoutSeconds)
+		case "concurrency":
+			setErr = setInt(&stage.Concurrency)
+		case "manager.agent", "manager.system_prompt", "manager.heartbeat_seconds":
+			if stage.Manager == nil {
+				stage.Manager = &FlowManager{}
+			}
+			switch field {
+			case "manager.agent":
+				setErr = setString(&stage.Manager.Agent)
+			case "manager.system_prompt":
+				setErr = setString(&stage.Manager.SystemPrompt)
+			case "manager.heartbeat_seconds":
+				setErr = setInt(&stage.Manager.HeartbeatSeconds)
+			}
+		case "worker.agent":
+			if stage.Worker == nil {
+				stage.Worker = &FlowWorker{}
+			}
+			setErr = setString(&stage.Worker.Agent)
+		case "session_policy.manager", "session_policy.worker":
+			if stage.SessionPolicy == nil {
+				stage.SessionPolicy = &FlowSessionPolicy{}
+			}
+			if field == "session_policy.manager" {
+				setErr = setString(&stage.SessionPolicy.Manager)
+			} else {
+				setErr = setString(&stage.SessionPolicy.Worker)
+			}
+		case "triggers":
+			setErr = decodeFlowValue(value, &stage.Triggers)
+		case "completion.requires_summary", "completion.requires_proof":
+			if stage.Completion == nil {
+				stage.Completion = &FlowCompletion{}
+			}
+			if field == "completion.requires_summary" {
+				setErr = setBool(&stage.Completion.RequiresSummary)
+			} else {
+				setErr = setBool(&stage.Completion.RequiresProof)
+			}
+		case "retry.limit", "retry.backoff", "retry.initial_seconds":
+			if stage.Retry == nil {
+				stage.Retry = &FlowRetry{}
+			}
+			switch field {
+			case "retry.limit":
+				setErr = setInt(&stage.Retry.Limit)
+			case "retry.backoff":
+				setErr = setString(&stage.Retry.Backoff)
+			case "retry.initial_seconds":
+				setErr = setInt(&stage.Retry.InitialSeconds)
+			}
+		default:
+			return nil, &ServiceError{Code: "FLOW_FIELD_UNKNOWN", Message: fmt.Sprintf("unknown flow stage field %q", field)}
+		}
+	}
+	if setErr != nil {
+		return nil, &ServiceError{Code: "VALIDATION_ERROR", Message: fmt.Sprintf("flow.%s %s", path, setErr)}
+	}
+	d.UpdatedAt = time.Now().UTC()
+	if err := s.save(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func findFlowStage(stages []FlowStage, id string) *FlowStage {
+	for i := range stages {
+		if stages[i].ID == id {
+			return &stages[i]
+		}
+	}
+	return nil
+}
+
+func numberAsInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case float64:
+		if v == float64(int(v)) {
+			return int(v), true
+		}
+	}
+	return 0, false
+}
+
+func decodeFlowValue(value any, target any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("has invalid shape: %w", err)
+	}
+	return nil
 }
 
 func buttonSpecExists(name string) (bool, error) {
@@ -195,6 +420,9 @@ func (s *Service) AddSteps(drawerName string, targets []string) (*Drawer, error)
 	d, err := s.Get(drawerName)
 	if err != nil {
 		return nil, err
+	}
+	if d.DrawerKind == DrawerKindFlow {
+		return nil, &ServiceError{Code: "DRAWER_KIND_MISMATCH", Message: fmt.Sprintf("flow drawer %q uses stages; action steps cannot be added", drawerName)}
 	}
 
 	btnSvc := button.NewService()

--- a/internal/drawer/validate.go
+++ b/internal/drawer/validate.go
@@ -3,6 +3,7 @@ package drawer
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/autonoco/buttons/internal/button"
@@ -36,6 +37,42 @@ type ValidationReport struct {
 // agent every issue at once — one round-trip per fix, not per bug.
 func Validate(d *Drawer, btnSvc *button.Service) ValidationReport {
 	report := ValidationReport{OK: true}
+
+	if d.SchemaVersion != 1 && d.SchemaVersion != SchemaVersion {
+		report.Errors = append(report.Errors, ValidationIssue{
+			Severity: "error",
+			Message:  fmt.Sprintf("unsupported drawer schema_version %d", d.SchemaVersion),
+		})
+		report.OK = false
+		return report
+	}
+
+	if d.SchemaVersion == SchemaVersion && d.DrawerKind == "" {
+		report.Errors = append(report.Errors, ValidationIssue{
+			Severity:    "error",
+			Message:     "schema-v2 drawer requires drawer_kind",
+			Remediation: "set drawer_kind to action or flow",
+		})
+	}
+
+	if d.DrawerKind == DrawerKindFlow {
+		validateFlowDefinition(d, &report)
+		report.OK = len(report.Errors) == 0
+		return report
+	}
+	if d.DrawerKind != "" && d.DrawerKind != DrawerKindAction {
+		report.Errors = append(report.Errors, ValidationIssue{
+			Severity: "error",
+			Message:  fmt.Sprintf("invalid drawer_kind %q", d.DrawerKind),
+		})
+	}
+	if d.Flow != nil {
+		report.Errors = append(report.Errors, ValidationIssue{
+			Severity:    "error",
+			Message:     "action drawer cannot define flow",
+			Remediation: "remove flow or set drawer_kind to flow and remove steps",
+		})
+	}
 
 	// Build quick lookups.
 	stepIDs := map[string]int{} // id -> index
@@ -287,6 +324,147 @@ func Validate(d *Drawer, btnSvc *button.Service) ValidationReport {
 
 	report.OK = len(report.Errors) == 0
 	return report
+}
+
+var (
+	flowStageIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	flowAgentPattern   = regexp.MustCompile(`^(?:activation\.(?:manager|worker)|agent:[A-Za-z0-9._-]+:[A-Za-z0-9._-]+)$`)
+)
+
+func validateFlowDefinition(d *Drawer, report *ValidationReport) {
+	addError := func(stageID, message, remediation string) {
+		report.Errors = append(report.Errors, ValidationIssue{
+			Severity:    "error",
+			StepID:      stageID,
+			Message:     message,
+			Remediation: remediation,
+		})
+	}
+
+	if d.SchemaVersion != SchemaVersion {
+		addError("", "flow drawer requires schema_version 2", "upgrade the drawer through the Buttons CLI")
+	}
+	if d.Steps != nil {
+		addError("", "flow drawer cannot define steps", "remove steps; flow drawers use flow.stages")
+	}
+	if d.Flow == nil {
+		addError("", "flow drawer requires a flow definition", "set flow.initial_stage, flow.manager, and flow.stages")
+		return
+	}
+
+	flow := d.Flow
+	if !validFlowAgentRef(flow.Manager.Agent) {
+		addError("", fmt.Sprintf("invalid manager agent reference %q", flow.Manager.Agent), "use activation.manager, activation.worker, or agent:<tenant>:<name>")
+	}
+	if flow.Manager.HeartbeatSeconds < 0 {
+		addError("", "manager heartbeat_seconds must be positive when set", "use a positive duration in seconds")
+	}
+	if flow.Limits != nil {
+		for name, value := range map[string]int{
+			"max_active_tasks":       flow.Limits.MaxActiveTasks,
+			"max_runtime_seconds":    flow.Limits.MaxRuntimeSeconds,
+			"max_attempts_per_stage": flow.Limits.MaxAttemptsPerStage,
+		} {
+			if value < 0 {
+				addError("", fmt.Sprintf("flow limit %s must be positive when set", name), "use zero to omit the limit or a positive value")
+			}
+		}
+	}
+	if len(flow.Stages) == 0 {
+		addError("", "flow requires at least one stage", "add a stage through `buttons drawer NAME stage add ID`")
+		return
+	}
+
+	stageIDs := make(map[string]struct{}, len(flow.Stages))
+	for _, stage := range flow.Stages {
+		if !flowStageIDPattern.MatchString(stage.ID) {
+			addError(stage.ID, fmt.Sprintf("invalid stage id %q", stage.ID), "use a non-empty kebab-case stage id")
+		}
+		if _, exists := stageIDs[stage.ID]; exists {
+			addError(stage.ID, fmt.Sprintf("duplicate stage id %q", stage.ID), "stage ids must be unique")
+		}
+		stageIDs[stage.ID] = struct{}{}
+	}
+	if _, exists := stageIDs[flow.InitialStage]; !exists {
+		addError("", fmt.Sprintf("initial stage %q does not exist", flow.InitialStage), "set flow.initial_stage to an existing stage id")
+	}
+
+	for _, stage := range flow.Stages {
+		if stage.Title == "" {
+			addError(stage.ID, "stage title is required", "set a human-readable stage title")
+		}
+		if stage.Manager != nil {
+			if !validFlowAgentRef(stage.Manager.Agent) {
+				addError(stage.ID, fmt.Sprintf("invalid manager agent reference %q", stage.Manager.Agent), "use activation.manager, activation.worker, or agent:<tenant>:<name>")
+			}
+			if stage.Manager.HeartbeatSeconds < 0 {
+				addError(stage.ID, "manager heartbeat_seconds must be positive when set", "use a positive duration in seconds")
+			}
+		}
+		if stage.Worker != nil && !validFlowAgentRef(stage.Worker.Agent) {
+			addError(stage.ID, fmt.Sprintf("invalid worker agent reference %q", stage.Worker.Agent), "use activation.worker or agent:<tenant>:<name>")
+		}
+		if stage.SessionPolicy != nil {
+			if !validFlowSessionPolicy(stage.SessionPolicy.Manager) {
+				addError(stage.ID, fmt.Sprintf("invalid manager session policy %q", stage.SessionPolicy.Manager), "use new_attempt, continue_stage, or continue_task")
+			}
+			if !validFlowSessionPolicy(stage.SessionPolicy.Worker) {
+				addError(stage.ID, fmt.Sprintf("invalid worker session policy %q", stage.SessionPolicy.Worker), "use new_attempt, continue_stage, or continue_task")
+			}
+		}
+		for _, trigger := range stage.Triggers {
+			switch trigger.Kind {
+			case "heartbeat":
+				if trigger.EverySeconds <= 0 {
+					addError(stage.ID, "heartbeat trigger requires positive every_seconds", "set every_seconds to a positive integer")
+				}
+			case "cron":
+				if strings.TrimSpace(trigger.Cron) == "" {
+					addError(stage.ID, "cron stage trigger requires cron", "set a cron expression")
+				}
+			case "event":
+				if strings.TrimSpace(trigger.EventType) == "" {
+					addError(stage.ID, "event stage trigger requires event_type", "set a durable platform event type")
+				}
+			case "webhook":
+				if strings.TrimSpace(trigger.HookID) == "" {
+					addError(stage.ID, "webhook stage trigger requires hook_id", "set a stable hook id")
+				}
+			default:
+				addError(stage.ID, fmt.Sprintf("invalid stage trigger kind %q", trigger.Kind), "use heartbeat, cron, event, or webhook")
+			}
+		}
+		for _, target := range stage.Transitions {
+			if _, exists := stageIDs[target]; !exists {
+				addError(stage.ID, fmt.Sprintf("unknown transition target %q", target), "target an existing stage id")
+			}
+		}
+		if stage.TimeoutSeconds < 0 {
+			addError(stage.ID, "timeout_seconds must be positive when set", "use a positive duration in seconds")
+		}
+		if stage.Concurrency < 0 {
+			addError(stage.ID, "concurrency must be positive when set", "use a positive integer")
+		}
+		if stage.Retry != nil {
+			if stage.Retry.Limit < 0 {
+				addError(stage.ID, "retry limit must not be negative", "use zero or a positive integer")
+			}
+			if stage.Retry.Backoff != "" && stage.Retry.Backoff != "fixed" && stage.Retry.Backoff != "exponential" {
+				addError(stage.ID, fmt.Sprintf("invalid retry backoff %q", stage.Retry.Backoff), "use fixed or exponential")
+			}
+			if stage.Retry.InitialSeconds < 0 {
+				addError(stage.ID, "retry initial_seconds must be positive when set", "use a positive duration in seconds")
+			}
+		}
+	}
+}
+
+func validFlowAgentRef(value string) bool {
+	return flowAgentPattern.MatchString(value)
+}
+
+func validFlowSessionPolicy(value string) bool {
+	return value == "" || value == "new_attempt" || value == "continue_stage" || value == "continue_task"
 }
 
 // validateRef checks one ${path} reference. Returns an issue if the

--- a/internal/store/http_publish.go
+++ b/internal/store/http_publish.go
@@ -68,6 +68,14 @@ func (p *HTTPPublisher) Publish(b *Bundle) error {
 	req.Header.Set("Content-Type", "application/gzip")
 	req.Header.Set("X-Content-Sha256", sum) // server verifies bytes against this
 	req.Header.Set("X-Button-Kind", kind)
+	if len(b.FlowDefinition) > 0 {
+		definitionHash := sha256hex(b.FlowDefinition)
+		if b.FlowDefinitionSHA256 != "" && b.FlowDefinitionSHA256 != definitionHash {
+			return fmt.Errorf("flow definition hash mismatch for %s", b.Name)
+		}
+		req.Header.Set("X-Drawer-Kind", "flow")
+		req.Header.Set("X-Flow-Definition-Sha256", definitionHash)
+	}
 	req.ContentLength = int64(len(tarball))
 
 	resp, err := p.httpClient().Do(req)

--- a/internal/store/http_publish.go
+++ b/internal/store/http_publish.go
@@ -68,8 +68,12 @@ func (p *HTTPPublisher) Publish(b *Bundle) error {
 	req.Header.Set("Content-Type", "application/gzip")
 	req.Header.Set("X-Content-Sha256", sum) // server verifies bytes against this
 	req.Header.Set("X-Button-Kind", kind)
-	if len(b.FlowDefinition) > 0 {
-		definitionHash := sha256hex(b.FlowDefinition)
+	packedDefinition, hasPackedDefinition := b.Files["flow-definition.json"]
+	if hasPackedDefinition || len(b.FlowDefinition) > 0 || b.FlowDefinitionSHA256 != "" {
+		if !hasPackedDefinition || len(packedDefinition) == 0 {
+			return fmt.Errorf("flow bundle %s is missing flow-definition.json", b.Name)
+		}
+		definitionHash := sha256hex(packedDefinition)
 		if b.FlowDefinitionSHA256 != "" && b.FlowDefinitionSHA256 != definitionHash {
 			return fmt.Errorf("flow definition hash mismatch for %s", b.Name)
 		}

--- a/internal/store/http_publish_test.go
+++ b/internal/store/http_publish_test.go
@@ -177,6 +177,50 @@ func TestHTTPPublisherRequiresNameAndVersion(t *testing.T) {
 	}
 }
 
+func TestHTTPPublisherSendsFlowDefinitionMetadata(t *testing.T) {
+	definition := []byte(`{"schema_version":2,"name":"software-delivery","drawer_kind":"flow"}`)
+	var drawerKind, definitionHash string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		drawerKind = r.Header.Get("X-Drawer-Kind")
+		definitionHash = r.Header.Get("X-Flow-Definition-Sha256")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	bundle := &Bundle{
+		Name:                 "@autono/software-delivery",
+		Kind:                 "drawer",
+		Version:              "1",
+		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`), "flow-definition.json": definition},
+		FlowDefinition:       definition,
+		FlowDefinitionSHA256: sha256hex(definition),
+	}
+	if err := (&HTTPPublisher{BaseURL: srv.URL}).Publish(bundle); err != nil {
+		t.Fatalf("publish flow bundle: %v", err)
+	}
+	if drawerKind != "flow" {
+		t.Fatalf("X-Drawer-Kind = %q, want flow", drawerKind)
+	}
+	if definitionHash != sha256hex(definition) {
+		t.Fatalf("X-Flow-Definition-Sha256 = %q, want %q", definitionHash, sha256hex(definition))
+	}
+}
+
+func TestHTTPPublisherRejectsMismatchedFlowDefinitionHash(t *testing.T) {
+	bundle := &Bundle{
+		Name:                 "@autono/software-delivery",
+		Kind:                 "drawer",
+		Version:              "1",
+		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`)},
+		FlowDefinition:       []byte(`{"drawer_kind":"flow"}`),
+		FlowDefinitionSHA256: "wrong",
+	}
+	err := (&HTTPPublisher{BaseURL: "http://unused.invalid"}).Publish(bundle)
+	if err == nil || !strings.Contains(err.Error(), "flow definition hash mismatch") {
+		t.Fatalf("Publish() error = %v, want flow definition hash mismatch", err)
+	}
+}
+
 // TestTarGzUntarGzRoundTrip pins the artifact contract: tarGz wraps, untarGz
 // strips, content survives. This is what makes publish → install lossless.
 func TestTarGzUntarGzRoundTrip(t *testing.T) {

--- a/internal/store/http_publish_test.go
+++ b/internal/store/http_publish_test.go
@@ -179,6 +179,7 @@ func TestHTTPPublisherRequiresNameAndVersion(t *testing.T) {
 
 func TestHTTPPublisherSendsFlowDefinitionMetadata(t *testing.T) {
 	definition := []byte(`{"schema_version":2,"name":"software-delivery","drawer_kind":"flow"}`)
+	staleInMemoryDefinition := []byte(`{"schema_version":2,"name":"stale","drawer_kind":"flow"}`)
 	var drawerKind, definitionHash string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		drawerKind = r.Header.Get("X-Drawer-Kind")
@@ -192,7 +193,7 @@ func TestHTTPPublisherSendsFlowDefinitionMetadata(t *testing.T) {
 		Kind:                 "drawer",
 		Version:              "1",
 		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`), "flow-definition.json": definition},
-		FlowDefinition:       definition,
+		FlowDefinition:       staleInMemoryDefinition,
 		FlowDefinitionSHA256: sha256hex(definition),
 	}
 	if err := (&HTTPPublisher{BaseURL: srv.URL}).Publish(bundle); err != nil {
@@ -207,17 +208,34 @@ func TestHTTPPublisherSendsFlowDefinitionMetadata(t *testing.T) {
 }
 
 func TestHTTPPublisherRejectsMismatchedFlowDefinitionHash(t *testing.T) {
+	definition := []byte(`{"drawer_kind":"flow"}`)
 	bundle := &Bundle{
 		Name:                 "@autono/software-delivery",
 		Kind:                 "drawer",
 		Version:              "1",
-		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`)},
-		FlowDefinition:       []byte(`{"drawer_kind":"flow"}`),
+		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`), "flow-definition.json": definition},
+		FlowDefinition:       definition,
 		FlowDefinitionSHA256: "wrong",
 	}
 	err := (&HTTPPublisher{BaseURL: "http://unused.invalid"}).Publish(bundle)
 	if err == nil || !strings.Contains(err.Error(), "flow definition hash mismatch") {
 		t.Fatalf("Publish() error = %v, want flow definition hash mismatch", err)
+	}
+}
+
+func TestHTTPPublisherRejectsMissingFlowDefinitionFile(t *testing.T) {
+	definition := []byte(`{"drawer_kind":"flow"}`)
+	bundle := &Bundle{
+		Name:                 "@autono/software-delivery",
+		Kind:                 "drawer",
+		Version:              "1",
+		Files:                map[string][]byte{"drawer.json": []byte(`{"schema_version":2}`)},
+		FlowDefinition:       definition,
+		FlowDefinitionSHA256: sha256hex(definition),
+	}
+	err := (&HTTPPublisher{BaseURL: "http://unused.invalid"}).Publish(bundle)
+	if err == nil || !strings.Contains(err.Error(), "missing flow-definition.json") {
+		t.Fatalf("Publish() error = %v, want missing flow-definition.json", err)
 	}
 }
 

--- a/internal/store/install.go
+++ b/internal/store/install.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -234,6 +235,21 @@ func fetchDrawerInstallable(src Source, name, version string) (*Bundle, *drawer.
 		return nil, nil, fmt.Errorf("drawer %q: invalid drawer.json: %w", name, err)
 	}
 	spec.Version = bundle.Version
+	if spec.DrawerKind == drawer.DrawerKindFlow {
+		normalized, err := drawer.NormalizeFlowDefinition(&spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("drawer %q: %w", name, err)
+		}
+		published, ok := bundle.Files["flow-definition.json"]
+		if !ok {
+			return nil, nil, fmt.Errorf("drawer %q: flow bundle has no flow-definition.json", name)
+		}
+		if !bytes.Equal(published, normalized) {
+			return nil, nil, fmt.Errorf("drawer %q: flow-definition.json does not match drawer.json", name)
+		}
+		bundle.FlowDefinition = normalized
+		bundle.FlowDefinitionSHA256 = sha256hex(normalized)
+	}
 	stamped, err := json.MarshalIndent(&spec, "", "  ")
 	if err != nil {
 		return nil, nil, err

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -21,11 +21,12 @@ type Publisher interface {
 
 // PublishResult reports what a publish produced.
 type PublishResult struct {
-	Name    string `json:"name"`
-	Kind    string `json:"kind"`
-	Version string `json:"version,omitempty"`
-	SHA256  string `json:"sha256"`
-	Files   int    `json:"files"`
+	Name                 string `json:"name"`
+	Kind                 string `json:"kind"`
+	Version              string `json:"version,omitempty"`
+	SHA256               string `json:"sha256"`
+	Files                int    `json:"files"`
+	FlowDefinitionSHA256 string `json:"flow_definition_sha256,omitempty"`
 }
 
 // Publish reads an installed/local button and hands it to dst. It's the inverse
@@ -40,7 +41,7 @@ func Publish(dst Publisher, name string) (*PublishResult, error) {
 	if err := dst.Publish(bundle); err != nil {
 		return nil, err
 	}
-	return &PublishResult{Name: bundle.Name, Kind: bundle.Kind, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+	return publishResult(bundle), nil
 }
 
 // PublishToRegistry publishes a local button to the hosted registry under a
@@ -77,9 +78,20 @@ func PublishToRegistry(dst Publisher, ref string) (*PublishResult, error) {
 			version = next
 			continue
 		}
-		return &PublishResult{Name: bundle.Name, Kind: bundle.Kind, Version: bundle.Version, SHA256: bundle.SHA256, Files: len(bundle.Files)}, nil
+		return publishResult(bundle), nil
 	}
 	return nil, fmt.Errorf("registry publish could not find an unused version after 1000 attempts")
+}
+
+func publishResult(bundle *Bundle) *PublishResult {
+	return &PublishResult{
+		Name:                 bundle.Name,
+		Kind:                 bundle.Kind,
+		Version:              bundle.Version,
+		SHA256:               bundle.SHA256,
+		Files:                len(bundle.Files),
+		FlowDefinitionSHA256: bundle.FlowDefinitionSHA256,
+	}
 }
 
 // loadLocalBundle reads a local button or drawer folder into a Bundle. localName
@@ -174,12 +186,30 @@ func loadLocalDrawerBundle(localName, identity, dir string) (*Bundle, error) {
 	if err := json.Unmarshal(specData, &spec); err != nil {
 		return nil, fmt.Errorf("drawer %q: invalid drawer.json: %w", localName, err)
 	}
+	var normalized []byte
+	var normalizedHash string
+	if spec.DrawerKind == drawer.DrawerKindFlow {
+		normalized, err = drawer.NormalizeFlowDefinition(&spec)
+		if err != nil {
+			return nil, fmt.Errorf("drawer %q: %w", localName, err)
+		}
+		files["flow-definition.json"] = normalized
+		normalizedHash = sha256hex(normalized)
+	}
 
 	name := spec.Name
 	if identity != "" {
 		name = identity
 	}
-	return &Bundle{Name: name, Kind: "drawer", Version: spec.Version, SHA256: hashFiles(files), Files: files}, nil
+	return &Bundle{
+		Name:                 name,
+		Kind:                 "drawer",
+		Version:              spec.Version,
+		SHA256:               hashFiles(files),
+		Files:                files,
+		FlowDefinition:       normalized,
+		FlowDefinitionSHA256: normalizedHash,
+	}, nil
 }
 
 func stampLocalBundleVersion(localName string, bundle *Bundle, version string) error {
@@ -240,6 +270,19 @@ func stampLocalDrawerBundleVersion(localName string, bundle *Bundle, version str
 
 	bundle.Version = version
 	bundle.Files["drawer.json"] = data
+	if spec.DrawerKind == drawer.DrawerKindFlow {
+		normalized, err := drawer.NormalizeFlowDefinition(&spec)
+		if err != nil {
+			return fmt.Errorf("normalize %q flow definition: %w", localName, err)
+		}
+		bundle.Files["flow-definition.json"] = normalized
+		bundle.FlowDefinition = normalized
+		bundle.FlowDefinitionSHA256 = sha256hex(normalized)
+	} else {
+		delete(bundle.Files, "flow-definition.json")
+		bundle.FlowDefinition = nil
+		bundle.FlowDefinitionSHA256 = ""
+	}
 	bundle.SHA256 = hashFiles(bundle.Files)
 
 	dir, err := config.DrawerDir(button.Slugify(localName))

--- a/internal/store/publish.go
+++ b/internal/store/publish.go
@@ -195,6 +195,8 @@ func loadLocalDrawerBundle(localName, identity, dir string) (*Bundle, error) {
 		}
 		files["flow-definition.json"] = normalized
 		normalizedHash = sha256hex(normalized)
+	} else {
+		delete(files, "flow-definition.json")
 	}
 
 	name := spec.Name

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -196,6 +196,32 @@ func TestPublishToRegistryAutoDetectsDrawerPackage(t *testing.T) {
 	}
 }
 
+func TestPublishNonFlowDrawerRemovesStaleFlowDefinition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	writeInstalledDrawer(t, home, drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "deploy-pack",
+		DrawerKind:    drawer.DrawerKindAction,
+		Steps:         []drawer.Step{{ID: "build", Button: "build"}},
+	})
+	staleDefinition := filepath.Join(home, "drawers", "deploy-pack", "flow-definition.json")
+	if err := os.WriteFile(staleDefinition, []byte(`{"drawer_kind":"flow","name":"stale"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pub := &capturePublisher{}
+	if _, err := Publish(pub, "deploy-pack"); err != nil {
+		t.Fatalf("publish non-flow drawer: %v", err)
+	}
+	if _, ok := pub.bundle.Files["flow-definition.json"]; ok {
+		t.Fatal("non-flow drawer publish retained stale flow-definition.json")
+	}
+	if len(pub.bundle.FlowDefinition) != 0 || pub.bundle.FlowDefinitionSHA256 != "" {
+		t.Fatalf("non-flow drawer retained normalized flow metadata: %+v", pub.bundle)
+	}
+}
+
 func TestPublishToRegistryAddsNormalizedFlowDefinition(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("BUTTONS_HOME", home)

--- a/internal/store/publish_test.go
+++ b/internal/store/publish_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/autonoco/buttons/internal/button"
 	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/manifest"
 )
 
 type capturePublisher struct {
@@ -191,6 +193,132 @@ func TestPublishToRegistryAutoDetectsDrawerPackage(t *testing.T) {
 	}
 	if local.Version != "1" {
 		t.Fatalf("local drawer version = %q, want 1", local.Version)
+	}
+}
+
+func TestPublishToRegistryAddsNormalizedFlowDefinition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	flow := &drawer.FlowDefinition{
+		InitialStage: "intake",
+		Manager:      drawer.FlowManager{Agent: "activation.manager", HeartbeatSeconds: 300},
+		Stages: []drawer.FlowStage{
+			{ID: "intake", Title: "Intake", Transitions: []string{"done"}},
+			{ID: "done", Title: "Done"},
+		},
+	}
+	writeInstalledDrawer(t, home, drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "software-delivery",
+		DrawerKind:    drawer.DrawerKindFlow,
+		Description:   "Move a ticket through delivery.",
+		Version:       "1",
+		Flow:          flow,
+	})
+
+	pub := &capturePublisher{}
+	res, err := PublishToRegistry(pub, "@autono/software-delivery")
+	if err != nil {
+		t.Fatalf("publish flow drawer: %v", err)
+	}
+	if pub.bundle == nil {
+		t.Fatal("publisher did not receive bundle")
+	}
+	normalized, ok := pub.bundle.Files["flow-definition.json"]
+	if !ok {
+		t.Fatalf("bundle files = %v; want flow-definition.json", pub.bundle.Files)
+	}
+	if string(pub.bundle.FlowDefinition) != string(normalized) {
+		t.Fatalf("bundle FlowDefinition does not match published normalized file")
+	}
+	if pub.bundle.FlowDefinitionSHA256 == "" {
+		t.Fatal("flow definition hash is empty")
+	}
+	if res.FlowDefinitionSHA256 != pub.bundle.FlowDefinitionSHA256 {
+		t.Fatalf("publish result flow hash = %q, want %q", res.FlowDefinitionSHA256, pub.bundle.FlowDefinitionSHA256)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(normalized, &got); err != nil {
+		t.Fatalf("normalized definition is invalid JSON: %v", err)
+	}
+	if got["schema_version"] != float64(2) || got["name"] != "software-delivery" || got["drawer_kind"] != "flow" || got["version"] != "1" {
+		t.Fatalf("normalized identity = %#v", got)
+	}
+	for _, excluded := range []string{"steps", "created_at", "updated_at"} {
+		if _, exists := got[excluded]; exists {
+			t.Errorf("normalized definition must exclude %s", excluded)
+		}
+	}
+	gotFlow, err := json.Marshal(got["flow"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFlow, err := json.Marshal(flow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotFlow) != string(wantFlow) {
+		t.Fatalf("flow changed during normalization:\n got %s\nwant %s", gotFlow, wantFlow)
+	}
+}
+
+func TestFlowDrawerPublishInstallRoundTripPreservesDefinition(t *testing.T) {
+	authorHome := t.TempDir()
+	t.Setenv("BUTTONS_HOME", authorHome)
+	svc := drawer.NewService()
+	if _, err := svc.CreateWithKind("software-delivery", "Move a ticket through delivery.", nil, drawer.DrawerKindFlow); err != nil {
+		t.Fatal(err)
+	}
+	for _, stage := range []struct{ id, title string }{{"intake", "Intake"}, {"done", "Done"}} {
+		if _, err := svc.AddFlowStage("software-delivery", stage.id, stage.title, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, value := range map[string]any{
+		"initial_stage":                             "intake",
+		"manager.agent":                             "activation.manager",
+		"manager.heartbeat_seconds":                 300,
+		"stages.intake.transitions":                 []string{"done"},
+		"stages.intake.worker.agent":                "activation.worker",
+		"stages.intake.completion.requires_summary": true,
+	} {
+		if _, err := svc.SetFlowField("software-delivery", path, value); err != nil {
+			t.Fatalf("set flow.%s: %v", path, err)
+		}
+	}
+	want, err := svc.Get("software-delivery")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub := &capturePublisher{}
+	if _, err := PublishToRegistry(pub, "@autono/software-delivery"); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	installHome := t.TempDir()
+	t.Setenv("BUTTONS_HOME", installHome)
+	src := memorySource{
+		refs: []ButtonRef{{Name: "@autono/software-delivery", Kind: "drawer", Version: pub.bundle.Version}},
+		bundles: map[string]*Bundle{
+			"@autono/software-delivery@" + pub.bundle.Version: pub.bundle,
+		},
+	}
+	if _, _, err := InstallManifest(src, &manifest.Manifest{
+		SchemaVersion: 1,
+		Dependencies:  map[string]string{"@autono/software-delivery": pub.bundle.Version},
+	}, nil, InstallOptions{}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got, err := drawer.NewService().Get("software-delivery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Flow, want.Flow) {
+		t.Fatalf("flow definition changed:\n got %#v\nwant %#v", got.Flow, want.Flow)
+	}
+	if _, err := os.Stat(filepath.Join(installHome, "drawers", "software-delivery", "flow-definition.json")); err != nil {
+		t.Fatalf("installed normalized definition: %v", err)
 	}
 }
 

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -29,11 +29,13 @@ type ButtonRef struct {
 
 // Bundle is a fetched package's content, ready to write to disk.
 type Bundle struct {
-	Name    string
-	Kind    string
-	Version string
-	SHA256  string            // content hash of Files (provenance pin)
-	Files   map[string][]byte // relative filename -> bytes (button.json/drawer.json, code, AGENTS.md)
+	Name                 string
+	Kind                 string
+	Version              string
+	SHA256               string            // content hash of Files (provenance pin)
+	Files                map[string][]byte // relative filename -> bytes (button.json/drawer.json, code, AGENTS.md)
+	FlowDefinition       []byte            // normalized flow-definition.json when Kind is a flow drawer
+	FlowDefinitionSHA256 string            // immutable definition metadata sent during registry publish
 }
 
 // Source is where buttons are installed/updated from. HTTPSource (the registry,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -258,6 +258,39 @@ func TestInstallManifestInstallsDrawerPackageAndMemberButtons(t *testing.T) {
 	}
 }
 
+func TestInstallManifestRejectsMismatchedNormalizedFlowDefinition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	d := drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "software-delivery",
+		DrawerKind:    drawer.DrawerKindFlow,
+		Version:       "1",
+		Flow: &drawer.FlowDefinition{
+			InitialStage: "intake",
+			Manager:      drawer.FlowManager{Agent: "activation.manager"},
+			Stages:       []drawer.FlowStage{{ID: "intake", Title: "Intake"}},
+		},
+	}
+	bundle := drawerBundle(t, "@autono/software-delivery", d)
+	bundle.Files["flow-definition.json"] = []byte(`{"schema_version":2,"name":"other","drawer_kind":"flow"}`)
+	bundle.SHA256 = hashFiles(bundle.Files)
+	src := memorySource{
+		refs: []ButtonRef{{Name: "@autono/software-delivery", Kind: "drawer", Version: "1"}},
+		bundles: map[string]*Bundle{
+			"@autono/software-delivery@1": bundle,
+		},
+	}
+
+	_, _, err := InstallManifest(src, &manifest.Manifest{
+		SchemaVersion: 1,
+		Dependencies:  map[string]string{"@autono/software-delivery": "1"},
+	}, nil, InstallOptions{})
+	if err == nil || !strings.Contains(err.Error(), "flow-definition.json does not match drawer.json") {
+		t.Fatalf("InstallManifest() error = %v, want normalized flow mismatch", err)
+	}
+}
+
 func TestInstallManifestHonorsExistingLock(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("BUTTONS_HOME", home)

--- a/internal/tools/schemagen/main.go
+++ b/internal/tools/schemagen/main.go
@@ -51,6 +51,7 @@ func run() error {
 	for k, v := range root {
 		doc[k] = v
 	}
+	doc["oneOf"] = drawerVariants()
 	if len(gen.defs) > 0 {
 		doc["$defs"] = gen.defs
 	}
@@ -76,6 +77,45 @@ func run() error {
 		fmt.Printf("wrote %s\n", p)
 	}
 	return nil
+}
+
+// drawerVariants makes the on-disk compatibility rule explicit. Schema v1 is
+// the legacy action shape; schema v2 is discriminated by drawer_kind and must
+// contain exactly one execution model.
+func drawerVariants() []any {
+	return []any{
+		map[string]any{
+			"title": "Legacy action drawer (schema v1)",
+			"properties": map[string]any{
+				"schema_version": map[string]any{"const": 1},
+			},
+			"required": []string{"schema_version", "name", "steps"},
+			"not": map[string]any{
+				"anyOf": []any{
+					map[string]any{"required": []string{"drawer_kind"}},
+					map[string]any{"required": []string{"flow"}},
+				},
+			},
+		},
+		map[string]any{
+			"title": "Action drawer (schema v2)",
+			"properties": map[string]any{
+				"schema_version": map[string]any{"const": 2},
+				"drawer_kind":    map[string]any{"const": "action"},
+			},
+			"required": []string{"schema_version", "name", "drawer_kind", "steps"},
+			"not":      map[string]any{"required": []string{"flow"}},
+		},
+		map[string]any{
+			"title": "Flow drawer (schema v2)",
+			"properties": map[string]any{
+				"schema_version": map[string]any{"const": 2},
+				"drawer_kind":    map[string]any{"const": "flow"},
+			},
+			"required": []string{"schema_version", "name", "drawer_kind", "flow"},
+			"not":      map[string]any{"required": []string{"steps"}},
+		},
+	}
 }
 
 // generator walks a Go type graph once and produces JSON Schema.

--- a/internal/tools/schemagen/main.go
+++ b/internal/tools/schemagen/main.go
@@ -252,7 +252,7 @@ func applyJSONSchemaTag(schema map[string]any, tag string) {
 		case "description":
 			schema["description"] = val
 		case "enum":
-			enums = append(enums, val)
+			enums = append(enums, schemaEnumValue(schema, val))
 		case "const":
 			// Numeric consts are stored as-is if they parse; else
 			// string const.
@@ -273,6 +273,28 @@ func applyJSONSchemaTag(schema map[string]any, tag string) {
 	if len(enums) > 0 {
 		schema["enum"] = enums
 	}
+}
+
+// schemaEnumValue preserves the Go field's JSON type when translating struct
+// tag values. Struct tags are text, but an enum on an integer/number field must
+// contain JSON numbers rather than strings or the generated schema is
+// internally contradictory.
+func schemaEnumValue(schema map[string]any, value string) any {
+	switch schema["type"] {
+	case "integer":
+		var number json.Number
+		if err := json.Unmarshal([]byte(value), &number); err == nil {
+			if _, err := number.Int64(); err == nil {
+				return jsonNumberToAny(number)
+			}
+		}
+	case "number":
+		var number json.Number
+		if err := json.Unmarshal([]byte(value), &number); err == nil {
+			return jsonNumberToAny(number)
+		}
+	}
+	return value
 }
 
 // splitTagRespectingEscapes splits a struct tag value on commas

--- a/test/integration/flow_drawer_test.go
+++ b/test/integration/flow_drawer_test.go
@@ -1,0 +1,142 @@
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readFlowDrawer(t *testing.T, env *testEnv, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(env.home, "drawers", name, "drawer.json"))
+	if err != nil {
+		t.Fatalf("read drawer.json: %v", err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode drawer.json: %v", err)
+	}
+	return value
+}
+
+func TestFlowDrawerAuthoringThroughCLI(t *testing.T) {
+	env := newTestEnv(t)
+
+	r := env.run("drawer", "create", "software-delivery", "--kind", "flow", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("create flow drawer: exit=%d stdout=%s stderr=%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+	created := readFlowDrawer(t, env, "software-delivery")
+	if created["schema_version"] != float64(2) || created["drawer_kind"] != "flow" {
+		t.Fatalf("created flow identity = %#v", created)
+	}
+	if _, mixed := created["steps"]; mixed {
+		t.Fatalf("flow drawer must not scaffold steps: %#v", created["steps"])
+	}
+
+	commands := [][]string{
+		{"drawer", "software-delivery", "stage", "add", "intake", "--title", "Intake"},
+		{"drawer", "software-delivery", "stage", "add", "research", "--title", "Research"},
+		{"drawer", "software-delivery", "set", "flow.initial_stage=intake"},
+		{"drawer", "software-delivery", "set", "flow.manager.agent=activation.manager"},
+		{"drawer", "software-delivery", "set", "flow.manager.heartbeat_seconds=300"},
+		{"drawer", "software-delivery", "set", `flow.stages.intake.transitions=["research"]`},
+		{"drawer", "software-delivery", "set", "flow.stages.research.worker.agent=activation.worker"},
+	}
+	for _, args := range commands {
+		r = env.run(args...)
+		if r.ExitCode != 0 {
+			t.Fatalf("%s: exit=%d stdout=%s stderr=%s", strings.Join(args, " "), r.ExitCode, r.Stdout, r.Stderr)
+		}
+	}
+
+	r = env.run("drawer", "software-delivery", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("inspect flow drawer: exit=%d stdout=%s stderr=%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+	if !strings.Contains(r.Stdout, `"ok": true`) {
+		t.Fatalf("flow validation not green: %s", r.Stdout)
+	}
+	for _, want := range []string{`"schema_version": 2`, `"version": "1"`, `"drawer_kind": "flow"`, `"initial_stage": "intake"`} {
+		if !strings.Contains(r.Stdout, want) {
+			t.Errorf("flow inspection missing %s: %s", want, r.Stdout)
+		}
+	}
+
+	got := readFlowDrawer(t, env, "software-delivery")
+	flow := got["flow"].(map[string]any)
+	if flow["initial_stage"] != "intake" {
+		t.Fatalf("initial_stage = %#v", flow["initial_stage"])
+	}
+	manager := flow["manager"].(map[string]any)
+	if manager["agent"] != "activation.manager" || manager["heartbeat_seconds"] != float64(300) {
+		t.Fatalf("manager = %#v", manager)
+	}
+	stages := flow["stages"].([]any)
+	if len(stages) != 2 {
+		t.Fatalf("stages = %#v", stages)
+	}
+	intake := stages[0].(map[string]any)
+	if intake["id"] != "intake" || intake["title"] != "Intake" {
+		t.Fatalf("intake = %#v", intake)
+	}
+	transitions := intake["transitions"].([]any)
+	if len(transitions) != 1 || transitions[0] != "research" {
+		t.Fatalf("intake transitions = %#v", transitions)
+	}
+
+	r = env.run("drawer", "software-delivery", "stage", "add", "intake", "--title", "Duplicate", "--json")
+	if r.ExitCode == 0 || !strings.Contains(r.Stdout+r.Stderr, "already exists") {
+		t.Fatalf("duplicate stage should fail: exit=%d stdout=%s stderr=%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+}
+
+func TestActionDrawerCreateKindRemainsCompatible(t *testing.T) {
+	env := newTestEnv(t)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "implicit", args: []string{"drawer", "create", "implicit-action", "--json"}},
+		{name: "explicit", args: []string{"drawer", "create", "explicit-action", "--kind", "action", "--json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := env.run(tc.args...)
+			if r.ExitCode != 0 {
+				t.Fatalf("create action: exit=%d stdout=%s stderr=%s", r.ExitCode, r.Stdout, r.Stderr)
+			}
+			name := tc.args[2]
+			got := readFlowDrawer(t, env, name)
+			if got["drawer_kind"] != "action" {
+				t.Fatalf("drawer_kind = %#v", got["drawer_kind"])
+			}
+			if _, ok := got["steps"]; !ok {
+				t.Fatalf("action drawer did not scaffold steps: %#v", got)
+			}
+		})
+	}
+}
+
+func TestFlowDrawerRejectsActionExecutionCommands(t *testing.T) {
+	env := newTestEnv(t)
+	r := env.run("drawer", "create", "managed-flow", "--kind", "flow", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("create flow: %s", r.Stderr)
+	}
+	r = env.run("create", "build", "--runtime", "shell", "--code", "echo ok", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("create button: %s", r.Stderr)
+	}
+
+	for _, args := range [][]string{
+		{"drawer", "managed-flow", "add", "build", "--json"},
+		{"drawer", "managed-flow", "press", "--json"},
+	} {
+		r = env.run(args...)
+		if r.ExitCode == 0 || !strings.Contains(r.Stdout+r.Stderr, "flow drawer") {
+			t.Fatalf("%s should reject action execution: exit=%d stdout=%s stderr=%s", strings.Join(args, " "), r.ExitCode, r.Stdout, r.Stderr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add schema-v2 action/flow Drawer discrimination while preserving schema-v1 action reads and presses
- add CLI-only flow authoring with `drawer create --kind flow`, `stage add`, and typed `flow.*` settings
- publish and verify normalized flow definitions with immutable SHA-256 metadata
- document the flow Drawer contract and add schema, CLI, publish/install, and compatibility coverage

## Verification
- `go vet ./...`
- `go test -race -count=1 ./internal/...`
- `go test -count=1 ./test/integration/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flow drawers for proactive, stage-based workflows alongside action drawers.
  * Added CLI support for creating flow drawers, adding stages, configuring flow fields, and viewing flow structure.
  * Added publishing and installation support with normalized flow definitions and integrity verification.
  * Added schema version 2 with documented action and flow drawer formats.

* **Bug Fixes**
  * Prevented unsupported action operations on flow drawers.
  * Preserved compatibility with legacy action drawers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->