### PR TITLE
Add buttons remove + add --no-refresh (fleet converge primitives)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var addNoRefresh bool
+
 var addCmd = &cobra.Command{
 	Use:   "add @desk/name[@version]",
 	Short: "Add a registry package dependency",
@@ -23,12 +25,17 @@ Bare package names are not supported in the MVP. Use scoped names like
 declares its kind. Omit @version to track latest; include @version to pin an
 exact immutable version.
 
+By default, add re-resolves every floating "latest" dependency against the
+registry while installing. Pass --no-refresh to install only the new package
+and keep other floating dependencies at their locked versions.
+
 Examples:
   buttons add @your-desk/hello
-  buttons add @your-desk/hello@1`,
+  buttons add @your-desk/hello@1
+  buttons add @your-desk/hello@1 --no-refresh`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		res, name, requested, err := runAdd(context.Background(), args[0])
+		res, name, requested, err := runAdd(context.Background(), args[0], !addNoRefresh)
 		if err != nil {
 			if jsonOutput {
 				_ = config.WriteJSONError("ADD_ERROR", err.Error())
@@ -61,7 +68,7 @@ Examples:
 	},
 }
 
-func runAdd(ctx context.Context, spec string) (*store.Result, string, string, error) {
+func runAdd(ctx context.Context, spec string, refreshFloating bool) (*store.Result, string, string, error) {
 	_ = ctx
 	name, requested, err := manifest.ParsePackageSpec(spec)
 	if err != nil {
@@ -90,7 +97,7 @@ func runAdd(ctx context.Context, spec string) (*store.Result, string, string, er
 	if err != nil {
 		return nil, "", "", err
 	}
-	res, next, err := store.InstallManifest(src, m, lock, store.InstallOptions{RefreshFloating: true})
+	res, next, err := store.InstallManifest(src, m, lock, store.InstallOptions{RefreshFloating: refreshFloating})
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -105,5 +112,6 @@ func runAdd(ctx context.Context, spec string) (*store.Result, string, string, er
 }
 
 func init() {
+	addCmd.Flags().BoolVar(&addNoRefresh, "no-refresh", false, "keep other floating (latest) dependencies at their locked versions")
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/manifest"
+)
+
+const testRegistryKey = "test-key"
+
+// testRegistry mocks the registry Worker for cmd-level add/remove tests:
+// /v1/index plus the bearer-gated download route, with x-content-sha256 set
+// like the real Worker. Entries and tarballs can grow mid-test (publishing a
+// new version) so floating-refresh behavior is observable.
+type testRegistry struct {
+	mu       sync.Mutex
+	entries  []map[string]any
+	tarballs map[string][]byte // "@desk/name@version" → tarball
+	srv      *httptest.Server
+}
+
+func newTestRegistry(t *testing.T) *testRegistry {
+	t.Helper()
+	reg := &testRegistry{tarballs: map[string][]byte{}}
+	reg.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+testRegistryKey {
+			http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"valid Bearer key required"}}`, http.StatusUnauthorized)
+			return
+		}
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		switch {
+		case r.URL.Path == "/v1/index":
+			_ = json.NewEncoder(w).Encode(reg.entries)
+		case strings.HasPrefix(r.URL.Path, "/v1/buttons/") && strings.HasSuffix(r.URL.Path, "/download"):
+			mid := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/buttons/"), "/download")
+			i := strings.LastIndex(mid, "/") // split name / version on the last slash
+			tb, ok := reg.tarballs[mid[:i]+"@"+mid[i+1:]]
+			if !ok {
+				http.Error(w, `{"error":{"code":"NOT_FOUND","message":"no button"}}`, http.StatusNotFound)
+				return
+			}
+			w.Header().Set("X-Content-Sha256", testSHA256(tb))
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(tb)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(reg.srv.Close)
+	t.Setenv("BUTTONS_REGISTRY_URL", reg.srv.URL)
+	t.Setenv("BUTTONS_BAT_REGISTRY_KEY", testRegistryKey)
+	return reg
+}
+
+// publishButton adds a shell button version to the mock registry index.
+func (reg *testRegistry) publishButton(t *testing.T, name, version string, requires map[string]string) {
+	t.Helper()
+	local := name[strings.LastIndex(name, "/")+1:]
+	spec := button.Button{SchemaVersion: 1, Name: local, Runtime: "shell", Version: version, Requires: requires}
+	data, err := json.MarshalIndent(&spec, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tb := testTarball(t, local, map[string][]byte{
+		"button.json": data,
+		"main.sh":     []byte("#!/bin/sh\necho " + local + "\n"),
+	})
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.tarballs[name+"@"+version] = tb
+	reg.entries = append(reg.entries, map[string]any{"name": name, "kind": "button", "version": version, "sha256": testSHA256(tb)})
+}
+
+// testTarball builds a gz tarball wrapping files under <folder>/ — the layout
+// tools/publish.mjs produces (the on-disk button folder name is the wrapper).
+func testTarball(t *testing.T, folder string, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: folder + "/", Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if err := tw.WriteHeader(&tar.Header{Name: folder + "/" + name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func testSHA256(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+func TestRunAddRefreshFloating(t *testing.T) {
+	cases := []struct {
+		name            string
+		refreshFloating bool // what --no-refresh toggles off
+		wantHello       string
+	}{
+		{name: "no-refresh keeps floating deps at locked versions", refreshFloating: false, wantHello: "1"},
+		{name: "default refresh re-resolves floating deps", refreshFloating: true, wantHello: "2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BUTTONS_HOME", t.TempDir())
+			reg := newTestRegistry(t)
+			reg.publishButton(t, "@autono/hello", "1", nil)
+			if _, _, _, err := runAdd(context.Background(), "@autono/hello", true); err != nil {
+				t.Fatalf("add hello: %v", err)
+			}
+			reg.publishButton(t, "@autono/hello", "2", nil) // a newer floating candidate
+			reg.publishButton(t, "@autono/pinned", "1", nil)
+
+			if _, _, _, err := runAdd(context.Background(), "@autono/pinned@1", tc.refreshFloating); err != nil {
+				t.Fatalf("add pinned: %v", err)
+			}
+
+			lock, err := manifest.LoadLockfile()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := lock.Dependencies["@autono/hello"].Version; got != tc.wantHello {
+				t.Fatalf("hello locked version = %q, want %q", got, tc.wantHello)
+			}
+			if got := lock.Dependencies["@autono/pinned"].Version; got != "1" {
+				t.Fatalf("pinned locked version = %q, want 1", got)
+			}
+		})
+	}
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/manifest"
+	"github.com/autonoco/buttons/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove @desk/name",
+	Short: "Remove a registry package dependency",
+	Long: `Remove a registry package dependency added with 'buttons add'.
+
+Remove drops the dependency from .buttons/buttons.json, deletes the
+installed package directory, and cleans .buttons/buttons-lock.json. Only
+directories the installer materialized (stamped with install state) are
+deleted; a package another installed package still requires keeps its
+files until its last dependent is removed too.
+
+Use 'buttons delete' to delete a locally created button.
+
+Examples:
+  buttons remove @your-desk/hello
+  buttons remove @your-desk/hello --json`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeDependencyNames,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, name, err := runRemove(context.Background(), args[0])
+		if err != nil {
+			if jsonOutput {
+				_ = config.WriteJSONError("REMOVE_ERROR", err.Error())
+				return errSilent
+			}
+			return err
+		}
+		agentsMdAction := updateProjectAgentsMD(button.NewService())
+
+		if jsonOutput {
+			out := map[string]any{
+				"name":    name,
+				"removed": res.Removed,
+			}
+			if len(res.Kept) > 0 {
+				out["kept"] = res.Kept
+			}
+			if agentsMdAction != "" {
+				out["agents_md"] = agentsMdAction
+			}
+			return config.WriteJSON(out)
+		}
+		fmt.Fprintf(os.Stderr, "Removed %s\n", name)
+		if len(res.Removed) > 0 {
+			fmt.Fprintf(os.Stderr, "Deleted %d package item(s): %s\n", len(res.Removed), strings.Join(res.Removed, ", "))
+		}
+		if len(res.Kept) > 0 {
+			fmt.Fprintf(os.Stderr, "Kept %d package item(s) still in use: %s\n", len(res.Kept), strings.Join(res.Kept, ", "))
+		}
+		if agentsMdAction != "" {
+			fmt.Fprintf(os.Stderr, "  AGENTS.md button list %s\n", agentsMdAction)
+		}
+		printNextHint("buttons list")
+		return nil
+	},
+}
+
+func runRemove(ctx context.Context, spec string) (*store.UninstallResult, string, error) {
+	_ = ctx
+	if !strings.HasPrefix(spec, "@") {
+		return nil, "", fmt.Errorf("%q is not a scoped package name: registry dependencies look like @desk/name; use `buttons delete %s` for a local button", spec, spec)
+	}
+	name, _, err := manifest.ParsePackageSpec(spec)
+	if err != nil {
+		return nil, "", err
+	}
+	m, err := manifest.Load()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, "", fmt.Errorf("no .buttons/buttons.json found: nothing to remove")
+		}
+		return nil, "", err
+	}
+	requested, ok := m.Dependencies[name]
+	if !ok {
+		return nil, "", fmt.Errorf("%s is not a dependency in .buttons/buttons.json", name)
+	}
+	delete(m.Dependencies, name)
+	lock, err := manifest.LoadLockfile()
+	if err != nil {
+		return nil, "", err
+	}
+	res, err := store.Uninstall(lock, name)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := manifest.Save(m); err != nil {
+		return nil, "", err
+	}
+	if err := manifest.SaveLockfile(lock); err != nil {
+		return nil, "", err
+	}
+	recordLifecycleHistory("remove", name, requested, res.Removed, lock)
+	return res, name, nil
+}
+
+// completeDependencyNames completes the scoped package names declared in
+// .buttons/buttons.json — the only valid arguments for `buttons remove`.
+func completeDependencyNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	m, err := manifest.Load()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(m.Dependencies))
+	for name := range m.Dependencies {
+		if strings.HasPrefix(name, toComplete) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func init() {
+	rootCmd.AddCommand(removeCmd)
+}

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/manifest"
+	"github.com/autonoco/buttons/internal/store"
+)
+
+func assertStringSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
+	}
+}
+
+func TestRunRemove(t *testing.T) {
+	cases := []struct {
+		name          string
+		remove        string
+		helloRequires map[string]string // requires stamped on @autono/hello
+		wantErr       string
+		wantRemoved   []string
+		wantKept      []string
+	}{
+		{
+			name:        "removes dep, its dir, and lock entry",
+			remove:      "@autono/hello",
+			wantRemoved: []string{"hello"},
+		},
+		{
+			name:          "keeps package another dep still requires",
+			remove:        "@autono/other",
+			helloRequires: map[string]string{"@autono/other": "latest"},
+			wantKept:      []string{"other"},
+		},
+		{
+			name:    "errors for a package not in the manifest",
+			remove:  "@autono/ghost",
+			wantErr: "not a dependency",
+		},
+		{
+			name:    "suggests delete for unscoped local names",
+			remove:  "hello",
+			wantErr: "buttons delete hello",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("BUTTONS_HOME", home)
+			reg := newTestRegistry(t)
+			reg.publishButton(t, "@autono/hello", "1", tc.helloRequires)
+			reg.publishButton(t, "@autono/other", "1", nil)
+			for _, spec := range []string{"@autono/hello", "@autono/other"} {
+				if _, _, _, err := runAdd(context.Background(), spec, true); err != nil {
+					t.Fatalf("add %s: %v", spec, err)
+				}
+			}
+
+			res, name, err := runRemove(context.Background(), tc.remove)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("runRemove(%q) error = %v, want it to contain %q", tc.remove, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("runRemove(%q): %v", tc.remove, err)
+			}
+			if name != tc.remove {
+				t.Fatalf("name = %q, want %q", name, tc.remove)
+			}
+			assertStringSlice(t, "removed", res.Removed, tc.wantRemoved)
+			assertStringSlice(t, "kept", res.Kept, tc.wantKept)
+
+			m, err := manifest.Load()
+			if err != nil {
+				t.Fatalf("load manifest: %v", err)
+			}
+			if _, ok := m.Dependencies[tc.remove]; ok {
+				t.Fatalf("manifest still lists %s", tc.remove)
+			}
+			lock, err := manifest.LoadLockfile()
+			if err != nil {
+				t.Fatalf("load lockfile: %v", err)
+			}
+			local := tc.remove[strings.LastIndex(tc.remove, "/")+1:]
+			removedDir := filepath.Join(home, "buttons", local)
+			if len(tc.wantRemoved) > 0 {
+				if _, ok := lock.Dependencies[tc.remove]; ok {
+					t.Fatalf("lock still lists %s", tc.remove)
+				}
+				if _, err := os.Stat(removedDir); !os.IsNotExist(err) {
+					t.Fatalf("dir %s should be gone, stat err = %v", removedDir, err)
+				}
+			}
+			if len(tc.wantKept) > 0 {
+				if _, ok := lock.Dependencies[tc.remove]; !ok {
+					t.Fatalf("lock entry for still-required %s should remain", tc.remove)
+				}
+				if _, err := os.Stat(filepath.Join(removedDir, "button.json")); err != nil {
+					t.Fatalf("still-required package files should remain: %v", err)
+				}
+			}
+
+			// The other dependency is untouched.
+			other := "@autono/other"
+			if tc.remove == other {
+				other = "@autono/hello"
+			}
+			if _, ok := m.Dependencies[other]; !ok {
+				t.Fatalf("manifest lost %s", other)
+			}
+			if _, ok := lock.Dependencies[other]; !ok {
+				t.Fatalf("lock lost %s", other)
+			}
+			otherDir := filepath.Join(home, "buttons", other[strings.LastIndex(other, "/")+1:])
+			for _, f := range []string{"button.json", "main.sh", store.InstallStateFile} {
+				if _, err := os.Stat(filepath.Join(otherDir, f)); err != nil {
+					t.Fatalf("other dep file %s missing: %v", f, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/store/uninstall.go
+++ b/internal/store/uninstall.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/config"
+	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/manifest"
+)
+
+// UninstallResult reports what Uninstall changed on disk.
+type UninstallResult struct {
+	// Removed lists installed names whose materialized dirs were deleted.
+	Removed []string `json:"removed"`
+	// Kept lists installed names left on disk — either another locked
+	// package still requires them, or the dir has no install state (it was
+	// not materialized by the installer, so we refuse to delete it).
+	Kept []string `json:"kept,omitempty"`
+}
+
+// Uninstall reverses what InstallManifest materialized for one package: it
+// deletes the package's button/drawer dir and drops its lock entry. It only
+// deletes dirs stamped with install state (written by the installer) — a dir
+// without one is never touched. A package another locked package still
+// requires keeps both its files and its lock entry; it remains a live
+// transitive dependency until its last dependent is removed. Transitive
+// dependencies of the removed package are not cascaded; the next full
+// install rebuilds the lock from the manifest and drops orphaned entries.
+func Uninstall(lock *manifest.Lockfile, name string) (*UninstallResult, error) {
+	if lock == nil {
+		return nil, fmt.Errorf("lockfile is required")
+	}
+	if err := manifest.ValidatePackageName(name); err != nil {
+		return nil, err
+	}
+	res := &UninstallResult{Removed: []string{}}
+	entry, ok := lock.Dependencies[name]
+	if !ok {
+		return res, nil // never installed; nothing materialized to delete
+	}
+	if dependents := lockDependents(lock, name); len(dependents) > 0 {
+		res.Kept = append(res.Kept, entry.InstalledName)
+		return res, nil
+	}
+	dir, err := packageDir(entry.Kind, button.Slugify(entry.InstalledName))
+	if err != nil {
+		return nil, err
+	}
+	delete(lock.Dependencies, name)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return res, nil // nothing materialized on disk
+		}
+		return nil, fmt.Errorf("stat %s: %w", dir, err)
+	}
+	if _, err := ReadInstallState(dir); err != nil {
+		// No install state means the installer did not materialize this
+		// dir — never delete files install state does not record.
+		res.Kept = append(res.Kept, entry.InstalledName)
+		return res, nil
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return nil, fmt.Errorf("remove %s: %w", dir, err)
+	}
+	res.Removed = append(res.Removed, entry.InstalledName)
+	return res, nil
+}
+
+func packageDir(kind, localName string) (string, error) {
+	switch kind {
+	case "button":
+		return config.ButtonDir(localName)
+	case "drawer":
+		return config.DrawerDir(localName)
+	default:
+		return "", fmt.Errorf("uninstalling kind %q is not implemented", kind)
+	}
+}
+
+// lockDependents returns the other locked packages that still require pkg,
+// read from their installed specs on disk. Best-effort: a package whose
+// installed spec is missing or unreadable contributes no requirements.
+func lockDependents(lock *manifest.Lockfile, pkg string) []string {
+	names := make([]string, 0, len(lock.Dependencies))
+	for name := range lock.Dependencies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var dependents []string
+	for _, name := range names {
+		if name == pkg {
+			continue
+		}
+		for _, dep := range installedRequires(name, lock.Dependencies[name]) {
+			if dep == pkg {
+				dependents = append(dependents, name)
+				break
+			}
+		}
+	}
+	return dependents
+}
+
+// installedRequires returns the package dependencies recorded in the
+// installed spec (button.json / drawer.json) of one locked package.
+func installedRequires(name string, entry manifest.LockEntry) []string {
+	dir, err := packageDir(entry.Kind, button.Slugify(entry.InstalledName))
+	if err != nil {
+		return nil
+	}
+	switch entry.Kind {
+	case "button":
+		data, err := os.ReadFile(filepath.Join(dir, "button.json")) // #nosec G304 -- dir is resolved under the Buttons data dir.
+		if err != nil {
+			return nil
+		}
+		var spec button.Button
+		if err := json.Unmarshal(data, &spec); err != nil {
+			return nil
+		}
+		deps := make([]string, 0, len(spec.Requires))
+		for dep := range spec.Requires {
+			deps = append(deps, dep)
+		}
+		sort.Strings(deps)
+		return deps
+	case "drawer":
+		data, err := os.ReadFile(filepath.Join(dir, "drawer.json")) // #nosec G304 -- dir is resolved under the Buttons data dir.
+		if err != nil {
+			return nil
+		}
+		var spec drawer.Drawer
+		if err := json.Unmarshal(data, &spec); err != nil {
+			return nil
+		}
+		deps, err := drawerPackageDependencies(name, &spec)
+		if err != nil {
+			return nil
+		}
+		return deps
+	}
+	return nil
+}

--- a/internal/store/uninstall_test.go
+++ b/internal/store/uninstall_test.go
@@ -1,0 +1,200 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autonoco/buttons/internal/button"
+	"github.com/autonoco/buttons/internal/drawer"
+	"github.com/autonoco/buttons/internal/manifest"
+)
+
+func assertStrings(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	cases := []struct {
+		name          string
+		remove        string
+		alphaRequires map[string]string
+		tamper        func(t *testing.T, home string)
+		wantRemoved   []string
+		wantKept      []string
+		wantLockEntry bool // lock still has the removed package afterwards
+		wantDir       bool // the package dir still exists afterwards
+	}{
+		{
+			name:        "removes package dir and lock entry",
+			remove:      "@autono/alpha",
+			wantRemoved: []string{"alpha"},
+		},
+		{
+			name:          "keeps package another locked package still requires",
+			remove:        "@autono/beta",
+			alphaRequires: map[string]string{"@autono/beta": "latest"},
+			wantKept:      []string{"beta"},
+			wantLockEntry: true,
+			wantDir:       true,
+		},
+		{
+			name:   "never deletes a dir without install state",
+			remove: "@autono/alpha",
+			tamper: func(t *testing.T, home string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(home, "buttons", "alpha", InstallStateFile)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantKept: []string{"alpha"},
+			wantDir:  true,
+		},
+		{
+			name:   "no-op for a package that was never installed",
+			remove: "@autono/ghost",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("BUTTONS_HOME", home)
+
+			alpha := sourceBundle(t, "@autono/alpha", button.Button{
+				SchemaVersion: 1,
+				Name:          "alpha",
+				Runtime:       "shell",
+				Version:       "1",
+				Requires:      tc.alphaRequires,
+			}, "#!/bin/sh\necho alpha\n")
+			beta := sourceBundle(t, "@autono/beta", button.Button{
+				SchemaVersion: 1,
+				Name:          "beta",
+				Runtime:       "shell",
+				Version:       "2",
+			}, "#!/bin/sh\necho beta\n")
+			src := memorySource{
+				refs: []ButtonRef{
+					{Name: "@autono/alpha", Kind: "button", Version: "1"},
+					{Name: "@autono/beta", Kind: "button", Version: "2"},
+				},
+				bundles: map[string]*Bundle{
+					"@autono/alpha@1": alpha,
+					"@autono/beta@2":  beta,
+				},
+			}
+			m := &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{
+				"@autono/alpha": "latest",
+				"@autono/beta":  "latest",
+			}}
+			_, lock, err := InstallManifest(src, m, nil, InstallOptions{RefreshFloating: true})
+			if err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			if tc.tamper != nil {
+				tc.tamper(t, home)
+			}
+
+			res, err := Uninstall(lock, tc.remove)
+			if err != nil {
+				t.Fatalf("Uninstall(%q): %v", tc.remove, err)
+			}
+			assertStrings(t, "removed", res.Removed, tc.wantRemoved)
+			assertStrings(t, "kept", res.Kept, tc.wantKept)
+
+			if _, ok := lock.Dependencies[tc.remove]; ok != tc.wantLockEntry {
+				t.Fatalf("lock entry present = %v, want %v", ok, tc.wantLockEntry)
+			}
+			local := tc.remove[strings.LastIndex(tc.remove, "/")+1:]
+			dir := filepath.Join(home, "buttons", local)
+			if _, err := os.Stat(dir); (err == nil) != tc.wantDir {
+				t.Fatalf("dir exists = %v (stat err %v), want %v", err == nil, err, tc.wantDir)
+			}
+			if tc.wantDir {
+				for _, f := range []string{"button.json", "main.sh"} {
+					if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+						t.Fatalf("kept package file %s missing: %v", f, err)
+					}
+				}
+			}
+
+			// Every package not named in the call is untouched.
+			for pkg, localName := range map[string]string{"@autono/alpha": "alpha", "@autono/beta": "beta"} {
+				if pkg == tc.remove {
+					continue
+				}
+				if _, ok := lock.Dependencies[pkg]; !ok {
+					t.Fatalf("lock lost %s", pkg)
+				}
+				otherDir := filepath.Join(home, "buttons", localName)
+				for _, f := range []string{"button.json", "main.sh", InstallStateFile} {
+					if _, err := os.Stat(filepath.Join(otherDir, f)); err != nil {
+						t.Fatalf("%s file %s missing: %v", pkg, f, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUninstallDrawerPackageKeepsMemberButtons(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BUTTONS_HOME", home)
+
+	pack := drawerBundle(t, "@autono/deploy-pack", drawer.Drawer{
+		SchemaVersion: drawer.SchemaVersion,
+		Name:          "deploy-pack",
+		Version:       "1",
+		Steps:         []drawer.Step{{ID: "build", Kind: "button", Button: "build"}},
+	})
+	build := sourceBundle(t, "@autono/build", button.Button{
+		SchemaVersion: 1,
+		Name:          "build",
+		Runtime:       "shell",
+		Version:       "1",
+	}, "#!/bin/sh\necho build\n")
+	src := memorySource{
+		refs: []ButtonRef{
+			{Name: "@autono/deploy-pack", Kind: "drawer", Version: "1"},
+			{Name: "@autono/build", Kind: "button", Version: "1"},
+		},
+		bundles: map[string]*Bundle{
+			"@autono/deploy-pack@1": pack,
+			"@autono/build@1":       build,
+		},
+	}
+	m := &manifest.Manifest{SchemaVersion: 1, Dependencies: map[string]string{"@autono/deploy-pack": "latest"}}
+	_, lock, err := InstallManifest(src, m, nil, InstallOptions{RefreshFloating: true})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	res, err := Uninstall(lock, "@autono/deploy-pack")
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	assertStrings(t, "removed", res.Removed, []string{"deploy-pack"})
+	if _, ok := lock.Dependencies["@autono/deploy-pack"]; ok {
+		t.Fatal("lock still lists @autono/deploy-pack")
+	}
+	if _, err := os.Stat(filepath.Join(home, "drawers", "deploy-pack")); !os.IsNotExist(err) {
+		t.Fatalf("drawer dir should be gone, stat err = %v", err)
+	}
+	// Member buttons are transitive deps; uninstall does not cascade — the
+	// next full install rebuilds the lock from the manifest and drops orphans.
+	if _, err := os.Stat(filepath.Join(home, "buttons", "build", "button.json")); err != nil {
+		t.Fatalf("member button should remain installed: %v", err)
+	}
+	if _, ok := lock.Dependencies["@autono/build"]; !ok {
+		t.Fatal("member button lock entry should remain")
+	}
+}


### PR DESCRIPTION
The inverse of `buttons add`, needed by the fleet bundle-converge engine (buttons-platform `docs/superpowers/plans/2026-07-20-fleet-bundle-deploy.md`) so removals actually converge on live VMs.

- **`buttons remove @desk/name`** — drops the dep from `.buttons/buttons.json`, deletes its materialized dirs, cleans its lock entry. Strictly registry deps: an unscoped name errors pointing at `buttons delete` (local buttons, untouched). Non-interactive, `--json`.
- **Safety**: only dirs stamped with `.buttons-install-state.json` are ever deleted (an unstamped dir is kept and reported); a package still required by another locked package keeps its files — live transitive deps survive.
- **`buttons add --no-refresh`** — pins one package without re-resolving unrelated floating deps (the converge single-package case; closes the RefreshFloating blast-radius question from the design).

Table-driven tests at store + cmd layers incl. an httptest registry end-to-end (add two → remove one → other dep intact) and refresh-vs-no-refresh floating pin. build/vet/full test suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)