### PR TITLE
Add first-class Bash runtime

### DIFF
--- a/.agents/skills/buttons/SKILL.md
+++ b/.agents/skills/buttons/SKILL.md
@@ -215,7 +215,7 @@ buttons create [flags]
 | `--max-response-size` | string | max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M |
 | `--method` | string | HTTP method for --url (default: GET) |
 | `--prompt` | string | prompt/instruction for the consuming agent (written to AGENTS.md) |
-| `--runtime` | string | code runtime: shell, python, node (default: shell) |
+| `--runtime` | string | code runtime: shell, bash, python, node (default: shell) |
 | `--timeout` | int | execution timeout in seconds |
 | `--url` | string | HTTP API endpoint URL (supports {{arg}} templates) |
 
@@ -611,7 +611,7 @@ Pass at press time: `--arg key=value`
 
 | Flag | Source | Runtime |
 |------|--------|--------|
-| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\|python\|node` (default: shell) |
+| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\|bash\|python\|node` (default: shell) |
 | `--code` | Inline script body (one-liners) | Same as above |
 | `-f`/`--file` | Existing script file (copied into button folder) | Detected from shebang |
 | `--url` | HTTP endpoint with `{{arg}}` templates | HTTP client |

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ By default, `buttons create <name>` scaffolds a shell button with a placeholder 
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--runtime` | | Scaffold runtime: shell, python, node (default: shell) |
+| `--runtime` | | Scaffold runtime: shell, bash, python, node (default: shell) |
 | `--code` | | Inline script body (shortcut for one-liners) |
 | `--file` | `-f` | Copy an existing script file into the button folder |
 | `--url` | | HTTP API endpoint (supports `{{arg}}` templates) |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,7 +44,7 @@ var createCmd = &cobra.Command{
 
 By default, 'buttons create <name>' scaffolds a shell button with a
 placeholder main.sh the agent can edit, then press. Use --runtime to
-scaffold a Python or Node button instead.
+scaffold a Bash, Python, or Node button instead.
 
 New buttons start with package version 1 in button.json. Registry publish uses
 that version, then auto-bumps to the next number if that immutable version
@@ -74,12 +74,13 @@ Common flags:
                         or name:enum:required:a|b|c; repeatable)
       --timeout SECS    execution timeout (default: 300)
   -d, --description S   human-readable description for 'buttons list'
-      --runtime NAME    shell | python | node  (default: shell)
+      --runtime NAME    shell | bash | python | node  (default: shell)
 
 Examples:
   buttons create deploy --arg env:enum:required:staging|prod|canary   # enum arg
   buttons create deploy                                  # scaffold, then edit main.sh
-  buttons create etl --runtime python                    # scaffold, then edit main.py
+  buttons create deploy --runtime bash                  # scaffold, then edit main.sh
+  buttons create etl --runtime python                   # scaffold, then edit main.py
   buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required
   buttons create k8s-deploy -f ./scripts/deploy.sh --arg env:string:required
   buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required
@@ -259,7 +260,7 @@ func resolveCreateTimeout(cmd *cobra.Command) int {
 func init() {
 	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "copy an existing script file into the button folder")
 	createCmd.Flags().StringVar(&createCode, "code", "", "inline script code (shortcut for one-liners)")
-	createCmd.Flags().StringVar(&createRuntime, "runtime", "", "code runtime: shell, python, node (default: shell)")
+	createCmd.Flags().StringVar(&createRuntime, "runtime", "", "code runtime: shell, bash, python, node (default: shell)")
 	createCmd.Flags().StringVar(&createURL, "url", "", "HTTP API endpoint URL (supports {{arg}} templates)")
 	createCmd.Flags().StringVar(&createMethod, "method", "", "HTTP method for --url (default: GET)")
 	createCmd.Flags().StringArrayVar(&createHeaders, "header", nil, "HTTP header as 'Key: Value' (repeatable)")

--- a/docs/buttons/cli.mdx
+++ b/docs/buttons/cli.mdx
@@ -11,7 +11,7 @@ buttons create tail-logs --code 'openclaw tail --service api --env production'
 buttons create git-status --code 'git status --short'
 ```
 
-`--code` writes the command straight into the button's `main.sh` and skips the placeholder scaffold. `--runtime` defaults to `shell`, so you don't pass it for a CLI command (it's there for `python` / `node` bodies). Press it like any other button:
+`--code` writes the command straight into the button's `main.sh` and skips the placeholder scaffold. `--runtime` defaults to `shell`, so you don't pass it for a portable CLI command; use `bash`, `python`, or `node` when the body requires that interpreter. Press it like any other button:
 
 ```bash
 buttons press git-status

--- a/docs/buttons/code.mdx
+++ b/docs/buttons/code.mdx
@@ -45,9 +45,16 @@ buttons press greet --arg name=Ada
   Args are declared at create time and stored in `button.json`. If you need to change them, delete and recreate the button — your `main.sh` is at the same path each time, so you can copy your edits over.
 </Note>
 
-## Scaffold in Python or Node
+## Scaffold in Bash, Python, or Node
 
 Pass `--runtime` to scaffold with the right shebang and extension:
+
+```bash
+buttons create deploy --runtime bash --arg env:string:required
+# → scaffolds main.sh with:
+#     #!/usr/bin/env bash
+#     set -euo pipefail
+```
 
 ```bash
 buttons create parse-json --runtime python --arg input:string:required
@@ -65,8 +72,13 @@ buttons create transform --runtime node --arg payload:string:required
 | Flag value | Interpreter used | File written |
 |---|---|---|
 | `shell` (default) | `/bin/sh` | `main.sh` |
+| `bash` | `bash` from `PATH` | `main.sh` |
 | `python` | `python3` | `main.py` |
 | `node` | `node` | `main.js` |
+
+The `bash` runtime requires Bash to be installed. If it is unavailable,
+`buttons press` returns `RUNTIME_MISSING`; Buttons does not install it
+automatically.
 
 ## Shortcuts for when you already know the code
 
@@ -95,7 +107,9 @@ buttons create deploy \
   -d "Deploy a tagged release"
 ```
 
-If the script has a shebang, the OS uses that interpreter directly — no need to pass `--runtime`. Without a shebang and without `--runtime`, Buttons defaults to `/bin/sh`.
+When importing code, Buttons infers the runtime from the file extension or
+shebang. Without a recognized extension or shebang, Buttons defaults to
+`/bin/sh`.
 
 ## Argument injection
 

--- a/docs/cli/buttons_create.md
+++ b/docs/cli/buttons_create.md
@@ -13,7 +13,7 @@ Create a new button.
 
 By default, 'buttons create `<name>`' scaffolds a shell button with a
 placeholder main.sh the agent can edit, then press. Use --runtime to
-scaffold a Python or Node button instead.
+scaffold a Bash, Python, or Node button instead.
 
 New buttons start with package version 1 in button.json. Registry publish uses
 that version, then auto-bumps to the next number if that immutable version
@@ -48,7 +48,7 @@ Common flags:
                         or name:enum:required:a|b|c; repeatable)
       --timeout SECS    execution timeout (default: 300)
   -d, --description S   human-readable description for 'buttons list'
-      --runtime NAME    shell | python | node  (default: shell)
+      --runtime NAME    shell | bash | python | node  (default: shell)
 ```
 
 **Examples:**
@@ -56,7 +56,8 @@ Common flags:
 ```bash
 buttons create deploy --arg env:enum:required:staging|prod|canary   # enum arg
 buttons create deploy                                  # scaffold, then edit main.sh
-buttons create etl --runtime python                    # scaffold, then edit main.py
+buttons create deploy --runtime bash                  # scaffold, then edit main.sh
+buttons create etl --runtime python                   # scaffold, then edit main.py
 buttons create greet --code 'echo "Hello, $BUTTONS_ARG_NAME"' --arg name:string:required
 buttons create k8s-deploy -f ./scripts/deploy.sh --arg env:string:required
 buttons create weather --url 'https://wttr.in/{{city}}?format=j1' --arg city:string:required
@@ -85,7 +86,7 @@ buttons create [name] [flags]
       --max-response-size string   max HTTP response body size for --url buttons (e.g. 10M, 1G). default: 10M
       --method string              HTTP method for --url (default: GET)
       --prompt string              prompt/instruction for the consuming agent (written to AGENTS.md)
-      --runtime string             code runtime: shell, python, node (default: shell)
+      --runtime string             code runtime: shell, bash, python, node (default: shell)
       --timeout int                execution timeout in seconds (default 300)
       --url string                 HTTP API endpoint URL (supports {{arg}} templates)
 ```

--- a/docs/concepts/button-json.mdx
+++ b/docs/concepts/button-json.mdx
@@ -51,7 +51,7 @@ Real files always carry `runtime`, `env`, `timeout_seconds`, and `mcp_enabled` e
 | `name` | Kebab-case button name. |
 | `description` | One-line description surfaced by `buttons list`, `summary`, and the board. |
 | `kind` | `""`/`"button"` for a regular button (pressed); `"app"` for an app button under `apps/` (see [App buttons](#app-buttons)). |
-| `runtime` | `shell`, `python`, or `node`. HTTP buttons (created with `--url`) carry an empty runtime and are identified by `url`; prompt-only buttons (created with `--prompt`) use `prompt`. |
+| `runtime` | `shell`, `bash`, `python`, or `node`. HTTP buttons (created with `--url`) carry an empty runtime and are identified by `url`; prompt-only buttons (created with `--prompt`) use `prompt`. |
 | `args` | Typed press-time arguments. |
 | `env` | Static environment variables injected into every press. |
 | `timeout_seconds` | Default timeout for this button. |
@@ -60,7 +60,7 @@ Real files always carry `runtime`, `env`, `timeout_seconds`, and `mcp_enabled` e
 
 ## Code buttons
 
-Code buttons use `runtime: shell`, `python`, or `node`. The script lives next to `button.json` as `main.sh`, `main.py`, or `main.js`.
+Code buttons use `runtime: shell`, `bash`, `python`, or `node`. The script lives next to `button.json` as `main.sh`, `main.py`, or `main.js`. Both shell runtimes use `main.sh`; `shell` executes it with `/bin/sh`, while `bash` resolves and executes Bash from `PATH`.
 
 Arguments arrive as environment variables:
 

--- a/docs/concepts/folder-structure.mdx
+++ b/docs/concepts/folder-structure.mdx
@@ -110,7 +110,7 @@ Commit the authored button and drawer folders — their `button.json` / `drawer.
 
 ## main.\*
 
-The script file for [code buttons](/buttons/code). The extension matches the runtime: `main.sh` for shell, `main.py` for Python, `main.js` for Node. HTTP, prompt-only, and app buttons do not have a `main.*` file.
+The script file for [code buttons](/buttons/code). The extension matches the runtime: `main.sh` for shell or Bash, `main.py` for Python, `main.js` for Node. HTTP, prompt-only, and app buttons do not have a `main.*` file.
 
 ## AGENTS.md
 

--- a/docs/concepts/json-output.mdx
+++ b/docs/concepts/json-output.mdx
@@ -59,7 +59,7 @@ The shape of `data` varies by command, but `ok` is always present, and on a fail
 | `VALIDATION_ERROR` | An argument value did not match its declared type |
 | `TIMEOUT` | The button execution exceeded its timeout |
 | `SCRIPT_ERROR` | The subprocess exited with a non-zero exit code |
-| `RUNTIME_MISSING` | The required interpreter (`python3`, `node`, etc.) is not on `$PATH` |
+| `RUNTIME_MISSING` | The required interpreter (`bash`, `python3`, `node`, etc.) is not on `$PATH` |
 | `QUEUE_TIMEOUT` | The press waited too long for a free slot in the button's concurrency queue |
 | `INTERNAL_ERROR` | An unexpected error inside the Buttons runtime |
 | `KIND_NOT_IMPLEMENTED` | A drawer step used a step kind not yet implemented in the v1 executor |

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -16,7 +16,7 @@ ghcr.io/autonoco/buttons:v0.128.0   # pinned version
 - **Runs as:** non-root user `buttons` (UID 1000), `WORKDIR /home/buttons`
 - **Entrypoint:** the `buttons` binary, so `docker run … <verb>` runs that command; bare `docker run …` defaults to `--help`
 - **Shell available:** `/bin/sh` — shell buttons work out of the box
-- **Python / Node:** not included — add via `apk add` in your derived image
+- **Bash / Python / Node:** not included — add via `apk add` in your derived image
 - **Architectures:** `linux/amd64`, `linux/arm64`
 
 ## Pattern 1: Multi-stage copy (recommended)
@@ -66,9 +66,9 @@ This lets you manage buttons on the host and invoke them from containers, or sha
 
 The mounted directory must be writable by UID 1000. If your host user has a different UID, either `chown` the directory to `1000` or add `--user "$(id -u)"` to the `docker run` invocation (combine with `-e BUTTONS_HOME=/home/buttons/.buttons` so the data dir is found regardless of that user's home).
 
-## Adding Python or Node to a derived image
+## Adding Bash, Python, or Node to a derived image
 
-Shell buttons work in the base image. For Python or Node buttons, extend the image:
+Shell buttons work in the base image. For Bash, Python, or Node buttons, extend the image:
 
 <CodeGroup>
 
@@ -87,7 +87,7 @@ RUN apk add --no-cache nodejs npm
 ```dockerfile Python + Node
 FROM ghcr.io/autonoco/buttons:v0.128.0
 
-RUN apk add --no-cache python3 py3-pip nodejs npm
+RUN apk add --no-cache bash python3 py3-pip nodejs npm
 ```
 
 </CodeGroup>

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -84,7 +84,7 @@ FROM ghcr.io/autonoco/buttons:v0.128.0
 RUN apk add --no-cache nodejs npm
 ```
 
-```dockerfile Python + Node
+```dockerfile Python + Node + Bash
 FROM ghcr.io/autonoco/buttons:v0.128.0
 
 RUN apk add --no-cache bash python3 py3-pip nodejs npm

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -46,7 +46,7 @@ FROM python:3.12-slim AS agent
 COPY --from=ghcr.io/autonoco/buttons:v0.128.0 /usr/local/bin/buttons /usr/local/bin/buttons
 ```
 
-The image is Alpine-based with `/bin/sh`, so shell buttons work out of the box. Add `python3` or `nodejs` via `apk add` in derived images when those runtimes are needed.
+The image is Alpine-based with `/bin/sh`, so shell buttons work out of the box. Bash is not included; add `bash`, `python3`, or `nodejs` via `apk add` in derived images when those runtimes are needed.
 
 <Tip>
 For one-off invocations with state persisted to the host:

--- a/docs/security/overview.mdx
+++ b/docs/security/overview.mdx
@@ -31,7 +31,7 @@ The security controls in Buttons are aimed at preventing unintended execution or
 
 ## Assumptions
 
-- **`$PATH` is trusted.** Buttons resolves `python3`, `node`, `sh`, and other interpreters by name. If an attacker can modify `$PATH`, they can substitute a malicious interpreter.
+- **`$PATH` is trusted.** Buttons resolves `bash`, `python3`, `node`, and other non-POSIX interpreters by name. If an attacker can modify `$PATH`, they can substitute a malicious interpreter.
 - **`~/.buttons/` is user-private.** The directory is created with mode `0700`. On shared systems, confirm your `umask` does not override this.
 - **The button creator is trusted.** Buttons does not distinguish between a button you created and one an agent created on your behalf. Both execute with your permissions.
 

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -138,6 +138,8 @@ type ArgDef struct {
 // ExtForRuntime returns the code file extension for a given runtime.
 func ExtForRuntime(runtime string) string {
 	switch runtime {
+	case "bash":
+		return ".sh"
 	case "python", "python3":
 		return ".py"
 	case "node", "javascript", "js":

--- a/internal/button/entity.go
+++ b/internal/button/entity.go
@@ -153,6 +153,8 @@ func ExtForRuntime(runtime string) string {
 // put the real implementation.
 func scaffoldFor(runtime string) string {
 	switch runtime {
+	case "bash":
+		return "#!/usr/bin/env bash\nset -euo pipefail\n\n# TODO: add your command here\n# Args arrive as $BUTTONS_ARG_<NAME>\n"
 	case "python", "python3":
 		return "#!/usr/bin/env python3\n# TODO: add your code here\n# Args arrive as os.environ[\"BUTTONS_ARG_<NAME>\"]\n"
 	case "node", "javascript", "js":

--- a/internal/button/service_test.go
+++ b/internal/button/service_test.go
@@ -135,6 +135,32 @@ func TestService_Create_ScaffoldNoSource(t *testing.T) {
 	}
 }
 
+func TestService_Create_BashScaffold(t *testing.T) {
+	home := setupTestEnv(t)
+	svc := NewService()
+
+	btn, err := svc.Create(CreateOpts{
+		Name:           "bash-script",
+		Runtime:        "bash",
+		TimeoutSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("bash scaffold create failed: %v", err)
+	}
+	if btn.Runtime != "bash" {
+		t.Fatalf("runtime = %q, want bash", btn.Runtime)
+	}
+
+	codePath := filepath.Join(home, "buttons", "bash-script", "main.sh")
+	data, err := os.ReadFile(codePath)
+	if err != nil {
+		t.Fatalf("bash scaffold not found: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "#!/usr/bin/env bash\n") {
+		t.Fatalf("bash scaffold = %q, want bash shebang", data)
+	}
+}
+
 func TestService_Create_CustomTimeout(t *testing.T) {
 	home := setupTestEnv(t)
 	script := createTestScript(t, home)

--- a/internal/engine/execute.go
+++ b/internal/engine/execute.go
@@ -69,11 +69,11 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 	}
 
 	// #nosec G204 -- `interpreter` is whitelisted by interpreterForRuntime() which
-	// only returns /bin/sh, a resolved python3/python, or a resolved node — never
-	// a user-supplied string. `codePath` is inside the button's own folder under
-	// ButtonsDir and is not influenced by button args at press time. Args reach the
-	// script exclusively via BUTTONS_ARG_* env vars (see cmd.Env below), so there
-	// is no string interpolation into a shell command.
+	// only returns /bin/sh or a resolved bash, python3/python, or node — never a
+	// user-supplied string. `codePath` is inside the button's own folder under
+	// ButtonsDir and is not influenced by button args at press time. Args reach
+	// the script exclusively via BUTTONS_ARG_* env vars (see cmd.Env below), so
+	// there is no string interpolation into a shell command.
 	cmd := exec.Command(interpreter, codePath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
@@ -187,8 +187,13 @@ func Execute(ctx context.Context, btn *button.Button, args, batteries map[string
 // interpreterForRuntime maps a runtime name to the interpreter binary path.
 func interpreterForRuntime(runtime string) (string, error) {
 	switch runtime {
-	case "shell", "sh", "bash", "":
+	case "shell", "sh", "":
 		return "/bin/sh", nil
+	case "bash":
+		if path, err := exec.LookPath("bash"); err == nil {
+			return path, nil
+		}
+		return "", fmt.Errorf("bash not found on PATH")
 	case "python", "python3":
 		if path, err := exec.LookPath("python3"); err == nil {
 			return path, nil

--- a/internal/engine/execute_test.go
+++ b/internal/engine/execute_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,33 @@ import (
 
 	"github.com/autonoco/buttons/internal/button"
 )
+
+func TestInterpreterForRuntimeBash(t *testing.T) {
+	want, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is not installed")
+	}
+
+	got, err := interpreterForRuntime("bash")
+	if err != nil {
+		t.Fatalf("interpreterForRuntime(bash): %v", err)
+	}
+	if got != want {
+		t.Fatalf("interpreter = %q, want resolved bash path %q", got, want)
+	}
+}
+
+func TestInterpreterForRuntimeBashMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := interpreterForRuntime("bash")
+	if err == nil {
+		t.Fatal("expected missing bash to return an error")
+	}
+	if !strings.Contains(err.Error(), "bash not found") {
+		t.Fatalf("error = %q, want bash not found", err)
+	}
+}
 
 // TestExecute_BatteriesInjectedAsEnv verifies the caller-provided
 // batteries map lands on the child process as BUTTONS_BAT_<KEY>. This

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -175,7 +175,7 @@ func PlanURL(url, nameOverride string) (*Plan, error) {
 	}}}, nil
 }
 
-// inferRuntime maps a script to a supported runtime (shell|python|node) by
+// inferRuntime maps a script to a supported runtime (shell|bash|python|node) by
 // extension first, then shebang, defaulting to shell.
 func inferRuntime(path, content string) string {
 	switch strings.ToLower(filepath.Ext(path)) {
@@ -183,7 +183,9 @@ func inferRuntime(path, content string) string {
 		return "python"
 	case ".js", ".mjs", ".cjs":
 		return "node"
-	case ".sh", ".bash":
+	case ".bash":
+		return "bash"
+	case ".sh":
 		return "shell"
 	}
 	first := content
@@ -196,6 +198,8 @@ func inferRuntime(path, content string) string {
 		return "python"
 	case strings.Contains(first, "node"):
 		return "node"
+	case strings.Contains(first, "bash"):
+		return "bash"
 	default:
 		return "shell"
 	}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -33,6 +33,30 @@ func TestPlanCodeInfersRuntime(t *testing.T) {
 	if plan.Items[0].Runtime != "node" || plan.Items[0].Name != "tool" {
 		t.Fatalf("shebang/override failed: %+v", plan.Items[0])
 	}
+
+	bash := filepath.Join(dir, "release.bash")
+	if err := os.WriteFile(bash, []byte("#!/usr/bin/env bash\necho release\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err = PlanCode(bash, "")
+	if err != nil {
+		t.Fatalf("plan bash: %v", err)
+	}
+	if plan.Items[0].Runtime != "bash" {
+		t.Fatalf(".bash runtime = %q, want bash", plan.Items[0].Runtime)
+	}
+
+	bashNoExt := filepath.Join(dir, "release-script")
+	if err := os.WriteFile(bashNoExt, []byte("#!/usr/bin/env bash\necho release\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan, err = PlanCode(bashNoExt, "")
+	if err != nil {
+		t.Fatalf("plan extensionless bash: %v", err)
+	}
+	if plan.Items[0].Runtime != "bash" {
+		t.Fatalf("bash shebang runtime = %q, want bash", plan.Items[0].Runtime)
+	}
 }
 
 func TestPlanCodeApplyCreatesFunctionalButton(t *testing.T) {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -135,6 +135,23 @@ func TestCreateGatedByFlag(t *testing.T) {
 	}
 }
 
+func TestCreateRuntimeSchemaIncludesBash(t *testing.T) {
+	s := New(Config{AllowCreate: true})
+	defs := s.toolDefs()
+	create := defs[len(defs)-1]
+	schema := create["inputSchema"].(map[string]any)
+	properties := schema["properties"].(map[string]any)
+	runtime := properties["runtime"].(map[string]any)
+	values := runtime["enum"].([]string)
+
+	for _, value := range values {
+		if value == "bash" {
+			return
+		}
+	}
+	t.Fatalf("runtime enum = %v, want bash", values)
+}
+
 // TestServeWire drives the full stdio loop with newline-delimited JSON-RPC and
 // checks initialize + tools/list responses come back id-matched.
 func TestServeWire(t *testing.T) {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -54,7 +54,7 @@ func (s *Server) toolDefs() []map[string]any {
 				"type": "object",
 				"properties": map[string]any{
 					"name":        map[string]any{"type": "string"},
-					"runtime":     map[string]any{"type": "string", "enum": []string{"shell", "python", "node"}},
+					"runtime":     map[string]any{"type": "string", "enum": []string{"shell", "bash", "python", "node"}},
 					"code":        map[string]any{"type": "string"},
 					"description": map[string]any{"type": "string"},
 				},

--- a/internal/tools/skillgen/main.go
+++ b/internal/tools/skillgen/main.go
@@ -139,7 +139,7 @@ func writeSkill(b *strings.Builder, root *cobra.Command) {
 	b.WriteString("`buttons create <name>` scaffolds a shell button with a placeholder `main.sh` the agent edits, then presses. Use a shortcut flag to skip the scaffold:\n\n")
 	b.WriteString("| Flag | Source | Runtime |\n")
 	b.WriteString("|------|--------|--------|\n")
-	b.WriteString("| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\\|python\\|node` (default: shell) |\n")
+	b.WriteString("| (none) | Scaffold `main.<ext>` with shebang + TODO | `--runtime shell\\|bash\\|python\\|node` (default: shell) |\n")
 	b.WriteString("| `--code` | Inline script body (one-liners) | Same as above |\n")
 	b.WriteString("| `-f`/`--file` | Existing script file (copied into button folder) | Detected from shebang |\n")
 	b.WriteString("| `--url` | HTTP endpoint with `{{arg}}` templates | HTTP client |\n")


### PR DESCRIPTION
## Summary

- execute `runtime: bash` buttons with Bash resolved from `PATH` instead of silently routing them through `/bin/sh`
- generate Bash-specific scaffolds with `#!/usr/bin/env bash` and `set -euo pipefail`
- infer Bash from `.bash` files and Bash shebangs
- advertise Bash through the existing CLI runtime option and MCP creation schema
- document Linux and Alpine availability requirements

## Root cause

Buttons accepted and persisted `runtime: bash`, but `interpreterForRuntime` grouped `bash` with `shell` and always returned `/bin/sh`. This made Bash buttons appear supported while executing under different POSIX shell implementations across macOS and Linux. On Ubuntu runners, Bash-specific syntax consequently failed under `dash`.

`runtime: shell` remains intentionally portable and continues to execute through `/bin/sh`. Bash buttons now fail with the existing `RUNTIME_MISSING` error when Bash is not installed.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- end-to-end Bash-only array smoke test through `buttons create --runtime bash` and `buttons press`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bash as a supported runtime for creating and running code buttons.
  * Bash buttons now generate dedicated scripts and resolve Bash from the system path.
  * Code imports can automatically detect Bash from file extensions or shebangs.
  * MCP button creation now accepts Bash as a runtime option.

* **Documentation**
  * Updated CLI, runtime, deployment, installation, security, and error guidance for Bash support.
  * Clarified behavior when Bash is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->