### PR TITLE
[skip release] fix(ci): serialize release publishing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,9 @@
 name: Auto-release
 
-# On every push to main, tags the next minor version and runs
-# goreleaser to publish binaries + Docker image in ONE workflow.
+# On pushes to main, tags the next minor version and runs goreleaser to
+# publish binaries + Docker image in ONE workflow. Rapid pushes are
+# serialized and may be coalesced by the concurrency group below; the newest
+# queued main commit is released after the active release finishes.
 #
 # Previous approach (separate auto-release → release.yml) broke
 # because GitHub blocks cross-workflow triggering from GITHUB_TOKEN:
@@ -16,6 +18,18 @@ name: Auto-release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semver tag to recover (for example, v0.135.0)
+        required: true
+        type: string
+
+# GoReleaser updates shared mutable destinations (:latest, Homebrew, npm).
+# Never let this workflow overlap another release workflow in this repository.
+concurrency:
+  group: buttons-release
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -32,17 +46,44 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: |
-      github.actor != 'github-actions[bot]' &&
-      !contains(github.event.head_commit.message, '[skip release]')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.actor != 'github-actions[bot]' &&
+        !contains(github.event.head_commit.message, '[skip release]')
+      )
     steps:
       - name: Check out code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Manual recovery must build the existing tag, not the branch used
+          # to dispatch the workflow. Push-triggered releases use their SHA.
+          ref: ${{ inputs.tag || github.sha }}
 
       - name: Determine next version
         id: version
         run: |
+          REQUESTED_TAG="${{ inputs.tag }}"
+          if [ -n "$REQUESTED_TAG" ]; then
+            if [[ ! "$REQUESTED_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid recovery tag: $REQUESTED_TAG" >&2
+              exit 1
+            fi
+
+            TAG_SHA=$(git rev-parse --verify "refs/tags/$REQUESTED_TAG^{commit}")
+            HEAD_SHA=$(git rev-parse HEAD)
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "Recovery checkout mismatch: $REQUESTED_TAG points to $TAG_SHA, checked out $HEAD_SHA" >&2
+              exit 1
+            fi
+
+            echo "latest=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+            echo "next=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+            echo "create_tag=false" >> "$GITHUB_OUTPUT"
+            echo "Recovering existing release: $REQUESTED_TAG"
+            exit 0
+          fi
+
           LATEST=$(git tag --list 'v*' --sort=-version:refname | head -n1)
           if [ -z "$LATEST" ]; then
             NEXT="v0.1.0"
@@ -54,9 +95,11 @@ jobs:
           fi
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "create_tag=true" >> "$GITHUB_OUTPUT"
           echo "Releasing: $LATEST → $NEXT"
 
       - name: Create and push tag
+        if: steps.version.outputs.create_tag == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
     tags:
       - 'v*'
 
+# Share the same lock as auto-release.yml so an externally pushed tag cannot
+# race a main-branch or manual recovery release.
+concurrency:
+  group: buttons-release
+  cancel-in-progress: false
+
 permissions:
   contents: write   # Create the GitHub Release.
   packages: write   # Push Docker images to ghcr.io.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,7 +128,10 @@ dockers:
   # Build the linux/amd64 image from the prebuilt amd64 binary.
   # goreleaser copies the correct binary into the build context before
   # running `docker build`. The image is tagged per-arch; the manifest
-  # list below joins them into multi-arch tags (:{version}, :latest).
+  # list below joins them into multi-arch tags (:{version}, :latest). Only
+  # immutable versioned architecture tags are pushed; the rolling manifest
+  # references those same tags so another release cannot invalidate a digest
+  # between image publication and manifest creation.
   - id: buttons-amd64
     goos: linux
     goarch: amd64
@@ -136,7 +139,6 @@ dockers:
     use: buildx
     image_templates:
       - "ghcr.io/autonoco/buttons:{{ .Version }}-amd64"
-      - "ghcr.io/autonoco/buttons:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       # Disable buildx attestation manifests. Without these flags, buildx
@@ -169,7 +171,6 @@ dockers:
     use: buildx
     image_templates:
       - "ghcr.io/autonoco/buttons:{{ .Version }}-arm64"
-      - "ghcr.io/autonoco/buttons:latest-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
       # Same attestation-disable rationale as the amd64 block above.
@@ -197,8 +198,8 @@ docker_manifests:
   # Rolling :latest manifest. Updated on every release.
   - name_template: "ghcr.io/autonoco/buttons:latest"
     image_templates:
-      - "ghcr.io/autonoco/buttons:latest-amd64"
-      - "ghcr.io/autonoco/buttons:latest-arm64"
+      - "ghcr.io/autonoco/buttons:{{ .Version }}-amd64"
+      - "ghcr.io/autonoco/buttons:{{ .Version }}-arm64"
 
 checksum:
   name_template: "checksums.txt"

--- a/internal/releaseconfig/release_config_test.go
+++ b/internal/releaseconfig/release_config_test.go
@@ -1,0 +1,73 @@
+package releaseconfig
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readRepoFile(t *testing.T, path ...string) string {
+	t.Helper()
+
+	parts := append([]string{"..", ".."}, path...)
+	contents, err := os.ReadFile(filepath.Join(parts...))
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Join(path...), err)
+	}
+	return string(contents)
+}
+
+func requireContains(t *testing.T, contents, want string) {
+	t.Helper()
+	if !strings.Contains(contents, want) {
+		t.Errorf("configuration is missing %q", want)
+	}
+}
+
+func TestReleaseWorkflowsShareSerializedReleaseGroup(t *testing.T) {
+	want := "concurrency:\n  group: buttons-release\n  cancel-in-progress: false"
+
+	for _, path := range []string{"auto-release.yml", "release.yml"} {
+		t.Run(path, func(t *testing.T) {
+			contents := readRepoFile(t, ".github", "workflows", path)
+			requireContains(t, contents, want)
+		})
+	}
+}
+
+func TestAutoReleaseCanRecoverAnExistingTagWithoutCreatingANewTag(t *testing.T) {
+	contents := readRepoFile(t, ".github", "workflows", "auto-release.yml")
+
+	for _, want := range []string{
+		"workflow_dispatch:",
+		"ref: ${{ inputs.tag || github.sha }}",
+		"REQUESTED_TAG=\"${{ inputs.tag }}\"",
+		"git rev-parse --verify \"refs/tags/$REQUESTED_TAG^{commit}\"",
+		"echo \"next=$REQUESTED_TAG\" >> \"$GITHUB_OUTPUT\"",
+		"echo \"create_tag=false\" >> \"$GITHUB_OUTPUT\"",
+		"echo \"create_tag=true\" >> \"$GITHUB_OUTPUT\"",
+		"if: steps.version.outputs.create_tag == 'true'",
+	} {
+		requireContains(t, contents, want)
+	}
+}
+
+func TestRollingManifestUsesImmutableVersionedImages(t *testing.T) {
+	contents := readRepoFile(t, ".goreleaser.yaml")
+
+	for _, forbidden := range []string{
+		"ghcr.io/autonoco/buttons:latest-amd64",
+		"ghcr.io/autonoco/buttons:latest-arm64",
+	} {
+		if strings.Contains(contents, forbidden) {
+			t.Errorf("rolling manifest still depends on mutable image %q", forbidden)
+		}
+	}
+
+	rollingManifest := regexp.MustCompile(`(?s)- name_template: "ghcr\.io/autonoco/buttons:latest"\s+image_templates:\s+- "ghcr\.io/autonoco/buttons:\{\{ \.Version \}\}-amd64"\s+- "ghcr\.io/autonoco/buttons:\{\{ \.Version \}\}-arm64"`)
+	if !rollingManifest.MatchString(contents) {
+		t.Error("rolling manifest does not reference immutable versioned architecture images")
+	}
+}


### PR DESCRIPTION
## Summary

- serialize automatic, tag-triggered, and manual release publishing with a shared repository concurrency group
- add an explicit existing-tag recovery path so `v0.135.0` can be completed without creating `v0.136.0`
- build the rolling `latest` manifest from immutable versioned architecture images
- add regression coverage for serialization, recovery safety, and immutable manifest inputs

## Root cause

Two main-branch release runs overlapped. The older `v0.134.0` run overwrote the mutable `latest-amd64` and `latest-arm64` tags after the `v0.135.0` run published them. GoReleaser then rejected the `v0.135.0` rolling manifest because those tags no longer resolved to the recorded digests.

## Impact

Future releases cannot overlap their shared mutable publishing destinations. An interrupted release can be recovered from its existing tag through `workflow_dispatch`, and rolling manifests no longer depend on mutable per-architecture tags.

The PR title includes `[skip release]` intentionally: merging this workflow fix must not mint `v0.136.0` before the incomplete `v0.135.0` release is recovered.

## Validation

- `go mod verify`
- `go build ./...`
- `go vet ./...`
- `go test -race -count=1 ./internal/...`
- `go test -count=1 ./test/integration/...`
- `actionlint .github/workflows/auto-release.yml .github/workflows/release.yml`
- `goreleaser v2.17.0 check`

## Recovery after merge

```bash
gh workflow run auto-release.yml --repo autonoco/buttons --ref main -f tag=v0.135.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual release recovery with tag validation and safeguards against releasing the wrong commit.
  * Prevented overlapping release runs through coordinated concurrency controls.

* **Bug Fixes**
  * Updated Docker release manifests to reference immutable, versioned architecture images instead of mutable tags.

* **Tests**
  * Added automated checks for release recovery, concurrency alignment, and immutable image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->