### PR TITLE
Prevent tokenless agent identity creation

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -116,6 +116,14 @@ run-token (saved to agent.json).`,
 		if !slugRe.MatchString(slug) {
 			return agentConfigError("slug must be one DNS label: lowercase letters, digits and hyphens, starting alphanumeric (max 63 chars)")
 		}
+		existing, err := agent.LoadConfig()
+		if err != nil {
+			return agentRuntimeError("AGENT_KEY_ERROR", err)
+		}
+		token := enrollToken()
+		if (existing == nil || existing.DeviceSeed == "") && token == "" {
+			return agentConfigError("device not enrolled and no ENROLL_TOKEN set: run `buttons batteries set ENROLL_TOKEN <token>` (or set $BUTTONS_BAT_ENROLL_TOKEN)")
+		}
 		c, err := agent.LoadOrCreate()
 		if err != nil {
 			return agentRuntimeError("AGENT_KEY_ERROR", err)
@@ -137,7 +145,6 @@ run-token (saved to agent.json).`,
 			tunnel = c.TunnelID
 		}
 
-		token := enrollToken()
 		res, err := (&agent.Client{BaseURL: reg}).Setup(cmd.Context(), id, token, runtime.GOOS+"/"+runtime.GOARCH, agent.RegisterParams{
 			Slug:      slug,
 			TunnelID:  tunnel,

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -53,6 +53,7 @@ func runAgentSetup(t *testing.T, slug string) {
 
 func TestAgentSetupWritesWebhookConfig(t *testing.T) {
 	t.Setenv("BUTTONS_HOME", t.TempDir())
+	t.Setenv("BUTTONS_BAT_ENROLL_TOKEN", "test-enroll-token")
 	srv := fakeSetupBroker(t)
 	defer srv.Close()
 	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
@@ -74,6 +75,7 @@ func TestAgentSetupWritesWebhookConfig(t *testing.T) {
 
 func TestAgentSetupRerunKeepsWebhookConfig(t *testing.T) {
 	t.Setenv("BUTTONS_HOME", t.TempDir())
+	t.Setenv("BUTTONS_BAT_ENROLL_TOKEN", "test-enroll-token")
 	srv := fakeSetupBroker(t)
 	defer srv.Close()
 	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
@@ -90,6 +92,7 @@ func TestAgentSetupRerunKeepsWebhookConfig(t *testing.T) {
 
 	// Re-run reuses the stored tunnel, so the broker returns no run-token and
 	// the config written by the first run must survive byte for byte.
+	t.Setenv("BUTTONS_BAT_ENROLL_TOKEN", "")
 	runAgentSetup(t, "cindy")
 	after, err := os.ReadFile(path)
 	if err != nil {
@@ -97,6 +100,29 @@ func TestAgentSetupRerunKeepsWebhookConfig(t *testing.T) {
 	}
 	if !bytes.Equal(before, after) {
 		t.Fatalf("re-run rewrote webhook.json:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestAgentSetupWithoutTokenDoesNotCreateDeviceIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+	t.Setenv("BUTTONS_BAT_ENROLL_TOKEN", "")
+	srv := fakeSetupBroker(t)
+	defer srv.Close()
+	t.Setenv("BUTTONS_REGISTRY_URL", srv.URL)
+
+	agentSetupTunnel = ""
+	agentSetupCmd.SetContext(context.Background())
+	err := agentSetupCmd.RunE(agentSetupCmd, []string{"cindy"})
+	if err == nil {
+		t.Fatal("expected tokenless fresh setup to fail")
+	}
+	path, pathErr := agent.ConfigPath()
+	if pathErr != nil {
+		t.Fatalf("ConfigPath: %v", pathErr)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("tokenless setup created agent identity at %s: %v", path, statErr)
 	}
 }
 


### PR DESCRIPTION
## What changed

- preflight fresh agent setup before generating a device seed
- require a real enrollment token when no device identity exists
- preserve tokenless reruns for already registered identities
- prove a rejected fresh setup leaves no agent.json behind

## Root cause

Agent setup generated and persisted device_seed before checking whether enrollment credentials existed. A failed template update therefore left a seed-only identity on the golden image, even though registration never completed.

## Impact

Fresh tokenless setup now fails before writing identity state. Registered agents can still rerun setup without another token.

## Validation

- go test ./...
